### PR TITLE
pylint.sh: Ignore pylint 1.x errors regardless of the punctuation

### DIFF
--- a/extra/pylint.sh
+++ b/extra/pylint.sh
@@ -21,8 +21,8 @@ for f in "$@"; do
     printf "%s" "$out" |
         grep -v \
             -e 'pygobject_register_sinkfunc is deprecated' \
-            -e "assertion 'G_TYPE_IS_BOXED (boxed_type)' failed" \
-            -e "assertion 'G_IS_PARAM_SPEC (pspec)' failed" \
+            -e "assertion .G_TYPE_IS_BOXED (boxed_type). failed" \
+            -e "assertion .G_IS_PARAM_SPEC (pspec). failed" \
             -e "return isinstance(object, (type, types.ClassType))"
     pep8 $(pep8options $f) $f || r=1 ret=1
     [ $r -eq 0 ] && echo "$f OK"


### PR DESCRIPTION
Commit eb78c30 modified extra/pylint.sh to hide the following
messages (among others):

```
  assertion 'G_TYPE_IS_BOXED (boxed_type)' failed
  assertion 'G_IS_PARAM_SPEC (pspec)' failed
```

however on my system (Fedora 19) they appear like

```
  assertion `G_TYPE_IS_BOXED (boxed_type)' failed
  assertion `G_IS_PARAM_SPEC (pspec)' failed
```

Note the difference in punctuation: backticks instead of apostrophes.
This might be a Linux vs. BSD issue.

This commit modifies the expression to match any character instead of
apostrophes.
