### PR TITLE
runner: Display statistics of a job

### DIFF
--- a/extra/runner/templates/index.html
+++ b/extra/runner/templates/index.html
@@ -28,6 +28,7 @@
     <div class="span8" height="100%">
       <input id="testruns_search_text" class="input-block-level" type="text"
         placeholder="Specify filter. For example: 'exit status' ILIKE motiontimeout">
+      <p id="totals"></p>
       <table id="testruns" class="table table-condensed sortable">
       <thead>
       <tr>
@@ -91,6 +92,7 @@
     $(document).on("keydown", navigate_testruns);
     tablequery.set_table("#testruns");
     tablequery.set_table_search_text("#testruns_search_text");
+    update_totals();
 
     var selected_row = $();
     function select_testrun() {
@@ -132,6 +134,23 @@
         }
         return false;
       }
+    };
+
+    function update_totals() {
+      var num_success = $(".success:visible").length;
+      var num_errors = $(".error:visible").length;
+      var num_warnings = $(".warning:visible").length;
+      var num_total = num_success + num_errors + num_warnings;
+      var percent_success = 0;
+      if (num_total > 0) {
+        percent_success = parseInt(num_success / num_total * 100);
+      }
+
+      $("#totals").html(
+        "<b>Success rate:</b> " + percent_success + "% (" +
+        num_success + " out of " + num_total + " tests passed, " +
+        num_errors + " UITestFailures, " + num_warnings + " other failures)"
+      );
     };
   });
 </script>


### PR DESCRIPTION
Display basic stats of a job: total number of tests, number of passed
tests, number of UITestFailures, number of other failures and success
rate.

Counters are increased by `runner/run`, therefore hiding a row of the
table doesn't affect the numbers.

Stats are displayed in `index.html` above the results table and below the
header line.

![screenshot](https://f.cloud.github.com/assets/3908828/1002238/4d37fdd8-0a79-11e3-8752-d8b2cfcec9c0.png)
