### PR TITLE
stbt.py: Avoid deprecation warning with pygobject >= 3.12

### DIFF
--- a/stbt.py
+++ b/stbt.py
@@ -28,6 +28,7 @@ import time
 import warnings
 
 import cv2
+import gi
 from gi.repository import GObject, Gst, GLib  # pylint: disable=E0611
 import numpy
 
@@ -35,7 +36,8 @@ import irnetbox
 from gst_hacks import map_gst_buffer, gst_iterate
 
 
-GObject.threads_init()  # Required for GObject < 3.12
+if getattr(gi, "version_info", (0, 0, 0)) < (3, 12, 0):
+    GObject.threads_init()
 Gst.init(None)
 
 warnings.filterwarnings(


### PR DESCRIPTION
See
https://help.gnome.org/misc/release-notes/3.12/developers.html.en#pygobject

Note that `gi.version_info` was added in 3.3.5, but our supported
distros that ship GStreamer 1 also ship a python-gi newer than 3.3.5:
- Fedora 19 ships 3.8.3 (Rawhide --the future Fedora 21-- will ship
  3.12).
- Ubuntu 12.10 ships 3.4.0 (14.04 will ship 3.12).
- Debian testing ships 3.10.
