### PR TITLE
test_that_stbt_run_exits_on_ctrl_c: Increase timeout

### DIFF
--- a/tests/test-stbt-run.sh
+++ b/tests/test-stbt-run.sh
@@ -80,7 +80,7 @@ test_that_stbt_run_exits_on_ctrl_c() {
     cat > test.py <<-EOF
 	from time import sleep
 
-	for c in range(20, 0, -1):
+	for c in range(60, 0, -1):
 	    print "%i bottles of beer on the wall" % c
 	    sleep(1)
 


### PR DESCRIPTION
It seems hard to believe that the "stbt run" process is scheduled 20
times before its parent process, but this was failing occasionally on
Travis.

If the test still fails on Travis with this increased timeout, we'll
know for sure that there's something else going wrong.
