### PR TITLE
runner: add tablequeryjs to reports to allow textual filtering

### DIFF
--- a/extra/runner/templates/index.html
+++ b/extra/runner/templates/index.html
@@ -5,6 +5,7 @@
   <title>Test results {{runs[0].timestamp}} - {{runs[-1].timestamp}}</title>
 
   <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
+  <link href="http://code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.min.css" rel="stylesheet">
   <style>
     table.sortable th { cursor: pointer; }
   </style>
@@ -25,6 +26,7 @@
   <div class="row-fluid" style="padding-top: 40px">
 
     <div class="span8" height="100%">
+      <input class="input-block-level" type="text" placeholder="Specify filter here..." id="testruns_search_text">
       <table id="testruns" class="table table-condensed sortable">
       <thead>
       <tr>
@@ -79,11 +81,15 @@
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
 <script src="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js"></script>
 <script src="http://cdn.jsdelivr.net/sorttable/2/sorttable.js"></script>
+<script src="http://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js"></script>
+<script src="http://cdn.jsdelivr.net/jquery.tablequeryjs/0.1.3/tablequery.min.js"></script>
 <script>
   $(document).ready(function() {
     $("#details").css("height", $(window).height());
     $("#testruns tbody tr").on("click", select_testrun);
     $(document).on("keydown", navigate_testruns);
+    tablequery.set_table("#testruns");
+    tablequery.set_table_search_text("#testruns_search_text");
 
     var selected_row = $();
     function select_testrun() {


### PR DESCRIPTION
This commit adds tablequeryjs [1] to stb-tester runner reports. This is
useful because it allows Wireshark-like text-based filtering of the HTML
table, executing queries such as:
- `tag ILIKE slave-1 or tag ILIKE slave-2`
- `"exit status" ILIKE "^(1|2)$"`

Currently tablequeryjs depends on both jQuery and jQuery UI. Removing
the latter as a dependency is tracked in [2] and I hope to get around to
this soon. There are also numerous usability improvements, all tracked
in issues, that I'm hoping to implement soon as well.

[1] https://github.com/asimihsan/tablequeryjs

[2] https://github.com/asimihsan/tablequeryjs/issues/4
