### PR TITLE
stbt tv: Allow complex source pipelines with shell escaping

### DIFF
--- a/stbt-tv
+++ b/stbt-tv
@@ -63,4 +63,4 @@ source_pipeline=${*:-$("$(dirname "$0")/stbt-config" global.source_pipeline)}
         esac)}
 
 set -x
-gst-launch-1.0 ${v:-} $source_pipeline ! videoconvert ! $sink sync=false
+eval gst-launch-1.0 ${v:-} $source_pipeline ! videoconvert ! $sink sync=false


### PR DESCRIPTION
Previously if you had a stbt.conf like:

```
source_pipeline=mysrc property="prop with spaces"
```

bash would get confused and would pass `property="prop` as `$2` and separately pass `with` as `$3` and `spaces"` as `$4`.  Using `eval` fixes this issue although it does make me slightly worried that if some bash syntax inadvertently ended up in source_pipeline stbt tv could behave oddly.

This is required for smart-tv support as, due to the complexities of image processing `source_pipeline`s can require many complex parameters.

This commit was originally part of #100 (Smart TV support) but has been broken out for easier review and merging.
