### PR TITLE
stbt batch summary report: Default filter from querystring

### DIFF
--- a/stbt-batch.d/templates/index.html
+++ b/stbt-batch.d/templates/index.html
@@ -129,7 +129,15 @@
     tablequery.set_table("#testruns");
     tablequery.set_table_search_text("#testruns_search_text");
     tablequery.on("search", update_totals);
+    tablequery.on("search", function() {
+      window.history.replaceState({}, "", "?" + $("#testruns_search_text").val())});
     update_totals();
+    var search_string = decodeURIComponent(window.location.search.substring(1));
+    if (search_string) {
+      $("#testruns_search_text").val(search_string);
+      // Hack until https://github.com/asimihsan/tablequeryjs/issues/18 fixed:
+      tablequery._table_search_text_on_keyup({}, search_string);
+    }
 
     function set_details_height() {
       $("#details").css("height", $(window).height() - 40);


### PR DESCRIPTION
Anything in the URL's querystring (the part after "?") when the page is
loaded is put into the "filter" search box. Similarly, when you type
into the filter, the querystring is automatically updated to match.

This makes it easy to share links to a subset of results.

This requires using an internal undocumented function of tablequeryjs.
Since we specify the tablequeryjs version explicitly, I can live with
that. We can revisit once a solution for
https://github.com/asimihsan/tablequeryjs/issues/18 is implemented;
in the meantime this functionality is too useful not to merge.
