### PR TITLE
Classify "really uninteresting" failures differently in the batch report

### DIFF
--- a/stbt-batch.d/report.py
+++ b/stbt-batch.d/report.py
@@ -118,8 +118,10 @@ class Run(object):
             return "success"
         elif self.exit_status == 1:
             return "error"  # Red: Possible system-under-test failure
-        else:
+        elif self.exit_status == 2:
             return "warning"  # Yellow: Test infrastructure error
+        else:
+            return "uninteresting"  # Grey: Things like sigterm
 
     def read(self, f):
         f = os.path.join(self.rundir, f)

--- a/stbt-batch.d/templates/index.html
+++ b/stbt-batch.d/templates/index.html
@@ -324,7 +324,7 @@
         markerOptions: { size: 5 }
       },
       series: [
-        {color: 'gray'},
+        {color: '#15bb35'},
         {color: 'orange', markerOptions: {style: 'filledSquare'}},
         {color: 'red', markerOptions: {style: 'filledSquare'}},
       ],

--- a/stbt-batch.d/templates/index.html
+++ b/stbt-batch.d/templates/index.html
@@ -14,6 +14,9 @@
     .jqplot-highlighter-tooltip {
       line-height: 1; background-color: rgba(208, 208, 208, 0.9); }
 
+    .uninteresting { background-color: #bbbbbb; color: #666666; }
+    .text-uninteresting { color: #666666; }
+
     /* Border around selected row, opening up like a '{' onto right pane */
     table#testruns { border-collapse: separate; }
     #testruns tr.selected td {
@@ -29,12 +32,15 @@
     #testruns tr.selected.error { background-color: #ffeaea; }
     #testruns tr.selected.success td { background-color: #edffe6; }
     #testruns tr.selected.warning td { background-color: #fffbe6; }
+    #testruns tr.selected.uninteresting td { background-color: #eeeeee; }
     #testruns tr.selected.error td:last-child {
       background: linear-gradient(to right, #ffeaea, #fff); }
     #testruns tr.selected.success td:last-child {
       background: linear-gradient(to right, #edffe6, #fff); }
     #testruns tr.selected.warning td:last-child {
       background: linear-gradient(to right, #fffbe6, #fff); }
+    #testruns tr.selected.uninteresting td:last-child {
+      background: linear-gradient(to right, #eeeeee, #fff); }
   </style>
 </head>
 
@@ -265,6 +271,7 @@
       var num_success = $(".success:visible").length;
       var num_failed = $(".error:visible").length;  // red
       var num_warnings = $(".warning:visible").length;  // yellow
+      var num_uninteresting = $(".uninteresting:visible").length;  // grey
       var num_total = num_success + num_failed + num_warnings;
       var percent_success = 0;
       if (num_total > 0) {
@@ -274,7 +281,8 @@
       $("#totals").html(
         "<span class='text-success'>Passed: " + format_summary(num_success, num_total) + ".</span> " +
         "<span class='text-error'>Failed: " + format_summary(num_failed, num_total) + ".</span> " +
-        "<span class='text-warning'>Errors: " + format_summary(num_warnings, num_total) + ".</span>");
+        "<span class='text-warning'>Errors: " + format_summary(num_warnings, num_total) + ".</span> " +
+        "<span class='text-uninteresting'>Uninteresting: " + format_summary(num_uninteresting, num_total) + ".</span>");
     };
   });
 </script>
@@ -291,7 +299,7 @@
     update_plot();
 
     function update_plot() {
-      plotSeries = [[], [], []];
+      plotSeries = [[], [], [], []];
       $($('#testruns > tbody > tr').filter(":visible").get().reverse()).each(
         function(index, element) {
           var timestamp = element.cells.item(0).textContent;
@@ -305,6 +313,8 @@
             seriesIndex = 1;
           } else if ($(element).hasClass('error')) {
             seriesIndex = 2;
+          } else if ($(element).hasClass('uninteresting')) {
+            seriesIndex = 3;
           } else {  // Test in progress
             return;
           }
@@ -327,6 +337,7 @@
         {color: '#15bb35'},
         {color: 'orange', markerOptions: {style: 'filledSquare'}},
         {color: 'red', markerOptions: {style: 'filledSquare'}},
+        {color: '#666666', markerOptions: {style: 'x'}},
       ],
       highlighter: {
         show: true,


### PR DESCRIPTION
By uninteresting failures, I mean the _really_ uninteresting things like sigterms, sigsegvs, etc
which have nothing to do with the system-under-test and therefore they shouldn't be coloured
and counted as part of the general "failures" as it skews the results.
