### PR TITLE
stbt.py: Fix race condition: TypeError on NoVideo

### DIFF
--- a/stbt.py
+++ b/stbt.py
@@ -1512,8 +1512,10 @@ class Display(object):
             self.novideo = False
         except Queue.Empty:
             self.novideo = True
-            Gst.debug_bin_to_dot_file_with_ts(
-                self.source_pipeline, Gst.DebugGraphDetails.ALL, "NoVideo")
+            pipeline = self.source_pipeline
+            if pipeline:
+                Gst.debug_bin_to_dot_file_with_ts(
+                    pipeline, Gst.DebugGraphDetails.ALL, "NoVideo")
             raise NoVideo("No video")
         if isinstance(gst_sample, Exception):
             raise UITestError(str(gst_sample))


### PR DESCRIPTION
During a NoVideo source pipeline reset `Display.source_pipeline` is `None`.  If simultaneously `get_sample` times out stbt will try to dump the source pipeline graph.  This causes `TypeError` to be raised:

```
  File ".../stbt/stbt.py", line 1493, in get_sample
    self.source_pipeline, Gst.DebugGraphDetails.ALL, "NoVideo")
TypeError: Argument 0 does not allow None as a value
```

Thanks to @lewishaley for reporting this bug and correctly diagnosing the cause.

Fixes drothlis/#197
