### PR TITLE
Draw clock & button-press timestamps on output video

### DIFF
--- a/stbt.conf
+++ b/stbt.conf
@@ -3,6 +3,8 @@ source_pipeline=videotestsrc is-live=true
 sink_pipeline=xvimagesink sync=false
 control=None
 verbose=0
+# prints clock on recorded video in right top corner
+show_clock = false
 
 # Handle loss of video (but without end-of-stream event) from the video capture
 # device. Set to "True" if you're using the Hauppauge HD PVR.


### PR DESCRIPTION
Previously it used only hardcoded and non-configurable values. With this commit we can specify in config file:
- text that is printed after stbt.press will last for float number of seconds (previously hardcoded 3 seconds)
- we can choose to have timestamp of when key press was received for function stbt.press
- we can choose to not display any text after stbt.press
- we can choose to display clock in right top corner
