### PR TITLE
Do not force the users of runner to store tests in a git repo

### DIFF
--- a/extra/runner/run
+++ b/extra/runner/run
@@ -79,10 +79,10 @@ run() {
   [ -n "$tag" ] && echo "Tag	${tag#-}" > extra-columns
 
   ( cd "$(dirname "$testpath")" &&
-    git describe --always --dirty
-  ) > git-commit ||
-  die "Failed to determine the test script's git revision."
+    git describe --always --dirty 2>/dev/null || echo untracked
+  ) > git-commit
 
+  grep -q untracked git-commit && echo $testpath > test-name ||
   ( cd "$(dirname "$testpath")" &&
     gitdir=$(dirname "$(abspath "$(git rev-parse --git-dir)")") &&
     echo "${testpath#$gitdir/}"

--- a/tests/test-the-runner.sh
+++ b/tests/test-the-runner.sh
@@ -308,3 +308,14 @@ test_runner_results_server_shows_directory_listing() {
         <(curl http://localhost:5788/my-test-session/) ||
         fail "Didn't find index.html at '/my-test-session/'"
 }
+
+test_runner_reads_git_parameters() {
+    "$srcdir"/extra/runner/run -1 "$testdir"/test.py &&
+    grep -v untracked latest/git-commit &&
+    grep -E '^tests/test.py$' latest/test-name &&
+
+    cp "$testdir/test.py" ./test.py &&
+    "$srcdir"/extra/runner/run -1 test.py &&
+    grep untracked latest/git-commit &&
+    grep -E '^/tmp/.+/test.py$' latest/test-name
+}


### PR DESCRIPTION
Currently runner refuses to run a test if it cannot determine the
test's git revision and repository root.

Allow the users of runner to execute tests that are not stored in a
repository, or to use other version tracking systems.
