### PR TITLE
stbt-power: Added a line to allow unsuccessful exit status of commands to propagate down a pipeline

### DIFF
--- a/stbt-power
+++ b/stbt-power
@@ -34,6 +34,9 @@ main() {
         esac
         shift
     done
+    #Allow return value of a pipeline to be non-zero if a command in the
+    #pipeline exits unsuccessfully (calls die)
+    set -o pipefail
     command="$1"
     [[ "$command" =~ ^(on|off|status)$ ]] || die "invalid command '$command'"
 


### PR DESCRIPTION
From: http://www.gnu.org/software/bash/manual/bashref.html#The-Set-Builtin

pipefail
    If set, the return value of a pipeline is the value of the last (rightmost) command to exit with a non-zero status, or zero if all commands in the pipeline exit successfully. This option is disabled by default.

Example of the bug:
pete@lotso: ~/support-scripts/power $ ./stbt-power --power-outlet ipp:rc.mathembedded.com:p62 status; echo $?
p62 = OFF
0
pete@lotso: ~/support-scripts/power $ ./stbt-power --power-outlet ipp:rc.mathembedded.com:p62 ono; echo $?
stbt power: error: invalid command 'ono'
1
pete@lotso: ~/support-scripts/power $ ./stbt-power --power-outlet ipp:rc.mathembedded.com:p654 status; echo $?
stbt power: error: invalid outlet 'p654' (hint: use the 'status' command)
0
