### PR TITLE
Tests: Skip tests that we don't have the appropriate dependencies for

### DIFF
--- a/tests/test-camera.sh
+++ b/tests/test-camera.sh
@@ -2,8 +2,7 @@
 
 skip_if_no_rsvg_plugins() {
     if ! gst-inspect-1.0 rsvg 2>&1 >/dev/null; then
-        echo "SKIP: Skipping test as rsvg plugins not installed"
-        exit 77
+        skip "rsvg plugins not installed"
     fi
 }
 

--- a/tests/test-stbt-batch.sh
+++ b/tests/test-stbt-batch.sh
@@ -1,6 +1,7 @@
 # Run with ./run-tests.sh
 
 create_test_repo() {
+    which git || skip "git is not installed"
     (
         git init tests &&
         cd tests &&

--- a/tests/test-stbt-control.sh
+++ b/tests/test-stbt-control.sh
@@ -5,6 +5,7 @@ test_that_stbt_control_sends_a_single_key() {
 }
 
 validate_stbt_record_control_recorder() {
+    which expect || skip "expect is not installed"
     control_uri=$1
 
     cat > test.expect <<-EOF &&
@@ -50,7 +51,7 @@ test_stbt_control_as_stbt_record_control_recorder__default_keymap() {
     if [[ $ret -ne 0 ]] &&
         cat log | grep -q "Unable to print keymap because the terminal is too small";
     then
-        return 77  # skip
+        skip "terminal is too narrow"
     fi
     return $ret
 }

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -218,11 +218,8 @@ test_that_is_screen_black_threshold_parameter_overrides_default() {
 }
 
 test_that_video_index_is_written_on_eos() {
-    which webminspector.py &>/dev/null || {
-        echo "webminspector.py not found; skipping this test." >&2
-        echo "See https://chromium.googlesource.com/webm/webminspector/" >&2
-        return 77
-    }
+    which webminspector.py &>/dev/null \
+        || skip "webminspector.py not found. See https://chromium.googlesource.com/webm/webminspector/"
 
     _test_that_video_index_is_written_on_eos 5 && return
     echo "Failed with 5s video; trying again with 20s video"

--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -3,6 +3,7 @@ timeout() { "$testdir"/timeout.pl "$@"; }
 timedout=142
 
 fail() { echo "error: $*"; exit 1; }
+skip() { echo "skipping: $*"; exit 77; }
 
 assert() {
     local not ret


### PR DESCRIPTION
The goal is to allow `./run-tests -i` to work against installed versions of stb-tester, without requiring any additional dependencies to be installed beyond stb-tester's existing runtime dependencies.

This should help with automated testing of the packaged versions of stb-tester as implemented in "extra/fedora/test-packaging.sh", although further work is required and this script will not yet succeed.
