### PR TITLE
irnetbox: Timeout the TCP connection attempt after 10 seconds.

### DIFF
--- a/irnetbox.py
+++ b/irnetbox.py
@@ -54,7 +54,9 @@ class IRNetBox:
         for i in range(6):
             try:
                 self._socket = socket.socket()
+                self._socket.settimeout(10)
                 self._socket.connect((hostname, port))
+                self._socket.settimeout(None)
                 break
             except socket.error as e:
                 if e.errno == errno.ECONNREFUSED and i < 5:


### PR DESCRIPTION
I'd like to use IRNetBox to determine whether the irnetbox has frozen or not. Usually attempting to set up a TCP socket to a dead irnetbox will raise a "Connection refused" socket exception. However, I've also seen times when the TCP socket connection attempt completely hangs.

This commit adds a 10 second timeout _to the socket connection attempt only_. I do not want to keep the timeout applied because this would change how the script behave later on; it seems to rely on blocking reads from the socket.
