### PR TITLE
stbt-tv: force-aspect-ratio in *imagesink

### DIFF
--- a/stbt-tv
+++ b/stbt-tv
@@ -55,10 +55,11 @@ source_pipeline=${*:-$("$(dirname "$0")/stbt-config" global.source_pipeline)}
 
 : ${sink:=$(
         case "$(uname)" in
-            (Darwin) echo glimagesink;;
+            (Darwin) echo "glimagesink force-aspect-ratio=true";;
             (Linux) lspci | grep -Eq '(VMware|VirtualBox)' &&
-                        echo ximagesink || echo xvimagesink;;
-            (*) echo ximagesink;;
+                        echo "ximagesink force-aspect-ratio=true" || \
+                        echo "xvimagesink force-aspect-ratio=true";;
+            (*) echo "ximagesink force-aspect-ratio=true";;
         esac)}
 
 set -x


### PR DESCRIPTION
The default behaviour of the sink is to create a window to accommodate
the full size of the video being piped to it, or as large as the display
will permit. However, if the size of the display limits the size of
the window, the video is squashed and the pixel aspect ratio is not
maintained.

By adding "force-aspect-ratio=true", the video is letterboxed [1] inside
the window and the aspect-ratio of the video is maintained. I've checked
that "force-aspect-ratio" is a valid option to all the listed *imagesinks,
however for obvious reasons it is not valid for "fakesink", so it has to
be explicitly added for every "real" sink element.

[1] http://en.wikipedia.org/wiki/Letterboxing_%28filming%29
