### PR TITLE
stbt.{warn,debug,ddebug}: don't cast unicode to python-string

### DIFF
--- a/stbt.py
+++ b/stbt.py
@@ -2627,20 +2627,20 @@ _debugstream = codecs.getwriter('utf-8')(sys.stderr)
 
 def warn(s):
     _debugstream.write("%s: warning: %s\n" % (
-        os.path.basename(sys.argv[0]), str(s)))
+        os.path.basename(sys.argv[0]), s))
 
 
 def debug(msg):
     """Print the given string to stderr if stbt run `--verbose` was given."""
     if _debug_level > 0:
         _debugstream.write(
-            "%s: %s\n" % (os.path.basename(sys.argv[0]), str(msg)))
+            "%s: %s\n" % (os.path.basename(sys.argv[0]), msg))
 
 
 def ddebug(s):
     """Extra verbose debug for stbt developers, not end users"""
     if _debug_level > 1:
-        _debugstream.write("%s: %s\n" % (os.path.basename(sys.argv[0]), str(s)))
+        _debugstream.write("%s: %s\n" % (os.path.basename(sys.argv[0]), s))
 
 
 # Tests


### PR DESCRIPTION
Commit 0f71ebe7 made all logging output encoded as utf-8. This was to
support utf-8 characters read by OCR. However, the commit did not update
the `warn`, `debug` and `ddebug` functions, which were casting their
messages to python-string type (which is ascii) and this was causing
errors because you _can't_ cast utf-8 encoded characters to ascii (not
just using `str()` anyway). This was raising UnicodeEncodeError.

e.g.:

```
In [8]: print 'ä'
ä
In [9]: print str('ä')
ä
In [10]: print u'ä'
ä
In [11]: print str(u'ä')
---------------------------------------------------------------------------
UnicodeEncodeError                        Traceback (most recent call last)
<ipython-input-11-383a35edd348> in <module>()
----> 1 print str(u'ä')
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe4' in...
position 0: ordinal not in range(128)
```

This commit fixes the issue by removing the `str()` cast. This shouldn't
cause breakage because the python string formatter `%s` used to insert
the message into the output string is _already_ calling the objects
`__repr__` or `__str__` methods (so something like `debug(1)` will just
cast the `int(1)` to `str('1')` anyway).
