### PR TITLE
stbt.py: Fix `stbt._set_config` for sections which don't yet exist

### DIFF
--- a/stbt.py
+++ b/stbt.py
@@ -1016,11 +1016,15 @@ def _set_config(section, option, value):
 
     parser = ConfigParser.SafeConfigParser()
     parser.read([custom_config])
+    if not parser.has_section(section):
+        parser.add_section(section)
     parser.set(section, option, value)
 
     with _sponge(custom_config) as f:
         parser.write(f)
 
+    if not config.has_section(section):
+        config.add_section(section)
     config.set(section, option, value)
 
 

--- a/tests/test_set_config.py
+++ b/tests/test_set_config.py
@@ -60,6 +60,14 @@ def test_that_set_config_modifies_config_value():
         assert get_config('global', 'test', 'goodbye')
 
 
+def test_that_set_config_creates_new_sections_if_required():
+    with set_config_test():
+        _set_config('non_existent_section', 'test', 'goodbye')
+        assert get_config('non_existent_section', 'test', 'goodbye')
+        _config_init(force=True)
+        assert get_config('non_existent_section', 'test', 'goodbye')
+
+
 def test_that_set_config_preserves_file_comments_and_formatting():
     # pylint:disable=W0511,W0101
     # FIXME: Preserve comments and formatting.  This is fairly tricky as


### PR DESCRIPTION
Bug discovered when trying to set a config item in an empty config file.
