### PR TITLE
make dist: Make release tarball generation even more deterministic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ stb-tester-$(VERSION).tar.gz: $(DIST)
 	$(TAR) -c --transform='s,^,stb-tester-$(VERSION)/,' \
 	       -f stb-tester-$(VERSION).tar $^ \
 	       --mtime="$(shell git show -s --format=%ci HEAD)" \
-	       --format=gnu && \
+	       --format=gnu --owner=root --group=root && \
 	$(GZIP) -9fn stb-tester-$(VERSION).tar
 
 


### PR DESCRIPTION
With this commit the generated tarball doesn't depend on the user that
ran `make dist`.  It makes the tarballs identical whether run on my Debian
or my Ubuntu 12.04 docker container.

This is an extension to the work started in ce079fe.

Tested with:

```
make -B dist && md5sum stb-tester-$(<VERSION).tar.gz
```
