### PR TITLE
make check: nosetest more files (all "*.py" files)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,8 +128,8 @@ check: check-pylint check-nosetests check-integrationtests check-bashcompletion
 check-nosetests:
 	# Workaround for https://github.com/nose-devs/nose/issues/49:
 	cp stbt-control nosetest-issue-49-workaround-stbt-control.py && \
-	nosetests --with-doctest -v \
-	    $(filter-out tests/test.py,$(wildcard $(subst -,_,$(PYTHON_FILES)))) \
+	nosetests --with-doctest -v --match "^test_" \
+	    $(shell git ls-files '*.py' | grep -v tests/test.py) \
 	    nosetest-issue-49-workaround-stbt-control.py && \
 	rm nosetest-issue-49-workaround-stbt-control.py
 check-integrationtests: install-for-test
@@ -140,8 +140,7 @@ check-hardware: install-for-test
 	export PATH="$$PWD/tests/test-install/bin:$$PATH" && \
 	tests/run-tests.sh -i tests/hardware/test-hardware.sh
 check-pylint:
-	printf "%s\n" \
-	    $(PYTHON_FILES) \
+	printf "%s\n" $(PYTHON_FILES) \
 	| PYTHONPATH=$(PWD) $(parallel) extra/pylint.sh
 check-bashcompletion:
 	@echo Running stbt-completion unit tests

--- a/tests/validate-ocr.py
+++ b/tests/validate-ocr.py
@@ -39,7 +39,7 @@ import jinja2
 import yaml
 
 
-def test(imgname, phrases, params):
+def check(imgname, phrases, params):
     from stbt import ocr
 
     img = cv2.imread(imgname)
@@ -91,7 +91,7 @@ def main(argv):
 
         phrases = [x.decode('utf-8') for x in sections[-1].split('\n')
                    if x.strip() != '']
-        results.append(test(imgname, phrases, params))
+        results.append(check(imgname, phrases, params))
 
     sys.stderr.write('\n')
 


### PR DESCRIPTION
37da66f8 tried to make `nosetests` check every python file, but filters
out files with "-" in the name because of the mistaken belief that
`nosetests` can't handle files with "-". In fact, `nosetests` can't
handle files that don't end in ".py"[1], and it was a coincidence that
all our python files that don't end in ".py" also have a "-" in the
filename.

37da66f8 filtered out some files that _do_ end in ".py", such as
`stbt-batch.d/report.py` and `tests/validate-ocr.py`.

I had to pass an explicit `--match` pattern to `nosetests` so that it
wouldn't think that `report.testrun` in `stbt-batch.d/report.py` is a
unit test. Similarly, I had to rename `test` in `validate-ocr.py`
because it isn't a unit test.

[1] https://github.com/nose-devs/nose/issues/49
