### PR TITLE
Stream live video through network with stbt tv

### DIFF
--- a/stbt-tv
+++ b/stbt-tv
@@ -17,6 +17,14 @@
 #/   -f             Do not show video output (i.e. direct the output to
 #/                  'fakesink'). This is to activate the pass-through output of
 #/                  Blackmagic cards for monitoring.
+#/   -l             Listen to client connections and stream compressed video
+#/                  through a TCP socket. Port number and video bandwidth (in
+#/                  bps) are read from the 'port' and 'bandwidth' parameters of
+#/                  the [tv] section of the stb-tester config file, or the
+#/                  default values 4953 for port number and 1500000 bps for
+#/                  bandwidth are used. Watch the stream on a remote computer
+#/                  with VLC by opening 'tcp://<host>:<port>', or with
+#/                  GStreamer's 'tcpclientsrc'.
 #/   -v             Enable 'gst-launch' verbose output.
 
 set -eu
@@ -27,6 +35,10 @@ while [ $# -gt 0 ]; do
     case "$1" in
         -h|--help) usage; exit 0;;
         -f) sink="fakesink silent=true";;
+        -l) port=$(stbt config tv.port 2>/dev/null || echo 4953);
+            bw=$(stbt config tv.bandwidth 2>/dev/null || echo 1500000);
+            sink="queue leaky=downstream ! ffenc_mpeg4 bitrate=$bw !
+                  mpegtsmux ! tcpserversink port=$port";;
         -v) v="-v";;
         -*) usage >&2; exit 1;;
         *) break;;


### PR DESCRIPTION
Launching `stbt tv` with `-s` command line argument streams video
through a TCP socket. Used in conjunction with `stbt control`,
it makes remote configuration of the set-top-boxes under test possible.

See commit message for details.
