### PR TITLE
debugging: Add checking to gst_to_opencv

### DIFF
--- a/stbt.py
+++ b/stbt.py
@@ -1249,9 +1249,13 @@ class GObjectTimeout(object):
         self.timeout_id = None
 
 
+_BGR_CAPS = Gst.Caps.from_string('video/x-raw,format=BGR')
+
+
 def gst_to_opencv(sample):
     buf = sample.get_buffer()
     caps = sample.get_caps()
+    assert caps.can_intersect(_BGR_CAPS)
     return numpy.ndarray(
         (caps.get_structure(0).get_value('height'),
          caps.get_structure(0).get_value('width'),


### PR DESCRIPTION
OpenCV requires video frames in BGR format.  Previously if you passed a `GstSample` in another format (e.g. I420 or RGB) `gst_to_opencv` would either produce a cryptic error message or silently continue having done the wrong thing.

This commit fixes that by adding an assertion.  Admittedly you have to try pretty hard to get your hands on a non BGR format `GstSample` but I've managed it in the past and this would have saved me some debugging effort.

This was developed for and has been been broken out of #100 Smart TV support for easier review and merging.
