### PR TITLE
stbt-record: Replace multiple wait_for_matches with a press_until_match

### DIFF
--- a/stbt-record
+++ b/stbt-record
@@ -45,26 +45,42 @@ def main(argv):
 def record(control_recorder, script_out):
     stbt.get_frame()  # Fail early if no video
     count = itertools.count()
+    write = write_wait_for_match
     old_key = None
     script_out.write("import stbt\n\n\n")
     try:
         for key in stbt.uri_to_remote_recorder(control_recorder):
-            write_wait_for_match(script_out, count.next(), old_key)
-            script_out.write("stbt.press('%s')\n" % key)
+            if old_key and key == old_key:
+                write = write_press_until_match
+            else:
+                write(script_out, count.next(), old_key)
+                write = write_wait_for_match
             stbt.press(key)
             old_key = key
     except KeyboardInterrupt:
-        write_wait_for_match(script_out, count.next(), old_key)
+        write(script_out, count.next(), old_key)
         return
-    write_wait_for_match(script_out, count.next(), old_key)
+    write(script_out, count.next(), old_key)
 
 
 def write_wait_for_match(script_out, i, old_key):
     if old_key is None:
         return
-    filename = "%04d-%s-complete.png" % (i, old_key)
-    stbt.save_frame(stbt.get_frame(), filename)
-    script_out.write("stbt.wait_for_match('%s')\n" % filename)
+    stbt.save_frame(stbt.get_frame(), filename(i, old_key))
+    script_out.write("stbt.press('%s')\n" % old_key)
+    script_out.write("stbt.wait_for_match('%s')\n" % (filename(i, old_key)))
+
+
+def write_press_until_match(script_out, i, old_key):
+    if old_key is None:
+        return
+    stbt.save_frame(stbt.get_frame(), filename(i, old_key))
+    script_out.write("stbt.press_until_match('%s', '%s')\n" % (
+                     old_key, filename(i, old_key)))
+
+
+def filename(i, old_key):
+    return "%04d-%s-complete.png" % (i, old_key)
 
 
 if __name__ == "__main__":

--- a/tests/test-stbt-record.sh
+++ b/tests/test-stbt-record.sh
@@ -1,6 +1,6 @@
 # Run with ./run-tests.sh
 
-test_record() {
+test_record_with_different_keys() {
     stbt-record -v -o test.py --control-recorder=file://<(
         sleep 1; echo gamut;
         sleep 1; echo checkers-8;
@@ -8,9 +8,25 @@ test_record() {
     [ -f 0001-gamut-complete.png ] &&
     [ -f 0002-checkers-8-complete.png ] &&
     [ -f 0003-smpte-complete.png ] &&
+    grep "wait_for_match" test.py &&
+    ! grep "press_until_match" test.py &&
     cp "$testdir/videotestsrc-gamut.png" 0001-gamut-complete.png &&
     cp "$testdir/videotestsrc-checkers-8.png" 0002-checkers-8-complete.png &&
     cp "$testdir/videotestsrc-redblue.png" 0003-smpte-complete.png &&
+    stbt-run -v test.py
+}
+
+test_record_with_multiple_presses_of_the_same_key() {
+    stbt-record -v -o test.py --control-recorder=file://<(
+        sleep 1; echo checkers-8;
+        sleep 1; echo checkers-8;
+        sleep 1; echo checkers-8; sleep 1;) &&
+    [ -f 0001-checkers-8-complete.png ] &&
+    [ ! -f 0002-checkers-8-complete.png ] &&
+    [ ! -f 0003-checkers-8-complete.png ] &&
+    grep "press_until_match" test.py &&
+    ! grep "wait_for_match" test.py &&
+    cp "$testdir/videotestsrc-checkers-8.png" 0001-checkers-8-complete.png &&
     stbt-run -v test.py
 }
 


### PR DESCRIPTION
If the user presses the same remote control key multiple times, then
insert a single `press_until_match` call to the output file instead of
multiple `press` and `wait_for_match` calls; and save a single template
image after the last keypress.

Example: instead of

``` py
stbt.press('OK')
stbt.wait_for_match('0001-OK-complete.png')
stbt.press('OK')
stbt.wait_for_match('0002-OK-complete.png')
```

have

``` py
stbt.press_until_match('OK', '0001-OK-complete.png')
```
