### PR TITLE
stbt batch run: Propagate exit status if running a single test

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -20,9 +20,12 @@ For installation instructions see
 
 ##### Breaking changes since 0.20
 
-* `stbt batch run` now exits with non-zero exit status if any of the tests in the
-  run failed or errored.  This, in combination with the `-1` option makes it
-  easier to use from and integrate with external CI systems.
+* `stbt batch run` now exits with non-zero exit status if any of the tests in
+  the run failed or errored.  In addition if only a single test was executed a
+  single time `stbt batch run` will propogate the exit status through.  This, in
+  combination with the `-1` option makes it easier to use from and integrate
+  with external CI systems and makes it possible to use `stbt batch run` just
+  like `stbt run`, but with calling the hooks and producing the HTML report.
 
 ##### User-visible changes since 0.20
 

--- a/stbt-batch.d/run
+++ b/stbt-batch.d/run
@@ -63,15 +63,22 @@ main() {
   [ $verbose -gt 0 ] && exec 3>&1
   [ $verbose -gt 1 ] && exec 4>&1
 
+  run_count=0
   while true; do
     while IFS=$'\t' read -a test; do
-      run "${test[@]}" || failure_count=$((failure_count+1))
+      run_count=$((run_count+1))
+      run "${test[@]}";
+      last_exit_status=$?
+      [ "$last_exit_status" = 0 ] || failure_count=$((failure_count+1))
       should_i_continue || break 2
     done < <(parse_test_args "$@")
     $run_once && break
   done
 
-  if [ "$failure_count" = 0 ]; then
+  if [ "$run_count" = 1 ]; then
+    # If we only run a single test a single time propagate the result through
+    exit "$last_exit_status"
+  elif [ "$failure_count" = 0 ]; then
     exit 0
   else
     exit 1

--- a/tests/test-stbt-batch.sh
+++ b/tests/test-stbt-batch.sh
@@ -408,6 +408,18 @@ test_that_stbt_batch_run_exits_with_failure_if_any_test_fails() {
         || fail "Test should fail"
 }
 
+test_that_stbt_batch_propagates_exit_status_if_running_a_single_test() {
+    create_test_repo
+    stbt batch run -1 tests/test_success.py
+    [ "$?" = 0 ] || fail "Test should succeed"
+
+    stbt batch run -1 tests/test_failure.py
+    [ "$?" = 1 ] || fail "Test should fail"
+
+    stbt batch run -1 tests/test_error.py
+    [ "$?" = 2 ] || fail "Test should error"
+}
+
 test_stbt_batch_output_dir() {
     create_test_repo
     mkdir "my results"


### PR DESCRIPTION
This enables using `stbt batch run` just like `stbt run`, but with calling the hooks and producing the HTML report.
