### PR TITLE
report: Replace percentage with percentage confidence interval in summary

### DIFF
--- a/extra/runner/templates/index.html
+++ b/extra/runner/templates/index.html
@@ -35,7 +35,7 @@
         tabindex="1"
         placeholder="Specify filter: A single word, or an expression like: 'exit status' ilike matchtimeout && test ilike mytestname">
       <p id="totals"></p>
-      <small class="muted">† percentage range reflects the fact that the true
+      <small class="muted">Percentage range reflects the fact that the true
       reliability of a test is much better known after running more repititons.
       It is calculated using the
       <a href="http://en.wikipedia.org/wiki/Binomial_proportion_confidence_interval#Wilson_score_interval">
@@ -215,7 +215,7 @@
     function format_summary(pos, n) {
       var a = wilson_score_interval_95(pos, n);
       return pos + "/" + n + " (" + parseFloat((a[0] * 100).toPrecision(2)) +
-             "% - " + parseFloat((a[1] * 100).toPrecision(2)) + "%†)";
+             "% - " + parseFloat((a[1] * 100).toPrecision(2)) + "%)";
     }
     function update_totals() {
       var num_success = $(".success:visible").length;


### PR DESCRIPTION
As you run more repetitions of a test you get a better idea of how reliable the test is.  A percentage is useful to describe a failure rate independent of the number of runs but doesn't include information on how reliable that percentage is likely to be.

This commit replaces the percentages in the report with percentage ranges called "confidence intervals".  This means that instead of 43/430 being a failure rate of 10% it will read 7.5% - 13%.  This means that there is a 95% chance that the "true" reliability of the test falls between 7.5% and 13% rather than the potentially misleading 10%.

![confidence-interval](https://f.cloud.github.com/assets/494659/1707207/417cb344-60fa-11e3-9edc-cfece317ae68.png)

We use the [Wilson Score Interval](http://en.wikipedia.org/wiki/Binomial_proportion_confidence_interval#Wilson_score_interval) to calculate the confidence interval. This assumes a binomial distribution (e.g. test pass/fail results are independent of each other).

This commit also introduces a doctest like test runner for javascript which I wrote to test my wilson_score_interval_95 function.  It depends on [seed](https://wiki.gnome.org/Seed) to run the javascript headless but could probably be fairly easily extended to run with nodejs or similar instead.

Possible future work:
- Include a further breakdown in the report summary by test exit status
  reason.
- Include a Chi-Squared Test for comparing the results with different
  filters applied to answer questions like "has reliability improved
  between these two versions of software?".
- Write tutorial documentation to help users understand the statistics
  and how to interpret test results.

See also:
- [Website for calculating confidence intervals](http://vassarstats.net/prop1.html)
- [Evan Miller's excellent "Statistical Formulas For Programmers"](http://www.evanmiller.org/statistical-formulas-for-programmers.html)
