### PR TITLE
Refactor: Draw match rectangle using similar mechanism as draw_text

### DIFF
--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -1733,10 +1733,11 @@ class Display(object):
                 if timeout_secs is not None:
                     if not self.start_timestamp:
                         self.start_timestamp = timestamp
-                    if timestamp - self.start_timestamp > timeout_secs * 1e9:
+                    if (timestamp - self.start_timestamp >
+                            timeout_secs * Gst.SECOND):
                         debug("timed out: %d - %d > %d" % (
                             timestamp, self.start_timestamp,
-                            timeout_secs * 1e9))
+                            timeout_secs * Gst.SECOND))
                         return
 
                 sample = _gst_sample_make_writable(sample)
@@ -1795,7 +1796,7 @@ class Display(object):
         for x in list(texts):
             text, duration, end_time = x
             if end_time is None:
-                end_time = now + (duration * 1e9)
+                end_time = now + (duration * Gst.SECOND)
                 texts.remove(x)
                 texts.append((text, duration, end_time))
             elif now > end_time:


### PR DESCRIPTION
This is a refactoring so that in `stbt.match` we don't have to modify
the frame directly to draw the match rectangle; we only have to register
the MatchResult by calling `Display.draw`, and it will get drawn by
`Display.push_sample`.

We can tell which frame (GStreamer buffer) the MatchResult corresponds
to by looking at `MatchResult.timestamp`. MatchResults without a
`timestamp` come from matching against a user-provided screenshot (not
from live video) so we ignore requests to draw those MatchResults
because we don't know which frame to draw them on.

I wanted to do this refactoring to keep things tidier when we introduce
`stbt.match_all` in a future commit.

In future we might want to do further enhancements to the match display,
for example show the rectangle for longer (so that you actually have a
chance to see it while the test is running), possibly fading out over
time. But for now we display the match rectangle during the single frame
corresponding to the match operation (which is the same behaviour as
existed before this commit). I think that's OK: You rarely look at the
video output while a test is running live, and in the `stbt batch`
recorded video you can pause and scrub to see the rectangle. Fading out
the rectangle might be a bit of work because OpenCV doesn't seem to have
built-in support for alpha blending.
