### PR TITLE
Correction of a bug in self tests

### DIFF
--- a/tests/stbt.conf
+++ b/tests/stbt.conf
@@ -10,12 +10,6 @@ source_pipeline=videotestsrc is-live=true ! video/x-raw-yuv,width=320,height=240
 sink_pipeline = ximagesink sync=false
 control=test
 
-match_method=sqdiff-normed
-match_threshold=0.80
-confirm_method=absdiff
-erode_passes=1
-confirm_threshold=0.16
-
 [record]
 source_pipeline=videotestsrc is-live=true ! video/x-raw-yuv,width=320,height=240
 sink_pipeline = ximagesink sync=false


### PR DESCRIPTION
`tests/run-tests.sh` makes sure that it uses the right configuration file.
Unused parameters are removed from `tests/stbt.conf` to avoid confusion.
