### PR TITLE
stbt.ocr: log text read by Tesseract

### DIFF
--- a/stbt.py
+++ b/stbt.py
@@ -702,7 +702,9 @@ def ocr(frame=None, region=None, mode=OcrMode.PAGE_SEGMENTATION_WITHOUT_OSD):
         subprocess.check_output([
             "tesseract", ocr_in.name, ocr_out.name[:-4], "-psm", str(mode)],
             stderr=subprocess.STDOUT)
-        return ocr_out.read().strip()
+        text = ocr_out.read().strip()
+        debug("OCR read '%s'." % text)
+        return text
 
 
 def frames(timeout_secs=None):


### PR DESCRIPTION
It can be nearly impossible to trace errors originating from an OCR
call because up until now the raw text read by Tesseract was not logged
anywhere in output, unless printed explicitly by the caller.
