### PR TITLE
stbt.py: Support multiple lirc devices connected to the same host

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,11 +53,24 @@ Global options
 --control=<uri>
   A remote control to use for controlling the set top box. `uri` can be:
 
-  lirc:<lircd_socket>:<remote_control_name>
+  lirc:([<lircd_socket>]|[<hostname>:]<port>):<remote_control_name>
     A hardware infrared emitter controlled by the lirc (Linux Infrared Remote
-    Control) daemon. `lircd_socket` defaults to `/var/run/lirc/lircd`.
+    Control) daemon.
+
+    * If `lircd_socket` is specified, remote control commands are sent via a
+      lircd socket file. `lircd_socket` defaults to `/var/run/lirc/lircd`.
+    * If `port` is specified, remote control commands are sent via a lircd TCP
+      listener on localhost.
+    * If `hostname` and `port` are specified, remote control commands are sent
+      via a lircd TCP listener on a remote host.
+
     `remote_control_name` is the name of a remote-control specification in
     lircd.conf.
+
+    Examples:
+        | lirc:/var/run/lirc/lircd:myremote
+        | lirc:8700:myremote
+        | lirc:192.168.100.100:8700:myremote
 
   irnetbox:<hostname>:<output>:<config_file>
     RedRat irNetBox network-controlled infrared emitter hardware.
@@ -105,10 +118,9 @@ Additional options to stbt record
 --control-recorder=<uri>
   The source of remote control presses.  `uri` can be:
 
-  lirc:<lircd_socket>:<remote_control_name>
+  lirc:([<lircd_socket>]|[<hostname>:]<port>):<remote_control_name>
     A hardware infrared receiver controlled by the lirc (Linux Infrared Remote
-    Control) daemon. `lircd_socket` and `remote_control_name` are as for
-    `--control`.
+    Control) daemon. Parameters are as for `--control`.
 
   vr:<hostname>:<port>
     Listens on the socket <hostname>:<port> for a connection and reads a
@@ -207,9 +219,7 @@ Linux server
 ------------
 
 An 8-core machine will be able to drive 4 set-top boxes simultaneously with at
-least 1 frame per second per set-top box. (Note that `stbt` currently doesn't
-support multiple lirc-based emitters on the same PC, but this is relatively
-trivial to fix and will be addressed in the near future.)
+least 1 frame per second per set-top box.
 
 
 SOFTWARE REQUIREMENTS

--- a/stbt-completion
+++ b/stbt-completion
@@ -116,13 +116,14 @@ _stbt_control() {
         --control=irnetbox:*:*:) _stbt_irnetbox_config;;
         --control=irnetbox:*:) _stbt_irnetbox_output;;
         --control=irnetbox:) _stbt_hostname;;
-        --control=lirc:*:) _stbt_lirc_name;;
-        --control=lirc:) _stbt_lirc_socket;;
+        --control=lirc:*:*:) _stbt_lirc_name;;
+        --control=lirc:*:) _stbt_lirc_port_or_name;;
+        --control=lirc:) _stbt_lirc_socket_or_port_or_hostname;;
         --control=vr:*:) _stbt_vr_port;;
         --control=vr:) _stbt_hostname;;
         *)
             compgen -W "$( \
-                    _stbt_no_space irnetbox: lirc:: vr:
+                    _stbt_no_space irnetbox: lirc: vr:
                     _stbt_trailing_space none test)" \
                 -- "$cur";;
     esac
@@ -153,19 +154,22 @@ _stbt_irnetbox_config() {
     compgen -f -- "$cur"
 }
 
-_stbt_lirc_socket() {
+_stbt_lirc_socket_or_port_or_hostname() {
     local cur="$_stbt_cur"
-    compgen -W ":" -- "$cur"
+    compgen -W "$(_stbt_no_space $(_lirc_tcp_ports))" -- "$cur"
     compgen -f -S ":" -- "$cur"
+    compgen -A hostname -S ":" -- "$cur"
+}
+
+_stbt_lirc_port_or_name() {
+    local cur="$_stbt_cur"
+    compgen -W "$(_stbt_no_space $(_lirc_tcp_ports))" -- "$cur"
+    compgen -W "$(_stbt_trailing_space $(_lirc_remote_names))" -- "$cur"
 }
 
 _stbt_lirc_name() {
     local cur="$_stbt_cur"
-    local names="$(
-        cat /etc/lirc/lircd.conf 2>/dev/null |
-        awk '/^begin remote/         { inremote = 1 }
-             inremote && /^ *name /  { print $2; inremote = 0 }')"
-    compgen -W "$(_stbt_trailing_space $names)" -- "$cur"
+    compgen -W "$(_stbt_trailing_space $(_lirc_remote_names))" -- "$cur"
 }
 
 _stbt_hostname() {
@@ -270,6 +274,17 @@ _stbt_no_space() {
 
 _stbt_camelcase() {
     echo "$*" | perl -pe 's/_([a-z])/\U$1/g'
+}
+
+_lirc_tcp_ports() {
+    ps ax | grep 'lircd' | \
+        perl -nle 'print $1 if (/--listen=(\d+)/ || /-l +(\d+)/)' | sort
+}
+
+_lirc_remote_names() {
+    cat /etc/lirc/lircd.conf 2>/dev/null |
+    awk '/^begin remote/         { inremote = 1 }
+         inremote && /^ *name /  { print $2; inremote = 0 }'
 }
 
 ## Unit tests


### PR DESCRIPTION
To use multiple LIRC devices connected to the same host:

(1) Stop `lirc` service.

(2) Run multiple `lircd` instances, and set the TCP ports that each
device listens to:
`sudo lircd --device=/dev/lirc0 --pidfile=/var/run/lirc/lirc0.pid
--listen=8765 --output=/var/run/lirc/lircd`
`sudo lircd --device=/dev/lirc1 --pidfile=/var/run/lirc/lirc1.pid
--listen=8766 --output=/var/run/lirc/lircd`

`lirc0` and `lirc1` can be addressed individually using the assigned TCP
ports; but both send the received key codes to `/var/run/lirc/lircd`
therefore any of the two can be used as 'control_recorder'.

(3) Send keys the same way as to a Virtual Remote but with LIRC command
strings:
`echo -e "SEND_ONCE humax MENU" | nc localhost 8765`
It's also possible to output keys via a LIRC device of a remote computer.

To put both remotes into use by stb-tester, all we need is a new remote
type with "hostname", "port" and "remote_control_name" parameters that
uses 'VirtualRemote._connect()' to connect and 'LircRemote.press(key)'
to send keys.
