### PR TITLE
make check: Don't explicitly list python files to test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,15 +120,16 @@ README.rst: stbt.py api-doc.sh
 clean:
 	rm -f stbt.1 stbt defaults.conf .stbt-prefix
 
+PYTHON_FILES = $(shell (git ls-files '*.py' && \
+           git grep --name-only -E '^\#!/usr/bin/(env python|python)') \
+           | sort | uniq)
+
 check: check-pylint check-nosetests check-integrationtests check-bashcompletion
 check-nosetests:
 	# Workaround for https://github.com/nose-devs/nose/issues/49:
 	cp stbt-control nosetest-issue-49-workaround-stbt-control.py && \
 	nosetests --with-doctest -v \
-	    gst_hacks.py \
-	    irnetbox.py \
-	    stbt.py \
-	    tests/test_*.py \
+	    $(filter-out tests/test.py,$(wildcard $(subst -,_,$(PYTHON_FILES)))) \
 	    nosetest-issue-49-workaround-stbt-control.py && \
 	rm nosetest-issue-49-workaround-stbt-control.py
 check-integrationtests: install-for-test
@@ -140,21 +141,7 @@ check-hardware: install-for-test
 	tests/run-tests.sh -i tests/hardware/test-hardware.sh
 check-pylint:
 	printf "%s\n" \
-	    gst_hacks.py \
-	    irnetbox.py \
-	    irnetbox-proxy \
-	    stbt.py \
-	    stbt-batch.d/instaweb \
-	    stbt-batch.d/report.py \
-	    stbt-config \
-	    stbt-control \
-	    stbt-record \
-	    stbt-run \
-	    stbt-templatematch \
-	    stbt_pylint_plugin.py \
-	    tests/fake-irnetbox \
-	    tests/test_*.py \
-	    tests/validate-ocr.py \
+	    $(PYTHON_FILES) \
 	| PYTHONPATH=$(PWD) $(parallel) extra/pylint.sh
 check-bashcompletion:
 	@echo Running stbt-completion unit tests

--- a/tests/fake-lircd
+++ b/tests/fake-lircd
@@ -12,12 +12,11 @@
 See http://www.lirc.org/html/technical.html#applications
 """
 
-from contextlib import contextmanager
 import os
 import re
-import signal
 import socket
 import tempfile
+from contextlib import contextmanager
 
 
 def main():

--- a/tests/hardware/test.py
+++ b/tests/hardware/test.py
@@ -1,6 +1,7 @@
-import stbt
 import argparse
 import sys
+
+import stbt
 
 
 def main(argv):
@@ -16,6 +17,7 @@ def main(argv):
         pass
 
     if args.test_pipeline_restart:
+        # pylint: disable=W0511
         # TODO: Automate this by using a Raspberry Pi to stimulate the capture
         #       hardware
         sys.stdout.write("Waiting for a long time for match to check pipeline "

--- a/tests/preconditions.py
+++ b/tests/preconditions.py
@@ -1,5 +1,6 @@
 from stbt import press, wait_for_match
 
+
 def checkers_via_gamut():
     """Change input video to "gamut" patterns, then "checkers" pattern"""
     wait_for_match("videotestsrc-redblue.png")

--- a/tests/test.py
+++ b/tests/test.py
@@ -5,9 +5,8 @@ import time
 
 import stbt
 
-
 for arg in sys.argv[1:]:
-    print("Command-line argument: %s\n" % arg)
+    print "Command-line argument: %s\n" % arg
 
 # Fail if this script is run more than once from the same $scratchdir
 n_runs = len(glob.glob("../????-??-??_??.??.??*"))  # includes current run


### PR DESCRIPTION
This increases coverage as you don't have to remember to add your python file to the list in the Makefile.  It also saves 15 lines of Makefile.

nosetests can't check files with `-` in the name so I use the subst/wildcard combination to filter those out.
