### PR TITLE
README, RPM specfile: stb-tester requires python 2.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -268,9 +268,8 @@ SOFTWARE REQUIREMENTS
 * GStreamer 0.10 (multimedia framework) + gstreamer-plugins-base +
   gstreamer-plugins-good.
 
-* python (we have tested with 2.6 and 2.7; on <2.7 you will also need to
-  install the python-argparse package) + pygst + docutils (for building
-  the documentation) + nose (for the self-tests).
+* python 2.7 + pygst + docutils (for building the documentation) + nose (for
+  the self-tests).
 
 * OpenCV (image processing library) version >= 2.0.0, and the OpenCV python
   bindings.

--- a/extra/stb-tester.spec
+++ b/extra/stb-tester.spec
@@ -20,7 +20,7 @@ Requires: opencv-python
 Requires: openssh-clients
 Requires: pygtk2
 Requires: pylint
-Requires: python >= 2.4
+Requires: python >= 2.7
 Requires: python-jinja2
 Requires: tesseract
 


### PR DESCRIPTION
Since 0.12 almost a year ago (specifically, commit 45263fa2) we require
python 2.7 (multiple context expressions in a single `with` statement is
new in 2.7). Since we don't test on 2.6, I don't know how many other
things we do aren't compatible with python 2.6, so at least we should
be honest about it.
