### PR TITLE
stbt tv: VirtualBox requires ximagesink

### DIFF
--- a/stbt-tv
+++ b/stbt-tv
@@ -41,7 +41,7 @@ source_pipeline=${*:-$("$STBT_LIBEXEC/stbt-config" global.source_pipeline)}
 : ${sink:=$(
         case "$(uname)" in
             (Darwin) echo glimagesink;;
-            (Linux) lspci | grep -q VMware &&
+            (Linux) lspci | grep -Eq '(VMware|VirtualBox)' &&
                         echo ximagesink || echo xvimagesink;;
             (*) echo ximagesink;;
         esac)}


### PR DESCRIPTION
It's not only VMWare but also VirtualBox that cannot display video with
`xvimagesink` and requires `ximagesink`.
