### PR TITLE
minor fix: reference to `noise_threshold` changed to `confirm_threshold`

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -152,7 +152,7 @@ if [ $# -eq 0 ]; then
     echo "Testing stbt-templatematch:" &&
     run test_that_stbt_templatematch_finds_match &&
     run test_that_stbt_templatematch_doesnt_find_match &&
-    run test_that_stbt_templatematch_applies_noise_threshold_parameter &&
+    run test_that_stbt_templatematch_applies_confirm_threshold_parameter &&
 
     echo "Testing 'make doc':" &&
     run test_that_readme_default_templatematch_values_are_kept_up_to_date &&

--- a/tests/test-stbt-templatematch.sh
+++ b/tests/test-stbt-templatematch.sh
@@ -8,7 +8,7 @@ test_that_stbt_templatematch_doesnt_find_match() {
     ! stbt-templatematch videotestsrc-full-frame.png videotestsrc-gamut.png
 }
 
-test_that_stbt_templatematch_applies_noise_threshold_parameter() {
+test_that_stbt_templatematch_applies_confirm_threshold_parameter() {
     ! stbt-templatematch videotestsrc-full-frame.png \
             videotestsrc-redblue-with-dots.png &&
     stbt-templatematch videotestsrc-full-frame.png \


### PR DESCRIPTION
Since 18a5e70e, the parameter `noise_threshold` has been marked for
deprecation in favour of using `confirm_threshold` instead.
