### PR TITLE
Region API consistency and helper functions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -780,6 +780,8 @@ class Region
         Region.ALL
         >>> print Region.ALL
         Region.ALL
+        >>> print c.translate(x=-9, y=-3)
+        Region(x=1, y=1, width=3, height=2)
 
 class MotionResult
     * `timestamp`: Video stream timestamp.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -61,9 +61,9 @@ For installation instructions see
   `region=None` to `ocr()` is still supported but deprecated and in the future
   we may change its meaning to mean the empty region for consistency.
 
-* `Region` now has convenience methods `extend()` and the function `intersect()`
-  to make it easier to receive a region, modify it and then pass it to another
-  function.
+* `Region` now has convenience methods `extend()` and `translate()` and the
+  function `intersect()` to make it easier to receive a region, modify it and
+  then pass it to another function.
 
 ##### Developer-visible changes since 0.20
 

--- a/stbt.py
+++ b/stbt.py
@@ -304,6 +304,8 @@ class Region(namedtuple('Region', 'x y right bottom')):
         Region.ALL
         >>> print Region.ALL
         Region.ALL
+        >>> print c.translate(x=-9, y=-3)
+        Region(x=1, y=1, width=3, height=2)
     """
     def __new__(cls, x, y, width=None, height=None, right=None, bottom=None):
         assert x is not None and (width is None) != (right is None)
@@ -374,6 +376,11 @@ class Region(namedtuple('Region', 'x y right bottom')):
         return Region.from_extents(
             self.x + x, self.y + y, self.right + right, self.bottom + bottom)
 
+    def translate(self, x=0, y=0):
+        """Returns a new region with the position of the region adjusted by the
+        given amounts."""
+        return Region.from_extents(self.x + x, self.y + y,
+                                   self.right + x, self.bottom + y)
 
 Region.ALL = Region(x=float("-inf"), y=float("-inf"),
                     right=float("inf"), bottom=float("inf"))


### PR DESCRIPTION
This is a series of changes inspired by @lewishaley's [perceptive comment on a previous review](https://github.com/wmanley/stb-tester/commit/604ff6182658de0bbf3d9f2256bfc57b7a508b3c#commitcomment-7133004) about the inconsistency of use of `Region` as a parameter to functions.  These changes are intended to correct these inconsistencies by enhancing `Region` to handle infinities and then using the (not so) special value `Region.all` to represent the whole frame where we want to.
