### PR TITLE
runner/run: Don't process tests arguments

### DIFF
--- a/extra/runner/run
+++ b/extra/runner/run
@@ -97,7 +97,7 @@ run() {
   user_command pre_run start
 
   [ $verbose -gt 0 ] && printf "\n$test $*...\n" || printf "$test $*... "
-  stbt run $v --save-video "video.webm" "$testpath" "$@" >rawout 2>rawerr &
+  stbt run $v --save-video "video.webm" "$testpath" -- "$@" >rawout 2>rawerr &
   stbtpid=$!
   local start_time=$(date +%s)
   ts '[%Y-%m-%d %H:%M:%.S %z] ' < rawout | tee stdout.log >&3 &


### PR DESCRIPTION
Although `stbt run` allows us to specify test arguments, if these start
with a dash, these will be processed as `stbt run` arguments instead of
test ones, i.e.:

```
stbt run mytest.py --my-flag
```

In order to get that working we need to use bash's double dash to force it
to stop taking arguments:

```
stbt run mytest.py -- --my-flag
```

Because of this, when using the runner, it's not possible to do:

```
run mytest.py --my-flag
```

And `run mytest.py -- --my-flag` wouldn't be acceptable because the double
dash is used to separate one test and its arguments from another.
