### PR TITLE
Fixes an issue with make install on Ubuntu Studio 12.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ install: stbt stbt.1 gst/libgst-stb-tester.so
 	    $(DESTDIR)$(libexecdir)/stbt \
 	    $(DESTDIR)$(plugindir) \
 	    $(DESTDIR)$(man1dir) \
-	    $(DESTDIR)$(sysconfdir)/{stbt,bash_completion.d}
+	    $(DESTDIR)$(sysconfdir)/bash_completion.d/stbt
 	$(INSTALL) -m 0755 stbt $(DESTDIR)$(bindir)
 	$(INSTALL) -m 0755 stbt-record stbt-run $(DESTDIR)$(libexecdir)/stbt
 	$(INSTALL) -m 0644 stbt.py $(DESTDIR)$(libexecdir)/stbt


### PR DESCRIPTION
On my system (make 3.81, install 8.13, Ubuntu Studio 12.04) the makefile was failing to install bash completion scripts because it was failing to ensure the parent directory existed; this change fixes that and make install now runs as expected.
