### PR TITLE
.travis.yml: Lock astroid to version 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
         xdotool
         xserver-xorg-video-dummy
         xterm
- - sudo pip install isort pylint==1.1.0
+ - sudo pip install isort astroid==1.1.0 pylint==1.1.0
  - git clone http://git.chromium.org/webm/webminspector.git ~/webminspector
  - wget http://ftpmirror.gnu.org/parallel/parallel-20140522.tar.bz2 &&
    tar -xvf parallel-20140522.tar.bz2 &&


### PR DESCRIPTION
astroid is a library used by pylint. Since astroid 1.2.0 was released,
our `make check-pylint` on Travis fails with `StopIteration` and the
below stack trace while checking tests/test_ocr.py. See bug #42 in the
astroid bug tracker[1](https://bitbucket.org/logilab/astroid/issue/42/pylint-with-astroid-120-fails-with).

```
File "/usr/local/bin/pylint", line 9, in <module>
  load_entry_point('pylint==1.1.0', 'console_scripts', 'pylint')()
File "/usr/local/lib/python2.7/dist-packages/pylint/__init__.py", line 21, in run_pylint
  Run(sys.argv[1:])
File "/usr/local/lib/python2.7/dist-packages/pylint/lint.py", line 1040, in __init__
  linter.check(args)
File "/usr/local/lib/python2.7/dist-packages/pylint/lint.py", line 626, in check
  self.check_astroid_module(astroid, walker, rawcheckers, tokencheckers)
File "/usr/local/lib/python2.7/dist-packages/pylint/lint.py", line 712, in check_astroid_module
  walker.walk(astroid)
File "/usr/local/lib/python2.7/dist-packages/pylint/utils.py", line 697, in walk
  self.walk(child)
File "/usr/local/lib/python2.7/dist-packages/pylint/utils.py", line 694, in walk
  cb(astroid)
File "/usr/local/lib/python2.7/dist-packages/pylint/checkers/base.py", line 246, in visit_function
  self._check_redefinition(node.is_method() and 'method' or 'function', node)
File "/usr/local/lib/python2.7/dist-packages/astroid/scoped_nodes.py", line 670, in is_method
  return self.type != 'function' and isinstance(self.parent.frame(), Class)
File "/usr/local/lib/python2.7/dist-packages/logilab/common/decorators.py", line 155, in __get__
  val = self.wrapped(inst)
File "/usr/local/lib/python2.7/dist-packages/astroid/scoped_nodes.py", line 536, in _function_type
  _type = _infer_decorator_callchain(node)
File "/usr/local/lib/python2.7/dist-packages/astroid/scoped_nodes.py", line 501, in _infer_decorator_callchain
  result = current.infer_call_result(current.parent).next()
StopIteration
```
