### PR TITLE
One line upgrade in javascript to improve behaviour of "Hide this result" link

### DIFF
--- a/extra/runner/static/edit-testrun.js
+++ b/extra/runner/static/edit-testrun.js
@@ -27,6 +27,7 @@ $(document).ready(function() {
                 function() {
                     del.replaceWith(
                         "<span id='deleted' class='text-error'>(Deleted)</span>");
+                    parent.$('tr.info').remove();
                 });
         }
         return false;


### PR DESCRIPTION
Previously to achieve this effect user had to refresh the page in a
browser. With this one liner this is no longer necessary. Result will be
removed from list as soon as we click "[hide this result]" link.
