### PR TITLE
stbt.uri_to_remote -> factories: [bug] check for empty string not None

### DIFF
--- a/stbt.py
+++ b/stbt.py
@@ -2233,7 +2233,7 @@ class LircRemote(object):
 
 
 def new_local_lirc_remote(lircd_socket, control_name):
-    if lircd_socket is None:
+    if lircd_socket is '':
         lircd_socket = '/var/run/lirc/lircd'
 
     def _connect():
@@ -2263,7 +2263,7 @@ def new_tcp_lirc_remote(hostname, port, control_name):
         control = new_tcp_lirc_remote("localhost", "8765", "humax")
         control.press("MENU")
     """
-    if hostname is None:
+    if hostname is '':
         hostname = 'localhost'
     port = int(port)
 


### PR DESCRIPTION
Commit 1cd69253 refactored the code for generating remote control objects
into a uri parser (using the `re` module). However, due to the fact that
in regex a glob '*' can match anything including an empty string, there
was a problem when the default lircd for a lirc remote or the default
hostname (localhost) for a virtual remote were used, because the check

``` python
if `param` is None:
     `param` = default
```

_did not take effect_ because `param` is '' (empty string).

This commit fixes this bug by correctly checking for the empty string
instead of None.
