### PR TITLE
make dist: Make release tarball generation more deterministic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ user_email?=$(shell git config user.email || echo "$$USER@$$(hostname)")
 
 INSTALL?=install
 TAR ?= $(shell which gnutar >/dev/null 2>&1 && echo gnutar || echo tar)
+GZIP ?= gzip
 
 tools = stbt-run
 tools += stbt-record
@@ -181,7 +182,13 @@ stb-tester-$(VERSION).tar.gz: $(DIST)
 	    printf 'Error: "make dist" requires GNU tar ' >&2; \
 	    printf '(use "make dist TAR=gnutar").\n' >&2; \
 	    exit 1; }
-	$(TAR) -c -z --transform='s,^,stb-tester-$(VERSION)/,' -f $@ $^
+	# Separate tar and gzip so we can pass "-n" for more deterministic tarball
+	# generation
+	$(TAR) -c --transform='s,^,stb-tester-$(VERSION)/,' \
+	       -f stb-tester-$(VERSION).tar $^ \
+	       --mtime="$(shell git show -s --format=%ci HEAD)" \
+	       --format=gnu && \
+	$(GZIP) -9fn stb-tester-$(VERSION).tar
 
 
 # Force rebuild if installation directories change


### PR DESCRIPTION
Debian packages include a `.orig.tar.gz` which is supposed to contain the
pristine upstream tarball.  We don't tend to use tarballs, generating our
tarballs and debian source packages directly from git.  Unfortunately
the Ubuntu PPA builders (and debian builders in general) will complain
if you try to upload the same package with the same version twice if the
orig tarballs are not byte for byte identical.

One way in which tarball generation is non-deterministic is storage of
timestamps in tarballs.  This commit improves the determinism of the
dist tarball by overriding the mtime of the files stored in the tarball,
setting it to the commit time, much like `git archive` does.

In my tests on my (Debian testing) machine, running `make dist` twice in
succession now produces byte-for-byte identical tarballs.  This is good
enough for the purposes of publishing PPAs.  I wouldn't be confident that
the tarballs would be byte-for-byte identical with different versions
of tar and gzip, on different architectures or even with different
environment variables set though.

I would have preferred to specify "pax" (posix 2001) rather than "gnu"
format tarballs but pax seems to store additional header information
which makes it nondeterministic.  Either way there is no real change here
as my tar defaults to gnu anyway, this just makes it explicit.
