### PR TITLE
runner/templates/testrun.html: Wrap failure reason to multiple lines

### DIFF
--- a/extra/runner/templates/testrun.html
+++ b/extra/runner/templates/testrun.html
@@ -10,7 +10,7 @@
     #args,
     #failure-reason,
     .extra_columns,
-    #notes { white-space: pre; }
+    #notes { white-space: pre-wrap; }
     .thumbnail p { word-wrap: break-word; text-align: center; }
     .editable-click { border-bottom: none; }
     #delete,


### PR DESCRIPTION
`white-space: pre` CSS property prevents the browser from wrapping the
text to multiple lines if it is too long; as a result, in many cases part
of the failure reason gets out of screen, even when the browser is expanded
to full screen.

Before:
![screenshot from 2013-09-02 10 47 56](https://f.cloud.github.com/assets/3908828/1066521/1eb1ed52-13b6-11e3-8d56-79b8c9f6b479.png)

After:
![screenshot from 2013-09-02 10 50 21](https://f.cloud.github.com/assets/3908828/1066523/23d8c170-13b6-11e3-80a5-c350a5ca0c52.png)
