### PR TITLE
Ensure minimum delay between subsequent key presses

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -300,7 +300,7 @@ The following functions are available:
 
 .. <start python docs>
 
-press(key)
+press(key, interpress_delay_secs=0.0)
     Send the specified key-press to the system under test.
 
     The mechanism used to send the key-press depends on what you've configured
@@ -308,6 +308,13 @@ press(key)
 
     `key` is a string. The allowed values depend on the control you're using:
     If that's lirc, then `key` is a key name from your lirc config file.
+
+    `interpress_delay_secs` is a floating-point number that specifies a minimum
+    time to wait after the preceding key press, in order to accommodate the
+    responsiveness of the device under test.
+
+    The global default for `interpress_delay_secs` can be set in the
+    configuration file, in section `press`.
 
 wait_for_match(image, timeout_secs=10, consecutive_matches=1, noise_threshold=None, match_parameters=None)
     Search for `image` in the source video stream.

--- a/stbt.conf
+++ b/stbt.conf
@@ -21,6 +21,9 @@ confirm_threshold=0.16
 # only its speed. Set to `1` to disable this optimisation.
 pyramid_levels = 3
 
+[press]
+interpress_delay_secs = 0
+
 [press_until_match]
 interval_secs = 3
 max_presses = 10

--- a/tests/test-make-doc.sh
+++ b/tests/test-make-doc.sh
@@ -36,7 +36,7 @@ test_that_readme_python_api_docs_are_kept_up_to_date() {
 	
 	.. <start python docs>
 	
-	press(key)
+	press(key, interpress_delay_secs=0.0)
 	    Send the specified key-press to the system under test.
 	
 	.. <end python docs>

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -291,3 +291,33 @@ test_draw_text() {
         --source-pipeline 'filesrc location=fifo ! gdpdepay' \
         verify-draw-text.py
 }
+
+test_that_press_waits_between_subsequent_presses() {
+    cat > test.py <<-EOF &&
+	import stbt, datetime
+	stbt.press('OK')
+	time1 = datetime.datetime.now()
+	stbt.press('OK', interpress_delay_secs=0.5)
+	time2 = datetime.datetime.now()
+	assert time2 - time1 >= datetime.timedelta(seconds=0.5), (
+	    "Expected: >= 0:00:00.5, got: %s between presses" % (time2 - time1))
+	EOF
+    STBT_CONFIG_FILE= stbt-run -v --control none test.py
+}
+
+test_that_press_reads_default_delay_from_stbt_conf() {
+    cat > stbt.conf <<-EOF &&
+	[press]
+	interpress_delay_secs = 0.5
+	EOF
+    cat > test.py <<-EOF &&
+	import stbt, datetime
+	stbt.press('OK')
+	time1 = datetime.datetime.now()
+	stbt.press('OK')
+	time2 = datetime.datetime.now()
+	assert time2 - time1 >= datetime.timedelta(seconds=0.5), (
+	    "Expected: >= 0:00:00.5, got: %s between presses" % (time2 - time1))
+	EOF
+    STBT_CONFIG_FILE="$PWD/stbt.conf" stbt-run -v --control none test.py
+}


### PR DESCRIPTION
Our usual way of ensuring that remote control keys are pressed at
the right time is:

``` py
stbt.press(key1)
stbt.wait_for_match(template)
stbt.press(key2)
```

Due to the enhanced template match algorithm introduced in commit
ac97d6dd, wait_for_match might return so fast that some set-top-boxes
miss the second key press. According to our measurement results
these set-top-boxes require a certain minimum delay between subsequent
key presses in order to register every key.

This commit adds a new optional parameter `interpress_delay_secs` to
`stbt.press` that specifies a minimum time to wait after the preceding
key press that `stbt.press` ensures. The default value of this parameter
is read from the parameter of the same name in the `[global]` section of
the stbt config file.
