### PR TITLE
stbt control: Detect duplicated keyboard keys in the keymap file

### DIFF
--- a/stbt-control
+++ b/stbt-control
@@ -13,6 +13,8 @@ import sys
 import threading
 import time
 
+from nose.tools import raises
+
 import stbt
 
 
@@ -230,7 +232,11 @@ def load_keymap(keymap_file):
         items = line.split("//")[0].split()
         if len(items) < 2:
             continue
-        elif len(items) == 2:
+        if items[0] in keymap:
+            raise stbt.ConfigurationError(
+                "Multiple remote control keys assigned to keyboard key '%s' "
+                "in the keymap file" % items[0])
+        if len(items) == 2:
             keymap[items[0]] = (items[1],) * 2
         else:
             keymap[items[0]] = (items[1], " ".join(items[2:]))
@@ -244,6 +250,11 @@ def test_load_keymap():
         "Enter  OK  //Move forward\n"))  # Test comments
     assert keymap["Backspace"] == ("BACK", "Go back to previous")
     assert keymap["Enter"] == ("OK", "OK")
+
+
+@raises(stbt.ConfigurationError)
+def test_load_keymap_with_duplicated_key():
+    load_keymap(__import__("StringIO").StringIO("o OK\no OPEN\n"))
 
 
 def validate(keyname):


### PR DESCRIPTION
If a user assigns multiple remote control keys to a keyboard key in the
keymap file, like

```
    o   OPEN
    o   OK
```

`stbt control` silently ignores this configuration issue and only
uses the mapping that is specified later in the keymap file.

Rase `stbt.ConfigurationError` if a keyboard key is duplicated.
