### PR TITLE
stbt batch report: Use table-layout:fixed

### DIFF
--- a/stbt-batch.d/templates/index.html
+++ b/stbt-batch.d/templates/index.html
@@ -100,10 +100,10 @@
         <td>
           {{run.exit_status}}
           {% if run.failure_reason not in ("", "success") %}
-            — <span>{{run.failure_reason}}</span>
+            — <span>{{run.failure_reason|e}}</span>
           {% endif %}
         </td>
-        <td>{{run.notes}}</td>
+        <td>{{run.notes|e}}</td>
         <td>{{run.duration}}</td>
         {% for column in extra_columns %}
           <td style="white-space: pre">{{


### PR DESCRIPTION
This fixes a variety of issues with the table display:
- On narrow windows, or with lots of extra-columns, the table used to exceed the width of its parent div. Once you clicked on a row, the right-hand pane would hide the overflowing part of the table so you wouldn't be able to see those columns.
- Table cell contents no longer wrap, so each table row is the same height, and you can fit in more rows per screen.
-  Since we're using CSS for the table-cell truncation we can include the full failure-reason and notes in the html, which means that the client-side search/filtering works on those fields.

Performance-wise I had hoped this would speed up rendering lots of results (10k+) but a while ago I had measured a similar change and it didn't have a noticeable effect.
