### PR TITLE
Fix test_ocr_on_live_video failure on OS X

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -52,11 +52,11 @@ fi
 
 run() {
     scratchdir=$(mktemp -d -t stb-tester.XXX)
+    [ -n "$scratchdir" ] || { echo "$0: mktemp failed" >&2; exit 1; }
     mkdir -p "$scratchdir/config/stbt"
     export XDG_CONFIG_HOME="$scratchdir/config"
     unset STBT_CONFIG_FILE
     cp "$testdir/stbt.conf" "$scratchdir/config/stbt"
-    [ -n "$scratchdir" ] || { echo "$0: mktemp failed" >&2; exit 1; }
     printf "$1... "
     ( cd "$scratchdir" && $1 ) > "$scratchdir/log" 2>&1
     local status=$?


### PR DESCRIPTION
On my Mac OS X system, test_ocr_on_live_video is failing 100% of the
time. The script gets stuck at `stbt.frames(timeout_secs=30).next()`
and times out with a `NoVideo` exception after 90 seconds.

This was already passing on Travis (Ubuntu 12.04).

`git bisect` reveals that this was introduced in c83c42a2, which sets
XDG_CONFIG_HOME (for a good reason) but also sets XDG_CACHE_HOME for
"[future] smart TV support" which hasn't landed yet.

Not setting XDG_CACHE_HOME fixes this problem. Inspecting
`$scratchdir/cache` after the test finished reveals the presence of a
`fontconfig` cache directory -- presumably this is what caused the 90
second pause. There is also a gstreamer cache directory (containing the
GStreamer registry) but I don't think this takes long to generate
because all the other self-tests complete quickly.

Now that the test passes, it takes 10 seconds to tear down because the
videotestsrc doesn't say "is-live=true" (unlike the majority of
self-tests, which take their source-pipeline from tests/stbt.conf). That
long teardown issue will be fixed in
https://github.com/drothlis/stb-tester/pull/162. We'll have to think
about adding some self-tests to make sure that a non-live source works
correctly; until then I'm leaving this the videotestsrc as it is,
because this seems to be the only self-test we have that uses a non-live
source.
