### PR TITLE
stbt._set_config: Don't fail if ~/.config/stbt/ doesn't exist

### DIFF
--- a/stbt.py
+++ b/stbt.py
@@ -1295,6 +1295,10 @@ def _set_config(section, option, value):
         parser.add_section(section)
     parser.set(section, option, value)
 
+    d = os.path.dirname(custom_config)
+    if not _mkdir(d):
+        raise RuntimeError(
+            "Failed to create directory '%s'; cannot write config file." % d)
     with _sponge(custom_config) as f:
         parser.write(f)
 

--- a/tests/test_set_config.py
+++ b/tests/test_set_config.py
@@ -81,3 +81,14 @@ def test_that_set_config_preserves_file_comments_and_formatting():
         _set_config('global', 'test', 'goodbye')
         assert open('test.cfg', 'r').read() == test_config.replace(
             'hello', 'goodbye')
+
+
+def test_that_set_config_creates_directories_if_required():
+    with _directory_sandbox() as d:
+        os.environ['XDG_CONFIG_HOME'] = d + '/.config'
+        if 'STBT_CONFIG_FILE' in os.environ:
+            del os.environ['STBT_CONFIG_FILE']
+        _set_config('global', 'test', 'hello2')
+        assert os.path.isfile(d + '/.config/stbt/stbt.conf')
+        _config_init(force=True)
+        assert get_config('global', 'test') == 'hello2'


### PR DESCRIPTION
This happens if the user hasn't created `~/.config/stbt/` and hasn't
specified `$STBT_CONFIG_FILE`.
