### PR TITLE
stbt._log_image_descriptions: print more accurate values for `certainty`

### DIFF
--- a/stbt.py
+++ b/stbt.py
@@ -1764,16 +1764,16 @@ def _log_image_descriptions(
                     pixel indicates position of best match).
                 <li>matchTemplate result <b>above match_threshold</b>
                     {{link("source_matchtemplate_threshold", level)}}
-                    of {{"%.2f"|format(match_parameters.match_threshold)}}
+                    of {{"%g"|format(match_parameters.match_threshold)}}
                     (white pixels indicate positions above the threshold).
 
             {% if (level == 0 and first_pass_matched) or level != min(levels) %}
                 <li>Matched at {{position}} {{link("source_with_roi")}}
-                    with certainty {{"%.2f"|format(first_pass_certainty)}}.
+                    with certainty {{"%.4f"|format(first_pass_certainty)}}.
             {% else %}
                 <li>Didn't match (best match at {{position}}
                     {{link("source_with_roi")}}
-                    with certainty {{"%.2f"|format(first_pass_certainty)}}).
+                    with certainty {{"%.4f"|format(first_pass_certainty)}}).
             {% endif %}
 
             </ul>


### PR DESCRIPTION
Both the user specified value for `match_threshold` and the value
calculated by opencv as the `certainty` were printed in the html debug
page rounded to 2 decimal places. This creates confusion when the two
values are printed as the same, which should mean that the templatematch
algorithm proceeds to the second pass, but this doesn't happen. Only from
looking at the console output can you see why the second pass didn't occur.

This commit modified the HMTL debug page so that

1) the `match_threshold` is printed as accurately as specifed (or the
   system default). The user is implicitly encouraged to not be more
   accurate that 2 decimal places by the system defaults (e.g. the default
   `match_threshold` is 0.80, not 0.8 or 0.800)

2) the calculated `certainty` is printed to 4 decimal places. I chose 4
   places rather than 3 because if you have a value such as 0.7995, the
   "%0.3f" python formatter will print "0.800", and although the trailing
   zeros imply rounding has occurred, it's more obvious to just give the
   extra decimal place. Obviously, 0.79995 will still round to 0.8000,
   but the chances of that happening are very small. Printing a full "%f"
   (6 decimal places) would be far too detailed.
