### PR TITLE
stbt control: Allow specifying keymap file in stbt config

### DIFF
--- a/stbt-control
+++ b/stbt-control
@@ -121,6 +121,15 @@ def show_help_keymap():
             m       MENU    Main Menu
             Enter   OK
             c       CLOSE   Close     // Go back to live TV
+
+    The keymap file to use can be specified by:
+
+    1. Passing the filename of the keymap to the --keymap=<filename> command
+       line argument.
+    2. Or setting the configuration value `control.keymap` to the filename of
+       the keymap file
+    3. Copying it into $XDG_CONFIG_PATH/stbt/control.conf (defaults to
+       $HOME/.config/stbt/control.conf).
     """
     print globals()["show_help_keymap"].__doc__
 
@@ -277,7 +286,8 @@ def test_validate():
 def default_keymap_file():
     config_dir = os.environ.get(
         'XDG_CONFIG_HOME', '%s/.config' % os.environ['HOME'])
-    return os.path.join(config_dir, "stbt", "control.conf")
+    return stbt.get_config("control", "keymap", "") or \
+        os.path.join(config_dir, "stbt", "control.conf")
 
 
 def error(s):

--- a/tests/test-stbt-control.sh
+++ b/tests/test-stbt-control.sh
@@ -3,9 +3,11 @@ test_that_stbt_control_sends_a_single_key() {
     cat log | grep -q 'NullRemote: Ignoring request to press "MENU"'
 }
 
-test_stbt_control_as_stbt_record_control_recorder() {
+validate_stbt_record_control_recorder() {
+    control_uri=$1
+
     cat > test.expect <<-EOF &&
-	spawn stbt record --control-recorder=stbt-control:$testdir/stbt-control.keymap
+	spawn stbt record --control-recorder=$control_uri
 	expect "stbt-control.keymap"
 	send "f"
 	sleep 1
@@ -33,4 +35,19 @@ test_stbt_control_as_stbt_record_control_recorder() {
 	stbt.wait_for_match('0003-smpte-complete.png')
 	EOF
     diff -u expected test.py
+}
+
+test_stbt_control_as_stbt_record_control_recorder__explict_keymap() {
+    validate_stbt_record_control_recorder \
+        stbt-control:$testdir/stbt-control.keymap
+}
+
+test_stbt_control_as_stbt_record_control_recorder__default_keymap() {
+    cp "$testdir/stbt-control.keymap" "$XDG_CONFIG_HOME/stbt/control.conf" &&
+    validate_stbt_record_control_recorder stbt-control
+}
+
+test_stbt_control_as_stbt_record_control_recorder__keymap_from_config() {
+    set_config control.keymap "$testdir/stbt-control.keymap" &&
+    validate_stbt_record_control_recorder stbt-control
 }


### PR DESCRIPTION
With this change the keymap file will default to the value stored in
"control.keymap" rather than and falling back to
`~/.config/stbt/control.conf`.  This makes it easier for the use-case
where you have a config file per device under test and you want to be
able to easily switch between them using the `STBT_CONFIG_FILE`
environment variable.

TODO:
- [x] Document this behaviour
- [x] Tests?
