### PR TITLE
runner/templates/testrun.html: list images before log files

### DIFF
--- a/extra/runner/templates/testrun.html
+++ b/extra/runner/templates/testrun.html
@@ -49,11 +49,6 @@
 <p><b>Notes:</b></p>
 <p id="notes">{{run.notes or "&nbsp;"}}</p>
 
-<p><b>Logs:</b>
-{% for f in run.files %}
-  <p><a href="{{f}}">{{f}}</a>
-{% endfor %}
-
 <ul class="thumbnails">
 {% for image in run.images %}
   <li class="span4">
@@ -64,6 +59,11 @@
   </li>
 {% endfor %}
 </ul>
+
+<p><b>Logs:</b>
+{% for f in run.files %}
+  <p><a href="{{f}}">{{f}}</a>
+{% endfor %}
 
 </div>
 </div>


### PR DESCRIPTION
In failure instances, the screenshot is what you want to see first to
diagnose a failure. When collecting additional log files (using the
runner.extra-logging hook) the number of logs can push the screenshot and
other image artifacts off the bottom of the page (meaning the user must
scroll down the page for each test run they investigate.

This change simply makes the image artifacts be listed before any logs.
