### PR TITLE
api-doc.sh: Raise error if command line argument is missing

### DIFF
--- a/api-doc.sh
+++ b/api-doc.sh
@@ -3,6 +3,8 @@
 # Generates documentation from python docstrings, and inserts it at the right
 # place in the README file specified in $1.
 
+set -u
+
 cd "$(dirname "$0")"
 
 doc() {


### PR DESCRIPTION
A tiny correction to api-doc.sh.
