### PR TITLE
stbt batch run: Add "-o" to specify output directory

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -25,6 +25,12 @@ For installation instructions see
   easier to use from and integrate with external CI systems.
 
 ##### User-visible changes since 0.20
+
+* `stbt batch run` has a new `-o` flag to specify the output directory where
+  you want the report and test-run logs to be saved. If not specified it
+  defaults to the existing behaviour, which is to write to the current working
+  directory.
+
 ##### Developer-visible changes since 0.20
 
 #### 0.20: Stb-tester ported to GStreamer 1; OCR accuracy improvements

--- a/stbt-batch.d/run
+++ b/stbt-batch.d/run
@@ -20,6 +20,8 @@
 #/   -v    Verbose. Print stbt standard output.
 #/   -vv   Extra verbose. Print stbt standard error output.
 #/
+#/   -o    Output directory to save the report and test-run
+#/         logs under (defaults to the current directory).
 #/   -t <tag>  Tag to add to test run directory names (useful
 #/         to differentiate directories when you intend to
 #/         merge test results from multiple machines).
@@ -32,18 +34,20 @@ main() {
   export PYTHONUNBUFFERED=x
 
   keep_going=0
+  outputdir="$PWD"
   run_once=false
   stop=false
   tag=
   v=-v
   verbose=0
   failure_count=0
-  while getopts ":1dhkt:v" option; do
+  while getopts ":1dhko:t:v" option; do
     case $option in
       1) run_once=true;;
       d) v=-vv;;
       h) usage; exit 0;;
       k) keep_going=$((keep_going + 1));;
+      o) outputdir=$(realpath "$OPTARG");;
       t) tag=-$OPTARG;;
       v) verbose=$((verbose + 1));;
       *) die "Invalid option '-$OPTARG'. Use '-h' for help.";;
@@ -79,13 +83,15 @@ run() {
 
   test="$1" && shift &&
   testpath=$(realpath "$test") &&
+  mkdir -p "$outputdir" &&
+  pushd "$outputdir" >/dev/null &&
   rundir=$(date +%Y-%m-%d_%H.%M.%S)"$tag" &&
   mkdir "$rundir" &&
   rm -f current"$tag" && ln -s "$rundir" current"$tag" &&
   cd "$rundir" &&
   tmpdir="$(mktemp -dt stbt-batch.XXX)" &&
   mkfifo "$tmpdir"/rawout "$tmpdir"/rawerr ||
-  die "Failed to set up test-run directory '$rundir'."
+  die "Failed to set up test-run directory '$outputdir/$rundir'."
 
   [ -n "$tag" ] && echo "Tag	${tag#-}" > extra-columns
 
@@ -146,6 +152,7 @@ run() {
 
   cd ..
   rm -f latest"$tag"; ln -s "$rundir" latest"$tag"
+  popd >/dev/null
   return $exit_status
 }
 

--- a/tests/test-stbt-batch.sh
+++ b/tests/test-stbt-batch.sh
@@ -407,3 +407,15 @@ test_that_stbt_batch_run_exits_with_failure_if_any_test_fails() {
     ! stbt batch run -1 tests/test_failure.py tests/test_success.py \
         || fail "Test should fail"
 }
+
+test_stbt_batch_output_dir() {
+    create_test_repo
+    mkdir "my results"
+    stbt batch run -1 -o "my-results" tests/test.py tests/test2.py \
+        || fail "Tests should succeed"
+
+    [[ -f "my-results"/index.html ]] || fail "'my-results/index.html' not created"
+    ! [[ -f index.html ]] || fail "index.html created in current directory"
+    grep -q test.py "my-results"/*/test-name || fail "First test's results not in 'my-results'"
+    grep -q test2.py "my-results"/*/test-name || fail "Second test's results not in 'my-results'"
+}


### PR DESCRIPTION
This makes it easier to run "stbt batch run" as the target of an ssh
command. For example:

```
ssh server.example.com stbt batch run -o /var/stbt-results/ ...
```

I didn't want to use "-C" a la make/tar/git because one day we might
want to use that to specify the input directory to save typing long test
pathnames. (`stbt batch run -C /long/path/to/tests test1.py test2.py`
instead of: `stbt batch run /long/path/to/tests/test1.py
/long/path/to/tests/test2.py`.)

"stbt batch run" doesn't output a single file so I think it's safe to
use "-o" for the output directory command-line option.

This doesn't support spaces in the output directory name, due to a bug
in "stbt batch report".
