### PR TITLE
Stbt batch exit status

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -19,6 +19,11 @@ For installation instructions see
 [Getting Started](http://stb-tester.com/getting-started.html).
 
 ##### Breaking changes since 0.20
+
+* `stbt batch run` now exits with non-zero exit status if any of the tests in the
+  run failed or errored.  This, in combination with the `-1` option makes it
+  easier to use from and integrate with external CI systems.
+
 ##### User-visible changes since 0.20
 ##### Developer-visible changes since 0.20
 

--- a/stbt-batch.d/run
+++ b/stbt-batch.d/run
@@ -37,6 +37,7 @@ main() {
   tag=
   v=-v
   verbose=0
+  failure_count=0
   while getopts ":1dhkt:v" option; do
     case $option in
       1) run_once=true;;
@@ -60,11 +61,17 @@ main() {
 
   while true; do
     while IFS=$'\t' read -a test; do
-      run "${test[@]}"
+      run "${test[@]}" || failure_count=$((failure_count+1))
       should_i_continue || break 2
     done < <(parse_test_args "$@")
     $run_once && break
   done
+
+  if [ "$failure_count" = 0 ]; then
+    exit 0
+  else
+    exit 1
+  fi
 }
 
 run() {
@@ -139,6 +146,7 @@ run() {
 
   cd ..
   rm -f latest"$tag"; ln -s "$rundir" latest"$tag"
+  return $exit_status
 }
 
 trap on_kill1 sigint sigterm

--- a/tests/test-stbt-batch.sh
+++ b/tests/test-stbt-batch.sh
@@ -7,6 +7,7 @@ create_test_repo() {
         git config user.name "Stb Tester" &&
         git config user.email "test-stbt-batch@stb-tester.com" &&
         cp "$testdir/test.py" "$testdir/test2.py" \
+           "$testdir"/test_{success,error,failure}.py \
            "$testdir/videotestsrc-checkers-8.png" \
            "$testdir/videotestsrc-gamut.png" . &&
         git add . &&
@@ -391,4 +392,18 @@ test_that_stbt_batch_run_isolates_stdin_of_user_hooks() {
     stbt batch run -1 tests/test.py tests/test2.py
     cat log | grep -q "STDIN=None" || fail "Data in user script's STDIN"
     cat log | grep -q "test2.py ..." || fail "test2.py wasn't executed"
+}
+
+test_that_stbt_batch_run_exits_with_failure_if_any_test_fails() {
+    create_test_repo
+    stbt batch run -1 tests/test_success.py || fail "Test should succeed"
+    cat */combined.log
+
+    ! stbt batch run -1 tests/test_failure.py || fail "Test should fail"
+    ! stbt batch run -1 tests/test_error.py || fail "Test should fail"
+
+    ! stbt batch run -1 tests/test_success.py tests/test_failure.py \
+        || fail "Test should fail"
+    ! stbt batch run -1 tests/test_failure.py tests/test_success.py \
+        || fail "Test should fail"
 }

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -1,0 +1,4 @@
+import stbt
+
+if __name__ == '__main__':
+    raise stbt.UITestError("Test Error")

--- a/tests/test_failure.py
+++ b/tests/test_failure.py
@@ -1,0 +1,4 @@
+import stbt
+
+if __name__ == '__main__':
+    raise stbt.UITestFailure("Test Failure")

--- a/tests/test_success.py
+++ b/tests/test_success.py
@@ -1,0 +1,2 @@
+if __name__ == '__main__':
+    pass


### PR DESCRIPTION
`stbt batch run` now exits with exit status `1` if any of the tests in the run failed or errored.  This, in combination with the `-1` option makes it easier to use from and integrate with external CI systems.
