### PR TITLE
stbt.argparser: `verbose` value not read from config file

### DIFF
--- a/stbt.py
+++ b/stbt.py
@@ -647,13 +647,16 @@ def argparser():
              '(default: %(default)s)')
 
     class IncreaseDebugLevel(argparse.Action):
+        num_calls = 0
+
         def __call__(self, parser, namespace, values, option_string=None):
+            self.num_calls += 1
             global _debug_level
-            _debug_level += 1
+            _debug_level = self.num_calls
             setattr(namespace, self.dest, _debug_level)
 
     global _debug_level
-    _debug_level = 0
+    _debug_level = int(get_config('global', 'verbose'))
     parser.add_argument(
         '-v', '--verbose', action=IncreaseDebugLevel, nargs=0,
         default=get_config('global', 'verbose'),

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -204,3 +204,25 @@ test_save_video() {
         --source-pipeline 'filesrc location=video.webm ! decodebin' \
         test.py
 }
+
+test_that_verbosity_level_is_read_from_config_file() {
+    cd "$scratchdir" &&
+    cat > stbt.conf <<-EOF &&
+	[global]
+	verbose = 2
+	EOF
+    touch test.py &&
+    STBT_CONFIG_FILE="$scratchdir/stbt.conf" stbt-run test.py &&
+    cat log | grep "verbose: 2"
+}
+
+test_that_verbose_command_line_argument_overrides_config_file() {
+    cd "$scratchdir" &&
+    cat > stbt.conf <<-EOF &&
+	[global]
+	verbose = 2
+	EOF
+    touch test.py &&
+    STBT_CONFIG_FILE="$scratchdir/stbt.conf" stbt-run -v test.py &&
+    cat log | grep "verbose: 1"
+}


### PR DESCRIPTION
Correction of a bug that `verbose = <level>` parameter is not read correctly from `stbt.conf`. See commit message.
