### PR TITLE
fixes for better pylint compliance

### DIFF
--- a/extra/pylint.sh
+++ b/extra/pylint.sh
@@ -7,20 +7,31 @@
 [ $# -gt 0 ] || { grep '^#/' "$0" | cut -c4- >&2; exit 1; }
 
 pylintoptions() {
+    # C0103: Invalid name for type <T>
+    # W0142: Used * or ** magic
+    echo --disable=C0103,W0142
+
+    # C0111: Missing docstring
+    # C0302: Too many lines in module
+    # W0603: Using the global statement
     case "$1" in
-        stbt.py) echo --disable=E1101;;
+        irnetbox.py) echo --disable=C0111;;
+        stbt.py) echo --disable=C0302,W0603;; 
+        stbt-record) echo --disable=C0111;;
     esac
 }
 pep8options() {
+    # E501: line too long > 80 chars (because pylint does it)
     case "$1" in
-        irnetbox.py) echo --ignore=E128,E203,E225,E226,E251,E501;;
+        irnetbox.py) echo --ignore=E501;;
+        stbt.py) echo --ignore=E501;;
     esac
 }
 
 ret=0
 for f in "$@"; do
     r=0
-    pylint --rcfile="$(dirname "$0")/pylint.conf" --errors-only \
+    pylint --rcfile="$(dirname "$0")/pylint.conf" \
         $(pylintoptions $f) $f || r=1 ret=1
     pep8 $(pep8options $f) $f || r=1 ret=1
     [ $r -eq 0 ] && echo "$f OK"

--- a/stbt-record
+++ b/stbt-record
@@ -10,10 +10,9 @@ import stbt
 
 import pygst  # gstreamer
 pygst.require("0.10")
-with stbt.ArgvHider(), stbt.StdErrHider():
+with stbt.ArgvHider(), stbt.StdErrHider():  # pylint: disable=C0321
     import gst
 
-import argparse
 import itertools
 import sys
 
@@ -88,13 +87,15 @@ class Display:
         self.pipeline.get_bus().connect("message::warning", self.on_warning)
         self.pipeline.set_state(gst.STATE_PLAYING)
 
-    def on_error(self, bus, message):
+    @staticmethod
+    def on_error(bus, message):  # pylint: disable=W0613
         assert message.type == gst.MESSAGE_ERROR
         err, dbg = message.parse_error()
         sys.stderr.write("Error: %s: %s\n%s\n" % (err, err.message, dbg))
         sys.exit(1)
 
-    def on_warning(self, bus, message):
+    @staticmethod
+    def on_warning(bus, message):  # pylint: disable=W0613
         assert message.type == gst.MESSAGE_WARNING
         err, dbg = message.parse_warning()
         sys.stderr.write("Warning: %s: %s\n%s\n" % (err, err.message, dbg))

--- a/stbt-run
+++ b/stbt-run
@@ -22,10 +22,11 @@ stbt.debug("Arguments:\n" + "\n".join([
     "%s: %s" % (k, v) for k, v in args.__dict__.items()]))
 
 stbt.init_run(args.source_pipeline, args.sink_pipeline, args.control)
-from stbt import press, press_until_match, wait_for_match, wait_for_motion, \
-    detect_match, MatchResult, Position, detect_motion, MotionResult, \
-    save_frame, get_frame, debug, \
-    UITestError, UITestFailure, MatchTimeout, MotionTimeout, ConfigurationError
+from stbt import (  # pylint: disable=W0611
+    press, press_until_match, wait_for_match, wait_for_motion, detect_match,
+    MatchResult, Position, detect_motion, MotionResult, save_frame, get_frame,
+    debug, UITestError, UITestFailure, MatchTimeout, MotionTimeout,
+    ConfigurationError)
 try:
     execfile(args.script)
 except Exception as e:


### PR DESCRIPTION
This change (1) removes the `--errors-only` flag from the pylint checker
so that now pylint will warn about refactors, conventions, and warnings
and not just errors, and (2) applies all of the pylint recommendations
to the affected python modules.

Some sensible global pylint exceptions as well as module-specific
exceptions are added in `extra/pylint.sh`. In acceptable situations,
inline pylint "disable" codes are added in the code.

A notable change for compliance is that the stbt.py `display` and
`control` variables are now module-private variables `_display` and
`_control`.
