### PR TITLE
API: Allow treating `MatchResult` as a boolean

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -672,7 +672,8 @@ class MatchParameters
 
 class MatchResult
     * `timestamp`: Video stream timestamp.
-    * `match`: Boolean result.
+    * `match`: Boolean result, the same as evaluating `MatchResult` as a bool.
+      e.g: `if match_result:` will behave the same as `if match_result.match`.
     * `region`: The `Region` in the video frame where the image was found.
     * `first_pass_result`: Value between 0 (poor) and 1.0 (excellent match)
       from the first pass of the two-pass templatematch algorithm.

--- a/stbt.py
+++ b/stbt.py
@@ -326,7 +326,8 @@ def _bounding_box(a, b):
 class MatchResult(object):
     """
     * `timestamp`: Video stream timestamp.
-    * `match`: Boolean result.
+    * `match`: Boolean result, the same as evaluating `MatchResult` as a bool.
+      e.g: `if match_result:` will behave the same as `if match_result.match`.
     * `region`: The `Region` in the video frame where the image was found.
     * `first_pass_result`: Value between 0 (poor) and 1.0 (excellent match)
       from the first pass of the two-pass templatematch algorithm.
@@ -376,6 +377,9 @@ class MatchResult(object):
     @property
     def position(self):
         return Position(self.region.x, self.region.y)
+
+    def __nonzero__(self):
+        return self.match
 
 
 def detect_match(image, timeout_secs=10, noise_threshold=None,

--- a/tests/run-performance-test.sh
+++ b/tests/run-performance-test.sh
@@ -14,8 +14,8 @@ cat > script.$$ <<-EOF
 	start = datetime.datetime.now()
 	for m in stbt.detect_match("template.png", timeout_secs=10):
 	    frames += 1
-	    print "%s %s %s" % (m.timestamp, m.match, m.position)
-	    # if not m.match:
+	    print "%s %s %s" % (m.timestamp, bool(m), m.position)
+	    # if not m:
 	    #     break
 	duration = (datetime.datetime.now() - start).total_seconds()
 	print "%.2f fps (%d frames in %.2fs)" % (

--- a/tests/test-match.sh
+++ b/tests/test-match.sh
@@ -270,7 +270,7 @@ test_press_until_match_searches_in_script_directory() {
 test_detect_match_searches_in_script_directory() {
     cat > test.py <<-EOF
 	m = detect_match("in-script-dir.png").next()
-	if not m.match:
+	if not m:
 	    raise Exception("'No match' when expecting match.")
 	EOF
     cp "$testdir"/videotestsrc-bw.png in-script-dir.png
@@ -287,7 +287,7 @@ test_detect_match_searches_in_library_directory() {
 	import stbt
 	def find():
 	    m = stbt.detect_match("in-helpers-dir.png").next()
-	    if not m.match:
+	    if not m:
 	        raise Exception("'No match' when expecting match.")
 	EOF
     cp "$testdir"/videotestsrc-bw.png stbt_helpers/in-helpers-dir.png
@@ -310,7 +310,7 @@ test_detect_match_searches_in_caller_directory() {
 	import stbt
 	def find(image):
 	    m = stbt.detect_match(image).next()
-	    if not m.match:
+	    if not m:
 	        raise Exception("'No match' when expecting match.")
 	EOF
     cp "$testdir"/videotestsrc-bw.png stbt_tests/in-caller-dir.png
@@ -330,7 +330,8 @@ test_detect_match_reports_match() {
     cat > test.py <<-EOF
 	# Should report a match
 	for match_result in detect_match("$testdir/videotestsrc-redblue.png"):
-	    if match_result.match:
+	    if match_result:
+	        assert match_result.match
 	        import sys
 	        sys.exit(0)
 	    else:
@@ -380,7 +381,8 @@ test_detect_match_reports_no_match() {
     cat > test.py <<-EOF
 	# Should not report a match
 	for match_result in detect_match("$testdir/videotestsrc-checkers-8.png"):
-	    if not match_result.match:
+	    if not match_result:
+	        assert not match_result.match
 	        import sys
 	        sys.exit(0)
 	    else:
@@ -421,7 +423,7 @@ test_detect_match_changing_template_is_not_racy() {
     cat > test.py <<-EOF
 	for match_result in detect_match("$testdir/videotestsrc-bw.png",
 	                                 timeout_secs=1):
-	    if not match_result.match:
+	    if not match_result:
 	        raise Exception("Match not reported.")
 	    # Leave time for another frame to be processed with this template
 	    import time
@@ -430,7 +432,7 @@ test_detect_match_changing_template_is_not_racy() {
 	for match_result in detect_match(
 	        "$testdir/videotestsrc-redblue-flipped.png"):
 	    # Not supposed to match
-	    if not match_result.match:
+	    if not match_result:
 	        import sys
 	        sys.exit(0)
 	    else:
@@ -445,12 +447,12 @@ test_detect_match_example_press_and_wait_for_match() {
 	key_sent = False
 	for match_result in detect_match("$testdir/videotestsrc-checkers-8.png"):
 	    if not key_sent:
-	        if match_result.match:
+	        if match_result:
 	            raise Exception("Wrong match reported.")
 	        press("checkers-8")
 	        key_sent = True
 	    else:
-	        if match_result.match:
+	        if match_result:
 	            import sys
 	            sys.exit(0)
 	raise Exception("Timeout occured without any result reported.")


### PR DESCRIPTION
This is part of an effort to make the stbt match API more composible.
For instance with the addition of a `match()` method you will be able
to write something like:

```
if match('template.png') or match('template2.png'):
    do_stuff()
```

The tests are updated to reflect the recommended way of expressing testing
for matches.
