### PR TITLE
extra/runner/server - fix to stop zombie bash processes from building up

### DIFF
--- a/extra/runner/server
+++ b/extra/runner/server
@@ -13,8 +13,11 @@ import argparse
 import mimetypes
 import os
 from os.path import abspath, basename, dirname, isdir, isfile, normpath
+import signal
 import subprocess
 import sys
+
+signal.signal(signal.SIGCHLD, signal.SIG_IGN)
 
 from flask import \
     Flask, abort, redirect, render_template, request, send_from_directory


### PR DESCRIPTION
This commit fixes an issue with the stb-tester runner server that allows
zombie bash processes to build up over time. This is important because
zombie processes consume PIDs, which are a finite resource because they
are 16-bit unsigned shorts on Linux OSs. On a production system I have
seen eight zombie processes under server, which isn't terrible but
inevitably would get worse over time.

`extra/runner/server` spawns `extra/runner/report` instances to
regenerate reports when a user edits fields. You don't want the web
server to call `wait()` synchronously with the web request because
this would block the single-threaded Flask server, and reports on
production systems running on slow backing stores can take on the
order of minutes to generate.

Instead we explicitly set the signal handler for `SIGCHLD` to
`SIG_IGN`. This is the default value, however by explicitly ignoring it
we signal to POSIX.1-2001-compliant kernels that init should instead
be responsible for reaping the child process when it ends. For
more information see [1] [2] [3].

[1] http://en.wikipedia.org/wiki/Child_process

[2] http://stackoverflow.com/questions/8425116/indefinite-daemonized-process-spawning-in-python

[3] http://en.wikipedia.org/wiki/Zombie_process
