### PR TITLE
Check our code conforms to PEP8 during make check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,5 +49,6 @@ clean:
 check: stbt
 	python -m doctest -v stbt.py stbt-run stbt-record
 	PATH="$$PWD:$$PATH" tests/run-tests.sh
+	pep8 stbt.py stbt-run stbt-record
 
 .DELETE_ON_ERROR:

--- a/stbt-record
+++ b/stbt-record
@@ -20,13 +20,14 @@ def main(argv):
     parser.add_argument('--control-recorder',
         help='The remote control to control the stb (default: %(default)s)')
     parser.add_argument('--source-pipeline',
-        help='A gstreamer pipeline to use for A/V input (default: %(default)s)')
+        help='A gstreamer pipeline to use for A/V input (default: '
+             '%(default)s)')
     parser.add_argument('-o', '--output-file',
         help='The filename of the generated script (default: %(default)s)')
     parser.set_defaults(**load_defaults('record'))
     args = parser.parse_args(argv[1:])
     debug("Arguments:\n" + "\n".join([
-                "%s: %s" % (k, v) for k,v in args.__dict__.items()]))
+                "%s: %s" % (k, v) for k, v in args.__dict__.items()]))
 
     record(args.source_pipeline, uri_to_remote_recorder(args.control_recorder),
            uri_to_remote(args.control), open(args.output_file, 'w'))
@@ -40,7 +41,8 @@ def record(video_source, remote_input, control, script_out):
                         " ! queue leaky=2",
                         " ! ffmpegcolorspace",
                         " ! appsink name=screenshot "
-                           "max-buffers=1 drop=true sync=false caps=video/x-raw-rgb",
+                                   "max-buffers=1 drop=true sync=false "
+                                   "caps=video/x-raw-rgb",
                         " t. ! queue leaky=2 ! xvimagesink sync=false",
                         ])
     pipeline = gst.parse_launch(display)

--- a/stbt-run
+++ b/stbt-run
@@ -14,17 +14,18 @@ import traceback
 
 
 def main(argv):
-    parser = argparse.ArgumentParser(description='Run an stb-tester test script')
+    parser = argparse.ArgumentParser('Run an stb-tester test script')
     parser.add_argument('--control',
         help='The remote control to control the stb (default: %(default)s)')
     parser.add_argument('--source-pipeline',
-        help='A gstreamer pipeline to use for A/V input (default: %(default)s)')
+        help='A gstreamer pipeline to use for A/V input (default: '
+             '%(default)s)')
     parser.add_argument('script',
         help='The test script to run (default: %(default)s)')
     parser.set_defaults(**load_defaults('run'))
     args = parser.parse_args(argv[1:])
     debug("Arguments:\n" + "\n".join([
-                "%s: %s" % (k, v) for k,v in args.__dict__.items()]))
+                "%s: %s" % (k, v) for k, v in args.__dict__.items()]))
 
     global display, control
     display = Display(args.source_pipeline)
@@ -45,8 +46,10 @@ def main(argv):
 def press(*args, **keywords):
     return control.press(*args, **keywords)
 
+
 def wait_for_match(*args, **keywords):
     return display.wait_for_match(*args, **keywords)
+
 
 def press_until_match(key, image, interval_secs=3, max_presses=10):
     i = 0
@@ -65,15 +68,22 @@ def press_until_match(key, image, interval_secs=3, max_presses=10):
 class Display:
     def __init__(self, gst_source_pipeline):
         imageprocessing = " ! ".join([
-                "queue leaky=2",          # Buffer the video stream, dropping frames if downstream processors aren't fast enough.
-                "ffmpegcolorspace",       # Convert to a colorspace that templatematch can handle.
-                "templatematch name=templatematch method=1", # OpenCV image-processing library.
+                # Buffer the video stream, dropping frames if downstream
+                # processors aren't fast enough:
+                "queue leaky=2",
+                # Convert to a colorspace that templatematch can handle:
+                "ffmpegcolorspace",
+                # OpenCV image-processing library:
+                "templatematch name=templatematch method=1",
                 ])
         xvideo = " ! ".join([
-                "ffmpegcolorspace",       # Convert to a colorspace that xvimagesink can handle.
-                "xvimagesink sync=false", # Display in the X Window System.
+                # Convert to a colorspace that xvimagesink can handle:
+                "ffmpegcolorspace",
+                # Display in the X Window System:
+                "xvimagesink sync=false",
                 ])
-        screenshot = "appsink name=screenshot max-buffers=1 drop=true sync=false"
+        screenshot = ("appsink name=screenshot max-buffers=1 drop=true "
+                      "sync=false")
         pipe = " ".join([
                 gst_source_pipeline,
                 "!", imageprocessing,
@@ -86,7 +96,8 @@ class Display:
         # those libraries are first mentioned. There is a bug in gst-opencv
         # where it erroneously claims to provide appsink, preventing the
         # loading of the real appsink -- so we load it first.
-        # TODO: Fix gst-opencv so that it doesn't prevent appsink from being loaded.
+        # TODO: Fix gst-opencv so that it doesn't prevent appsink from being
+        #       loaded.
         gst.parse_launch("appsink")
 
         self.pipeline = gst.parse_launch(pipe)
@@ -132,12 +143,12 @@ class Display:
                 self.start_timestamp = buf.timestamp
 
             certainty = st["result"]
-            debug("Match %d found at %d,%d (last: %d,%d) with dimensions %dx%d."
-                  " Certainty: %d%%. Timestamp: %d."
+            debug("Match %d found at %d,%d (last: %d,%d) with dimensions "
+                  "%dx%d. Certainty: %d%%. Timestamp: %d."
                   % (self.match_count,
                      st["x"], st["y"], self.last_x, self.last_y,
                      st["width"], st["height"],
-                     certainty*100.0, buf.timestamp))
+                     certainty * 100.0, buf.timestamp))
 
             if certainty > self.certainty and (
                     self.match_count == 0 or
@@ -162,6 +173,7 @@ class Display:
 
 class UITestFailure(Exception):
     pass
+
 
 class MatchTimeout(UITestFailure):
     def __init__(self, screenshot, expected, timeout_secs):

--- a/stbt.py
+++ b/stbt.py
@@ -21,7 +21,7 @@ def save_frame(buf, filename):
     src.emit('end-of-stream')
     pipeline.set_state(gst.STATE_PLAYING)
     msg = pipeline.get_bus().poll(
-        gst.MESSAGE_ERROR | gst.MESSAGE_EOS, 25 * gst.SECOND);
+        gst.MESSAGE_ERROR | gst.MESSAGE_EOS, 25 * gst.SECOND)
     pipeline.set_state(gst.STATE_NULL)
     if msg.type == gst.MESSAGE_ERROR:
         (e, debug) = msg.parse_error()
@@ -38,9 +38,11 @@ def uri_to_remote(uri):
     else:
         raise RuntimeException('Invalid remote control URI: "%s"' % uri)
 
+
 class NullRemote:
     def press(self, key):
         pass
+
 
 class VirtualRemote:
     """Send a key-press to a set-top box running a VirtualRemote listener.
@@ -56,7 +58,7 @@ class VirtualRemote:
         import socket
         s = socket.socket()
         s.connect((self.stb, self.port))
-        s.send("D\t%s\n\0U\t%s\n\0" % (key, key)) # send key Down, then key Up.
+        s.send("D\t%s\n\0U\t%s\n\0" % (key, key))  # send key Down, then key Up
         debug("Pressed " + key)
 
 
@@ -93,6 +95,7 @@ class FileToSocket:
     """
     def __init__(self, f):
         self.file = f
+
     def recv(self, bufsize, flags=0):
         return self.file.read(bufsize)
 
@@ -140,7 +143,8 @@ def virtual_remote_listen(address, port):
     serversocket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     serversocket.bind((address, port))
     serversocket.listen(5)
-    sys.stderr.write("Waiting for connection from virtual remote control port %d...\n" % port)
+    sys.stderr.write("Waiting for connection from virtual remote control "
+                     "port %d...\n" % port)
     (connection, address) = serversocket.accept()
     sys.stderr.write("Accepted connection from %s\n" % str(address))
     return key_reader(read_records(connection, '\n\0'))
@@ -163,7 +167,7 @@ def load_defaults(tool):
         # User config: ~/.config/stbt/stbt.conf, as per freedesktop's base
         # directory specification:
         '%s/stbt/stbt.conf' % os.environ.get('XDG_CONFIG_HOME',
-                                             '%s/.config' % os.environ['HOME']),
+                                            '%s/.config' % os.environ['HOME']),
         # Config files specific to the test suite / test run:
         os.environ.get('STBT_CONFIG_FILE', ''),
         'stbt.conf'])
@@ -187,6 +191,7 @@ class ArgvHider:
     def __enter__(self):
         self.argv = sys.argv[:]
         del sys.argv[1:]
+
     def __exit__(self, type, value, traceback):
         sys.argv = self.argv
 


### PR DESCRIPTION
PEP8[1] is the Python style guide.  This requires the pep8 binary
provided by the package python-pep8 on Fedora.

This commit also fixes all of the PEP8 violations detected by that tool.

[1] http://www.python.org/dev/peps/pep-0008/
