### PR TITLE
stbt.as_precondition: preserve screenshot from intercepted failures

### DIFF
--- a/stbt.py
+++ b/stbt.py
@@ -801,7 +801,10 @@ def as_precondition(message):
     try:
         yield
     except UITestFailure as e:
-        raise PreconditionError(message, e)
+        exc = PreconditionError(message, e)
+        if hasattr(e, 'screenshot'):
+            exc.screenshot = e.screenshot  # pylint: disable=W0201
+        raise exc
 
 
 class UITestError(Exception):


### PR DESCRIPTION
Just because the error comes from inside the `as_precondition` context,
to be marked as a "less interesting" failure, doesn't mean that there's
no value in keeping the screenshot from the intercepted Exception.
