### PR TITLE
stbt: Add SamsungTCPRemote

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,11 @@ Global options
     "IR Signal Database Utility".
     stbt supports the irNetBox models II and III.
 
+  samsung:<hostname>[:<port>]
+    Can be used to control Samsung Smart TVs using the same TCP network
+    protocol that their mobile phone app uses.  Tested against a Samsung
+    UE32F5370 but will probably work with all recent Samsung Smart TVs.
+
   vr:<hostname>[:<port>]
     A "virtual remote" that communicates with the set-top box over TCP.
     Requires a virtual remote listener (which we haven't released yet) running

--- a/stbt-completion
+++ b/stbt-completion
@@ -175,11 +175,12 @@ _stbt_control_uri() {
         --control=lirc:*:*:) _stbt_lirc_name;;
         --control=lirc:*:) _stbt_lirc_port_or_name;;
         --control=lirc:) _stbt_lirc_socket_or_port_or_hostname;;
+        --control=samsung:*) _stbt_hostname;;
         --control=vr:*:) _stbt_vr_port;;
         --control=vr:) _stbt_hostname;;
         *)
             compgen -W "$( \
-                    _stbt_no_space irnetbox: lirc: vr:
+                    _stbt_no_space irnetbox: lirc: vr: samsung:
                     _stbt_trailing_space none test)" \
                 -- "$cur";;
     esac


### PR DESCRIPTION
SamsungTCPRemote controls certain Samsung Smart TVs according to [the
protocol reverse engineered by Mike Szymaniak](http://sc0ty.pl/2012/02/samsung-tv-network-remote-control-protocol/).  It works with my
Samsung UE32F5370.
