### PR TITLE
stbt.precondition

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -446,7 +446,7 @@ class OcrMode
     SINGLE_WORD = 8
     SINGLE_WORD_IN_A_CIRCLE = 9
 
-precondition(message)
+as_precondition(message)
     Context manager that replaces UITestFailures with UITestErrors.
 
     If you run your test scripts with stb-tester's batch runner, the reports it
@@ -454,8 +454,9 @@ precondition(message)
     red results, and unhandled exceptions of any other type as yellow results.
     Note that `wait_for_match`, `wait_for_motion`, and similar functions raise
     `UITestFailure` (red results) when they detect a failure. By running such
-    functions inside a `precondition` context, any `UITestFailure` (red) they
-    raise will be caught, and a `UITestError` (yellow) will be raised instead.
+    functions inside an `as_precondition` context, any `UITestFailure` (red)
+    they raise will be caught, and a `UITestError` (yellow) will be raised
+    instead.
 
     When running a single test script hundreds or thousands of times to
     reproduce an intermittent defect, it is helpful to mark unrelated failures
@@ -468,7 +469,7 @@ precondition(message)
 
     For example:
 
-    >>> with precondition("Channels tuned"):  #doctest:+NORMALIZE_WHITESPACE
+    >>> with as_precondition("Channels tuned"):  #doctest:+NORMALIZE_WHITESPACE
     ...     # Call tune_channels(), which raises:
     ...     raise UITestFailure("Failed to tune channels")
     Traceback (most recent call last):
@@ -651,7 +652,7 @@ class NoVideo(UITestFailure)
     No video available from the source pipeline.
 
 class PreconditionError(UITestError)
-    Exception raised by `precondition`.
+    Exception raised by `as_precondition`.
 
 class UITestFailure(Exception)
     The test failed because the system under test didn't behave as expected.

--- a/api-doc.sh
+++ b/api-doc.sh
@@ -74,7 +74,7 @@ python_docstrings() {
     doc detect_motion
     doc ocr
     doc OcrMode
-    doc precondition
+    doc as_precondition
     doc frames
     doc save_frame
     doc get_frame
@@ -100,11 +100,11 @@ substitute_ocr_default_mode() {
     sed "/^ocr(/ s/mode=3/mode=OcrMode.$mode/"
 }
 
-# stbt.precondition's `@contextmanager` decorator screws up the function
+# stbt.as_precondition's `@contextmanager` decorator screws up the function
 # signature seen by pydoc
-substitute_precondition_signature() {
-    local sig=$(sed -n '/^def precondition/ { s/:$//; s/^def //; p; }' stbt.py)
-    sed "s/^precondition(.*/$sig/"
+substitute_as_precondition_signature() {
+    local sig=$(sed -n '/^def as_precondition/ { s/:$//; s/^def //; p; }' stbt.py)
+    sed "s/^as_precondition(.*/$sig/"
 }
 
 # Prints sed commands to apply,
@@ -130,7 +130,7 @@ substitute_default_params() {
 cat $1 |
 substitute_python_docstrings |
 substitute_ocr_default_mode |
-substitute_precondition_signature |
+substitute_as_precondition_signature |
 sed -f <(substitute_default_params) \
 > $1.new &&
 mv $1.new $1

--- a/stbt.py
+++ b/stbt.py
@@ -763,7 +763,7 @@ def debug(msg):
 
 
 @contextlib.contextmanager
-def precondition(message):
+def as_precondition(message):
     """Context manager that replaces UITestFailures with UITestErrors.
 
     If you run your test scripts with stb-tester's batch runner, the reports it
@@ -771,8 +771,9 @@ def precondition(message):
     red results, and unhandled exceptions of any other type as yellow results.
     Note that `wait_for_match`, `wait_for_motion`, and similar functions raise
     `UITestFailure` (red results) when they detect a failure. By running such
-    functions inside a `precondition` context, any `UITestFailure` (red) they
-    raise will be caught, and a `UITestError` (yellow) will be raised instead.
+    functions inside an `as_precondition` context, any `UITestFailure` (red)
+    they raise will be caught, and a `UITestError` (yellow) will be raised
+    instead.
 
     When running a single test script hundreds or thousands of times to
     reproduce an intermittent defect, it is helpful to mark unrelated failures
@@ -785,7 +786,7 @@ def precondition(message):
 
     For example:
 
-    >>> with precondition("Channels tuned"):  #doctest:+NORMALIZE_WHITESPACE
+    >>> with as_precondition("Channels tuned"):  #doctest:+NORMALIZE_WHITESPACE
     ...     # Call tune_channels(), which raises:
     ...     raise UITestFailure("Failed to tune channels")
     Traceback (most recent call last):
@@ -858,7 +859,7 @@ class ConfigurationError(UITestError):
 
 
 class PreconditionError(UITestError):
-    """Exception raised by `precondition`."""
+    """Exception raised by `as_precondition`."""
     def __init__(self, message, original_exception):
         super(PreconditionError, self).__init__()
         self.message = message

--- a/tests/test-stbt-run.sh
+++ b/tests/test-stbt-run.sh
@@ -33,7 +33,7 @@ test_stbt_run_return_code_on_precondition_error() {
     local ret
     cat > test.py <<-EOF
 	import stbt
-	with stbt.precondition("Tune to gamut pattern"):
+	with stbt.as_precondition("Tune to gamut pattern"):
 	    press("gamut")
 	    wait_for_match("$testdir/videotestsrc-gamut.png", timeout_secs=0)
 	EOF


### PR DESCRIPTION
See the docstring of stbt.precondition for details. This approach has
proved very useful when running a single test script hundreds or
thousands of times to reproduce a particular intermittent defect.
