### PR TITLE
stbt batch run: Classify blackmagic failure correctly

### DIFF
--- a/stbt-batch.d/run
+++ b/stbt-batch.d/run
@@ -192,7 +192,7 @@ check_capture_hardware() {
 
     decklinksrc)
       ( echo "$(basename "$0"): Checking Blackmagic video-capture device"
-        GST_DEBUG=decklinksrc:4 GST_DEBUG_NO_COLOR=1 \
+        GST_DEBUG=decklinksrc:5 GST_DEBUG_NO_COLOR=1 \
         "$runner"/../stbt-run --sink-pipeline='fakesink sync=false' \
           <(echo "import time; time.sleep(1)") 2>&1
       ) | ts '[%Y-%m-%d %H:%M:%.S %z] ' > decklinksrc.log
@@ -200,9 +200,12 @@ check_capture_hardware() {
       if grep -q "enable video input failed" decklinksrc.log; then
         local subdevice=$(
           "$runner"/../stbt-config global.source_pipeline |
-          grep -o subdevice=. | awk -F= '{print $2}')
+          grep -o device-number=. | awk -F= '{print $2}')
         local users=$(
-          lsof -F Lnc /dev/blackmagic${subdevice:-0} 2>/dev/null |
+          lsof -F Lnc \
+            /dev/blackmagic${subdevice:-0} \
+            /dev/blackmagic/dv${subdevice:-0} \
+            2>/dev/null |
           # Example `lsof` output:
           # p70752
           # cgst-launch-0.10


### PR DESCRIPTION
The classification for errors due to the Blackmagic Intensity Pro
video-capture card hasn't worked correctly since we ported stbt to
GStreamer 1.0 in commit a83333a2.

Also the "blackmagic card in use by another process" detection logic
hasn't worked since the blackmagic device moved from /dev/blackmagic0 to
/dev/blackmagic/dv0 -- presumably this changed with the recently
released blackmagic 10.0 driver. We look at both locations, thus
providing an upgrade path to users (upgrade stb-tester first, then
upgrade the blackmagic driver -- if you care enough about getting this
error classification right).

Thanks to Lewis Haley for the bug report and for the detailed solution.
Fixes #144.
