### PR TITLE
stbt.ocr: hide Tesseract use message

### DIFF
--- a/stbt.py
+++ b/stbt.py
@@ -700,7 +700,8 @@ def ocr(frame=None, region=None, mode=OcrMode.PAGE_SEGMENTATION_WITHOUT_OSD):
     with mktmp(suffix=".png") as ocr_in, mktmp(suffix=".txt") as ocr_out:
         cv2.imwrite(ocr_in.name, frame)
         subprocess.check_call([
-            "tesseract", ocr_in.name, ocr_out.name[:-4], "-psm", str(mode)])
+            "tesseract", ocr_in.name, ocr_out.name[:-4], "-psm", str(mode)],
+            stderr=open(os.devnull, 'wb'))
         return ocr_out.read().strip()
 
 


### PR DESCRIPTION
With every call, Tesseract prints something like
"""
Tesseract Open Source OCR Engine v3.02.02 with Leptonica
"""
to stderr. This is really annoying when running a test as `stbt run`
(i.e. no -v flag) because the Tesseract messages come through and messes
up my regular debug (e.g. printing what Tesseract has read).

This patch does have the downside of sending _all_ stderr from Tesseract
to /dev/null, however the extra work necessary to create piped processes
in Python makes this this method more desirable.

From a user's perspective, if there is a problem with the Tesseract call,
they get an exception because (we are using `check_call`) that makes it
very clear the problem was with the Tesseract call. Moreover, the only
kind of errors they are likely to get are that there is a problem with
the installation - the whole call to Tesseract is tightly controlled by
stbt and there aren't many ways for it to go wrong.
