### PR TITLE
stbt run: Pass optional arguments after script name to script

### DIFF
--- a/stbt-run
+++ b/stbt-run
@@ -9,6 +9,7 @@ https://github.com/drothlis/stb-tester/blob/master/LICENSE for details).
 import os
 import sys
 import traceback
+import argparse
 
 import stbt
 
@@ -22,7 +23,7 @@ parser.add_argument(
 parser.add_argument(
     'script', help='The test script to run', metavar='SCRIPT')
 parser.add_argument(
-    'args', nargs='*', metavar='ARG',
+    'args', nargs=argparse.REMAINDER, metavar='ARG',
     help='Additional arguments passed on to the SCRIPT')
 
 args = parser.parse_args(sys.argv[1:])

--- a/tests/test-stbt-run.sh
+++ b/tests/test-stbt-run.sh
@@ -9,6 +9,14 @@ test_extra_arguments() {
     stbt run -v test.py -- a "b c"
 }
 
+test_that_optional_arguments_are_passed_through_to_test_script() {
+    cat > test.py <<-EOF
+	import sys
+	assert sys.argv[1:] == ['--option', '--source-pipeline=not_real']
+	EOF
+    stbt run -v test.py --option --source-pipeline=not_real
+}
+
 test_script_accesses_its_path() {
     touch module.py
     cat > test.py <<-EOF
@@ -37,7 +45,7 @@ test_stbt_run_return_code_on_precondition_error() {
 	    press("gamut")
 	    wait_for_match("$testdir/videotestsrc-gamut.png", timeout_secs=0)
 	EOF
-    stbt run -v test.py --control none &> test.log
+    stbt run -v --control none test.py &> test.log
     ret=$?
     [[ $ret == 2 ]] || fail "Unexpected return code $ret"
     assert grep \


### PR DESCRIPTION
Previously if you were to run:

```
stbt run test.py --food=haloumi
```

stbt run would fail not recognising the optional argument `--food`.  This commit fixes this issue.  Now all arguments that come after the test name, optional or not, are passed to the test script.  While I believe this is correct behaviour this change is backward incompatible.  Before if you were to run

```
stbt run test.py --source-pipeline=videotestsrc
```

stbt would use the source pipeline specified.  Now the source-pipeline is passed through as an argument to the test script.  I don't think this will be a problem in practice but it's still worth mentioning in the release notes.

This was written for and has been split out of Pull Request #100 - Smart TV Support
