### PR TITLE
stbt control: Do not raise `curses.error` if the terminal is too small

### DIFF
--- a/stbt-control
+++ b/stbt-control
@@ -139,8 +139,14 @@ def main_loop(control_uri, keymap_file):
     timer = None
 
     with terminal() as term:
-        term.addstr("Keymap: %s\nListener: %s\n\n%s\n\n" % (
-            keymap_file, control_uri, keymap_string(keymap)))
+        printed_keymap = "Keymap: %s\nListener: %s\n\n%s\n\n" % (
+                         keymap_file, control_uri, keymap_string(keymap))
+        if keymap_fits_terminal(term, printed_keymap):
+            term.addstr(printed_keymap)
+        else:
+            term.addstr("Unable to print keymap because the terminal is too "
+                        "small. Use without printed keymap or press 'q' to "
+                        "quit.\n")
         while True:  # Main loop
             keycode = term.getch()
             if keycode == ord('q'):  # 'q' for 'Quit' is pre-defined
@@ -160,6 +166,13 @@ def main_loop(control_uri, keymap_file):
 def clear_last_command(term):
     term.move(term.getyx()[0], 0)
     term.clrtoeol()
+
+
+def keymap_fits_terminal(term, printed_keymap):
+    term_y, term_x = term.getmaxyx()
+    keymap_y = printed_keymap.count("\n")
+    keymap_x = len(printed_keymap.split("\n")[0])
+    return term_y > keymap_y and term_x > keymap_x
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
`stbt control` uses `curses` module for terminal handling. `curses`
raises the unhelpful `curses.error` exception if the terminal is smaller
than what is required to print the keymap.

If the terminal is too small do not print the keymap and print an error
message instead, but do not quit the tool as the more experienced users
who remember key mappings might not need the printed keymap at all.
