### PR TITLE
restart_source configuration option is undocumented

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,10 @@ Global options
 --sink-pipeline=<pipeline>
   A gstreamer pipeline to use for video output, like `xvimagesink`.
 
+--restart-source
+  Restart the GStreamer source pipeline when video loss is detected, to work
+  around the behaviour of the Hauppauge HD PVR video-capture device.
+
 -v, --verbose
   Enable debug output.
 

--- a/stbt-record
+++ b/stbt-record
@@ -36,7 +36,9 @@ def main(argv):
         raise
 
     try:
-        stbt.init_run(args.source_pipeline, args.sink_pipeline, args.control)
+        stbt.init_run(
+            args.source_pipeline, args.sink_pipeline, args.control,
+            restart_source=args.restart_source)
         record(args.control_recorder, script)
     finally:
         stbt.teardown_run()

--- a/stbt-run
+++ b/stbt-run
@@ -32,7 +32,7 @@ stbt.debug("Arguments:\n" + "\n".join([
 try:
     stbt.init_run(
         args.source_pipeline, args.sink_pipeline, args.control,
-        args.save_video)
+        args.save_video, args.restart_source)
     from stbt import (  # pylint: disable=W0611
         press, press_until_match, wait_for_match, wait_for_motion,
         detect_match, MatchResult, Position, detect_motion, MotionResult,

--- a/stbt.py
+++ b/stbt.py
@@ -647,6 +647,13 @@ def argparser():
         help='A gstreamer pipeline to use for video output '
              '(default: %(default)s)')
 
+    parser.add_argument(
+        '--restart-source', action='store_true',
+        default=(get_config('global', 'restart_source').lower() in
+                 ("1", "yes", "true", "on")),
+        help='Restart the GStreamer source pipeline when video loss is '
+             'detected')
+
     class IncreaseDebugLevel(argparse.Action):
         num_calls = 0
 
@@ -668,9 +675,11 @@ def argparser():
 
 
 def init_run(
-        gst_source_pipeline, gst_sink_pipeline, control_uri, save_video=False):
+        gst_source_pipeline, gst_sink_pipeline, control_uri, save_video=False,
+        restart_source=False):
     global _display, _control
-    _display = Display(gst_source_pipeline, gst_sink_pipeline, save_video)
+    _display = Display(
+        gst_source_pipeline, gst_sink_pipeline, save_video, restart_source)
     _control = uri_to_remote(control_uri, _display)
 
 
@@ -690,7 +699,8 @@ _control = None
 
 
 class Display:
-    def __init__(self, user_source_pipeline, user_sink_pipeline, save_video):
+    def __init__(self, user_source_pipeline, user_sink_pipeline, save_video,
+                 restart_source=False):
         gobject.threads_init()
 
         self.novideo = False
@@ -700,6 +710,8 @@ class Display:
         self.start_timestamp = None
         self.underrun_timeout = None
         self.video_debug = []
+
+        self.restart_source_enabled = restart_source
 
         appsink = (
             "appsink name=appsink max-buffers=1 drop=true sync=false "
@@ -759,11 +771,9 @@ class Display:
         appsink = self.source_pipeline.get_by_name("appsink")
         appsink.connect("new-buffer", self.on_new_buffer)
 
-        if get_config("global", "restart_source", default="false").lower() in (
-                "1", "yes", "true", "on"):
+        if self.restart_source_enabled:
             # Handle loss of video (but without end-of-stream event) from the
             # Hauppauge HDPVR capture device.
-            debug("restart_source: true")
             source_queue = self.source_pipeline.get_by_name("q")
             self.start_timestamp = None
             source_queue.connect("underrun", self.on_underrun)

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -216,6 +216,24 @@ test_that_verbose_command_line_argument_overrides_config_file() {
     cat log | grep "verbose: 1"
 }
 
+test_that_restart_source_option_is_read() {
+    cat > test.py <<-EOF &&
+	import stbt
+	print "value: %s" % stbt._display.restart_source_enabled
+	EOF
+    # Read from the command line
+    stbt-run -v --restart-source --control none test.py &&
+    cat log | grep "restart_source: True" &&
+    cat log | grep "value: True" &&
+    echo > log &&
+    # Read from the config file
+    sed 's/restart_source = .*/restart_source = True/' \
+        "$testdir/stbt.conf" > stbt.conf &&
+    STBT_CONFIG_FILE="$PWD/stbt.conf" stbt-run -v --control none test.py &&
+    cat log | grep "restart_source: True" &&
+    cat log | grep "value: True"
+}
+
 test_press_visualisation() {
     [[ $(uname) == Darwin ]] && {
         echo "Skipping this test because vp8enc/webmmux don't work on OS X" >&2


### PR DESCRIPTION
The configuration option `global.restart_source` is undocumented in
stb-tester (it's only mentioned in the release notes and a comment in
the system-wide config file) even though this is an important feature
for Hauppauge HD PVR users.

To make users aware of this option, make `restart_source` available as
`--restart-source` command line argument, just like other configuration
options, and mention it in the stbt man page.
