### PR TITLE
Add a wrapper to manage errors in cv2.imread()

### DIFF
--- a/stbt.py
+++ b/stbt.py
@@ -1008,14 +1008,12 @@ def _log_image(image, name, directory):
     cv2.imwrite(os.path.join(d, name) + ".png", image)
 
 
-
-def _cv2_imread(path):
+def _cv2_imread(path, flags):
     while True:
-        img = cv2.imread(path)
+        img = cv2.imread(path, flags)
         if img is not None:
             break
     return img
-
 
 
 def uri_to_remote(uri, display):


### PR DESCRIPTION
Sometimes a random failure can be raised by cv2.imread() even though the
template exists and is a valid png file. This seems to come from libpng,
not from OpenCV.

This has been identified in other projects, but doesn't seem to have been
addressed/fixed. See the links below as references to this same problem:
1) http://lists.freebsd.org/pipermail/freebsd-ports/2012-November/079729.html
2) http://lists.osgeo.org/pipermail/mapserver-users/2012-February/071566.html
3) http://www.amsn-project.net/forums/index.php?topic=1205.0;wap2
4) https://bugs.php.net/bug.php?id=34640

This case can be identified by two means:
1) Grabbing the output to stderr. Iit will contain the string
   "libpng error: incorrect data check"
2) Checking the value returned by this function is None

This commit adds a thin wrapper _cv2_imread() that calls cv2.imread() and
makes sure it behaves as it should.
