### PR TITLE
pylint 1.1 support: `disable-msg` is deprecated in favor of `disable`

### DIFF
--- a/stbt.py
+++ b/stbt.py
@@ -28,12 +28,11 @@ import time
 import warnings
 
 import cv2
-from gi.repository import GObject, Gst, GLib  # pylint: disable-msg=E0611
+from gi.repository import GObject, Gst, GLib  # pylint: disable=E0611
 import numpy
 
 import irnetbox
 from gst_hacks import map_gst_buffer, gst_iterate
-
 
 GObject.threads_init()  # Required for GObject < 3.12
 Gst.init(None)


### PR DESCRIPTION
This is a warning on pylint 1.1.  `disable-msg` was deprecated in 0.21.0. Our oldest platform (Ubuntu 12.04) has 0.25.

I would have just pushed this but I want to make sure travis is happy with the new syntax.
