### PR TITLE
stbt-run: Let a test script access its real path

### DIFF
--- a/stbt-run
+++ b/stbt-run
@@ -6,6 +6,7 @@ License: LGPL v2.1 or (at your option) any later version (see
 https://github.com/drothlis/stb-tester/blob/master/LICENSE for details).
 """
 
+import os
 import sys
 import traceback
 
@@ -39,6 +40,8 @@ try:
         save_frame, get_frame, MatchParameters,
         debug, UITestError, UITestFailure, MatchTimeout, MotionTimeout,
         ConfigurationError)
+    __file__ = args.script
+    sys.path.insert(0, os.path.dirname(os.path.abspath(args.script)))
     execfile(args.script)
 except Exception as e:  # pylint: disable=W0703
     sys.stdout.write("FAIL: %s: %s: %s\n" % (args.script, type(e).__name__, e))

--- a/tests/test-stbt-run.sh
+++ b/tests/test-stbt-run.sh
@@ -11,3 +11,13 @@ test_extra_arguments() {
     ! stbt-run -v test.py smpte "$testdir/videotestsrc-checkers-8.png" &&
     stbt-run -v test.py checkers-8 "$testdir/videotestsrc-checkers-8.png"
 }
+
+test_script_accesses_its_path() {
+    touch module.py
+    cat > test.py <<-EOF
+	import module
+	print '__file__: ' + __file__
+	EOF
+
+    stbt-run -v test.py && cat log | grep '__file__: test.py'
+}


### PR DESCRIPTION
If a test script is executed with `python` (without stbt):
- the script's directory is added to the beginning of `sys.path`, therefore
  it's possible to import a module from the script's directory;
- the script's path is accessible through the `__file__` special variable.

If a test script is executed with `stbt run`:
- stbt-run's directory is iserted to `sys.path`, therefore it's not
  possible to import a module from the script's directory;
- `__file__` variable contains the path of `stbt-run`.

To let a test script access its real path just like it was executed without
stb-tester, add the script's directory to `sys.path`, and override `__file__`
variable to contain the test script's path.
