### PR TITLE
stbt.py: Fix teardown hang with BlackMagic Intensity Pro

### DIFF
--- a/docs/backwards-compatibility.md
+++ b/docs/backwards-compatibility.md
@@ -37,14 +37,9 @@ Advice for users of specific hardware:
     shutdown.  This shouldn't affect your ability to test with the VidiU but we
     are looking into it.
 
-*   **Blackmagic Intensity Pro** - **has known issue with the current
-    stb-tester master branch**. During pipeline teardown (after the test script
-    has run to completion) `stbt run` hangs indefinitely. We are investigating
-    and will fix this before the 0.19 release.
-
-    In GStreamer 1.0 `decklinksrc`'s `subdevice` property has been renamed to
-    `device-number`. You also need to add a `videoconvert` element. So
-    `source_pipeline` should become:
+*   **Blackmagic Intensity Pro** - In GStreamer 1.0 `decklinksrc`'s `subdevice`
+    property has been renamed to `device-number`. You also need to add a
+    `videoconvert` element. So `source_pipeline` should become:
 
         decklinksrc mode=... connection=... device-number=0 ! videoconvert
 

--- a/gst_hacks.py
+++ b/gst_hacks.py
@@ -70,3 +70,19 @@ def test_map_buffer_modifying_data():
         a[2] = 1
 
     assert b.extract_dup(0, 5) == "he\x01lo"
+
+
+def gst_iterate(gst_iterator):
+    """Wrap a Gst.Iterator to expose the Python iteration protocol.  The
+    gst-python package exposes similar functionality on Gst.Iterator itself so
+    this code should be retired in the future once gst-python is broadly enough
+    available."""
+    result = Gst.IteratorResult.OK
+    while result == Gst.IteratorResult.OK:
+        result, value = gst_iterator.next()
+        if result == Gst.IteratorResult.OK:
+            yield value
+        elif result == Gst.IteratorResult.ERROR:
+            raise RuntimeError("Iteration Error")
+        elif result == Gst.IteratorResult.RESYNC:
+            raise RuntimeError("Iteration Resync")

--- a/stbt.py
+++ b/stbt.py
@@ -32,7 +32,7 @@ from gi.repository import GObject, Gst, GLib  # pylint: disable-msg=E0611
 import numpy
 
 import irnetbox
-from gst_hacks import map_gst_buffer
+from gst_hacks import map_gst_buffer, gst_iterate
 
 
 GObject.threads_init()
@@ -1127,6 +1127,7 @@ class Display(object):
         self.start_timestamp = None
         self.underrun_timeout = None
         self.video_debug = []
+        self.tearing_down = False
 
         self.restart_source_enabled = restart_source
 
@@ -1321,8 +1322,9 @@ class Display(object):
         sys.stderr.write("Warning: %s: %s\n%s\n" % (err, err.message, dbg))
 
     def on_eos_from_source_pipeline(self, _bus, _message):
-        warn("Got EOS from source pipeline")
-        self.restart_source()
+        if not self.tearing_down:
+            warn("Got EOS from source pipeline")
+            self.restart_source()
 
     def on_eos_from_sink_pipeline(self, _bus, _message):
         debug("Got EOS")
@@ -1353,6 +1355,8 @@ class Display(object):
         return False  # stop the timeout from running again
 
     def start_source(self):
+        if self.tearing_down:
+            return False
         warn("Restarting source pipeline...")
         self.create_source_pipeline()
         self.source_pipeline.set_state(Gst.State.PLAYING)
@@ -1361,9 +1365,31 @@ class Display(object):
             self.underrun_timeout.start()
         return False  # stop the timeout from running again
 
+    @staticmethod
+    def appsink_await_eos(appsink, timeout=None):
+        done = threading.Event()
+
+        def on_eos(_appsink):
+            done.set()
+            return True
+        hid = appsink.connect('eos', on_eos)
+        if appsink.get_property('eos'):
+            appsink.disconnect(hid)
+            return True
+        d = done.wait(timeout)
+        appsink.disconnect(hid)
+        return d
+
     def teardown(self):
+        self.tearing_down = True
         if self.source_pipeline:
+            for elem in gst_iterate(self.source_pipeline.iterate_sources()):
+                elem.send_event(Gst.Event.new_eos())
+            if not self.appsink_await_eos(
+                    self.source_pipeline.get_by_name('appsink'), timeout=10):
+                debug("teardown: Source pipeline did not teardown gracefully")
             self.source_pipeline.set_state(Gst.State.NULL)
+            self.source_pipeline = None
         if not self.novideo:
             debug("teardown: Sending eos")
             self.appsrc.emit("end-of-stream")


### PR DESCRIPTION
Since the port to GStreamer 1.0 the BlackMagic Intensity Pro has caused an intermittant hang during pipeline teardown (after the test script has run to completion).  While it should be valid to call

```
source_pipeline.set_state(Gst.State.NULL)
```

at any time this was hanging.

It seems from the backtraces that the `GstBaseSrc` thread that was associated with `decklinksrc` was blocked calling `gst_task_join`, e.g. waiting for the BlackMagic thread to finish.  In turn there was another thread (presumably the target of the join) calling into the proprietary BlackMagic blob which seemed to be just blocked on `poll()`, presumably as part of an event loop.  There must be some sort of race condition in there.

Instead we shut the pipeline down more gently by first sending EOS to the source pipeline and then only after receiving EOS from our `appsink` do we precede to state NULL.  This way we can be certain that the pipeline is quiescent before attempting the state change.   This seems to fix the hang.

Fixes #110
