### PR TITLE
Stbt record failsafe with no frame buffer

### DIFF
--- a/stbt-record
+++ b/stbt-record
@@ -61,6 +61,11 @@ def record(display, remote_input, control, script_out):
             interrupt = True
         buf = display.screenshot.get_property('last-buffer')
         if not interrupt:
+            if not buf:
+                sys.stderr.write(
+                    "No frame in frame buffer. Unable to take screenshot.\n"
+                    "Key press event '%s' not being sent.\n" % key)
+                continue
             control.press(key)
         if old_key:
             filename = '%04d-%s-complete.png' % (count.next(), old_key)


### PR DESCRIPTION
This branch contains 2 commits which aim to overcome a problem seen with stbt-record
when frames are not available on the frame-buffer (for whatever reason), cause stbt-record
to fatal error when it attempts to save the current frame to disk.

The first commit (which modifies stbt-record.Display class) is not necessarily complete per se; it does what is needed but I think the code could possibly be optimised. I don't know if the way I am restarting the pipeline is correct.
