### PR TITLE
stbt power: Support ATEN network-controlled PDU's

### DIFF
--- a/extra/debian/control
+++ b/extra/debian/control
@@ -48,6 +48,7 @@ Depends: ${shlibs:Depends},
          python-gobject,
          python-jinja2,
          python-opencv,
+         snmp,
          tesseract-ocr,
          tesseract-ocr-eng
 Description: Automated User Interface testing for set-top boxes. 

--- a/extra/stb-tester.spec.in
+++ b/extra/stb-tester.spec.in
@@ -17,6 +17,7 @@ Requires: gstreamer1-plugins-base
 Requires: gstreamer1-plugins-good
 Requires: lsof
 Requires: moreutils
+Requires: net-snmp-utils
 Requires: opencv
 Requires: opencv-python
 Requires: openssh-clients

--- a/stbt-power
+++ b/stbt-power
@@ -9,14 +9,15 @@
 #/   --power-outlet <uri>
 #/                 Address of the power device and the outlet on the device.
 #/                 The format of <uri> is: (ipp|pdu):<hostname>:<outlet>
-#/                   ipp|pdu     Model of the controllable power supply:
-#/                               * ipp: IP Power 9258
-#/                               * pdu: PDUeX KWX
-#/                   <hostname>  The device's network address.
-#/                   <outlet>    Address of the individual power outlet on
-#/                               the device. Allowed values depend on the
-#/                               specific device model. Optional for the
-#/                               "status" command.
+#/                   aten|ipp|pdu  Model of the controllable power supply:
+#/                                 * aten: ATEN (all models)
+#/                                 * ipp: IP Power 9258
+#/                                 * pdu: PDUeX KWX
+#/                   <hostname>    The device's network address.
+#/                   <outlet>      Address of the individual power outlet on
+#/                                 the device. Allowed values depend on the
+#/                                 specific device model. Optional for the
+#/                                 "status" command.
 #/                 Taken from stbt.conf's "global.power_outlet" if not
 #/                 specified on the command line.
 
@@ -53,10 +54,40 @@ main() {
 }
 
 uri() {
-    local regex='^(?<model>pdu|ipp):(?<hostname>[^: ]+)(:(?<outlet>[^: ]+))?$'
+    local regex='^(?<model>pdu|ipp|aten):(?<hostname>[^: ]+)(:(?<outlet>[^: ]+))?$'
     echo "$2" | perl -ne \
         "if (/$regex/) { print $+{$1} ? $+{$1} : ''; }
          else { exit 1; }"
+}
+
+aten() {
+    local command=$1 hostname=$2 outlet=$3 status
+    aten_command $command $hostname $outlet
+    if [[ $command =~ ^(on|off)$ ]]; then
+        # ATEN PE6108G outlets take between 4-8 seconds to power on
+        for _ in {1..12}; do
+            sleep 1
+            status=$(aten_command status $hostname $outlet)
+            [[ "${status,,}" == $command ]] && return
+        done
+        die "timed out waiting for outlet to power $command"
+    fi
+}
+aten_command() {
+    local command=$1 hostname=$2 outlet=$3 snmp_command
+    local outlet_oid="enterprises.21317.1.3.2.2.2.2.$((1 + outlet)).0"
+    local snmp_param="-Oq -v 2c -c administrator $hostname $outlet_oid"
+
+    case $command in
+        on) snmp_command="snmpset $snmp_param int 2" ;;
+        off) snmp_command="snmpset $snmp_param int 1" ;;
+        status) snmp_command="snmpget $snmp_param" ;;
+    esac
+    output="$($snmp_command)" || die "failed to connect to '$hostname'"
+    echo "$output" | grep -q 'No Such Object available' &&
+        die "invalid outlet '$outlet' or unsupported device"
+    [[ $command == status ]] &&
+        echo "$output" | cut -d' ' -f2 | sed -e 's/1/OFF/' -e 's/2/ON/'
 }
 
 ipp() {


### PR DESCRIPTION
While ATEN PDU's have a web interface they also support SNMP, which is a
more direct and reliable way of controlling them. This commit implements
support for ATEN PDU's over SNMP in a new `aten()` function. It also
updates the regex to recognise the `aten` as a valid model. To query and
control the PDU, it makes use of the `snmpget` and `snmpset` commands
from Net-SNMP (Fedora package: `net-snmp-utils`) [1].

The relevant SNMP OID's were found using ATEN's MIB file v1.1.109 [2],
which applies to _all_ ATEN PDU's:

```
outlet1Status  enterprises.21317.1.3.2.2.2.2.2.0
outlet2Status  enterprises.21317.1.3.2.2.2.2.3.0
outlet3Status  enterprises.21317.1.3.2.2.2.2.4.0
...            ...
outlet42Status enterprises.21317.1.3.2.2.2.2.44.0
```

Each outlet status is an integer that can take a value from 1-8. From
the MIB file:

```
Display and control outlet status. Can't set pending status.

Enumerations:
1 - off
2 - on
3 - pending
4 - reboot
5 - fault
6 - noauth
7 - not-support
8 - pop
```

When querying the outlet status, this implementation maps 1->OFF and
2->ON. It also maps 3->PENDING, because this is the status that is
returned in the first few seconds during a transition from OFF to ON,
and it seemed misleading to map it to either OFF or ON.

The Net-SNMP commands use SNMPv2c because it is faster than SNMPv1 and
unlike SNMPv3 it doesn't require authentication (which would also be
slower).

When `snmpget` or `snmpset` operate on an OID that is not known to the
device, they do not fail with non-zero status but instead print: "No
Such Object available on this agent at this OID". In stbt-power this
should only happen if (1) the device is not an ATEN PDU or (2) the
outlet was specified incorrectly (non-integer, less than 1, or greater
than the device's number of actual outlets).

Note that the SNMPv2 read & write community is hard-coded to
"administrator", which is the default on ATEN PDU's.

This was tested on an ATEN PE610G 8-outlet PDU and Net-SNMP v5.7.2.

[1] http://net-snmp.sourceforge.net/docs/man/
[2] http://www.aten.com/export.php?mid=20130906165112002&type=driver
