### PR TITLE
stbt-completion: Correction of completion of LIRC control-recorder

### DIFF
--- a/stbt-completion
+++ b/stbt-completion
@@ -128,8 +128,9 @@ _stbt_control_recorder() {
     local cur="$_stbt_cur"
     local prev="$_stbt_prev"
     case "$prev" in
-        --control-recorder=lirc:*:) _stbt_lirc_name;;
-        --control-recorder=lirc:) _stbt_lirc_socket;;
+        --control-recorder=lirc:*:*:) _stbt_lirc_name;;
+        --control-recorder=lirc:*:) _stbt_lirc_port_or_name;;
+        --control-recorder=lirc:) _stbt_lirc_socket_or_port_or_hostname;;
         --control-recorder=vr:*:) _stbt_vr_port;;
         --control-recorder=vr:) _stbt_hostname;;
         --control-recorder=file:) _stbt_control_file;;


### PR DESCRIPTION
A modification missing from 1ccc2b1f: the new LIRC remote types haven't
been added to the completion function of '--control-recorder'.
