### PR TITLE
stbt.draw_text: Fade out older text

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -32,6 +32,10 @@ UNRELEASED.
   executing test.  The tools for replay have not yet been written.  For more
   information, including the format definition see `_stbt/state_watch.py`.
 
+* The text drawn by `stbt.draw_text` and `stbt.press` on the recorded video now
+  fades out over a few seconds. This makes it easier to distinguish the new
+  messages from the old messages.
+
 ##### Bugfixes and packaging fixes since 22
 
 ##### Developer-visible changes since 22

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -1983,10 +1983,12 @@ class Display(object):
         with _numpy_from_sample(sample) as img:
             _draw_text(
                 img, datetime.datetime.now().strftime("%H:%M:%S:%f")[:-4],
-                (10, 30))
+                (10, 30), (255, 255, 255))
             for i, x in enumerate(reversed(texts)):
                 origin = (10, (i + 2) * 30)
-                _draw_text(img, x['text'], origin)
+                age = float(now - x['start_time']) / (3 * Gst.SECOND)
+                color = (int(255 * max([1 - age, 0.5])),) * 3
+                _draw_text(img, x['text'], origin, color)
             for match_result in matches:
                 _draw_match(img, match_result.region, match_result.match)
 
@@ -2084,7 +2086,7 @@ class Display(object):
                 "is still alive!" if self.mainloop_thread.isAlive() else "ok"))
 
 
-def _draw_text(numpy_image, text, origin):
+def _draw_text(numpy_image, text, origin, color):
     (width, height), _ = cv2.getTextSize(
         text, fontFace=cv2.FONT_HERSHEY_DUPLEX, fontScale=1.0, thickness=1)
     cv2.rectangle(
@@ -2093,7 +2095,7 @@ def _draw_text(numpy_image, text, origin):
         thickness=cv2.cv.CV_FILLED, color=(0, 0, 0))
     cv2.putText(
         numpy_image, text, origin, cv2.FONT_HERSHEY_DUPLEX, fontScale=1.0,
-        color=(255, 255, 255))
+        color=color)
 
 
 def _draw_match(numpy_image, region, match_, thickness=3):

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -1977,18 +1977,17 @@ class Display(object):
             if now >= match_result.timestamp:
                 self.match_annotations.remove(match_result)
 
-        now = datetime.datetime.now().strftime("%H:%M:%S:%f")[:-4]
-        texts = texts + [(now, 0, 0)]
-
-        if texts or matches:  # Draw the annotations.
-            sample = _gst_sample_make_writable(sample)
-            with _numpy_from_sample(sample) as img:
-                for i in range(len(texts)):
-                    text, _, _ = texts[len(texts) - i - 1]
-                    origin = (10, (i + 1) * 30)
-                    _draw_text(img, text, origin)
-                for match_result in matches:
-                    _draw_match(img, match_result.region, match_result.match)
+        sample = _gst_sample_make_writable(sample)
+        with _numpy_from_sample(sample) as img:
+            _draw_text(
+                img, datetime.datetime.now().strftime("%H:%M:%S:%f")[:-4],
+                (10, 30))
+            for i in range(len(texts)):
+                text, _, _ = texts[len(texts) - i - 1]
+                origin = (10, (i + 2) * 30)
+                _draw_text(img, text, origin)
+            for match_result in matches:
+                _draw_match(img, match_result.region, match_result.match)
 
         self.appsrc.props.caps = sample.get_caps()
         self.appsrc.emit("push-buffer", sample.get_buffer())

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -1964,13 +1964,13 @@ class Display(object):
         texts = self.text_annotations
         matches = []
         for x in list(texts):
-            text, duration, end_time = x
-            if end_time is None:
-                end_time = now + (duration * Gst.SECOND)
-                texts.remove(x)
-                texts.append((text, duration, end_time))
-            elif now > end_time:
-                texts.remove(x)
+            text, duration, start_time = x
+            if start_time is None:
+                self.text_annotations.remove(x)
+                self.text_annotations.append((text, duration, now))
+
+            if now >= start_time + (duration * Gst.SECOND):
+                self.text_annotations.remove(x)
         for match_result in list(self.match_annotations):
             if match_result.timestamp == now:
                 matches.append(match_result)

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -1951,7 +1951,7 @@ class Display(object):
                 datetime.datetime.now().strftime("%H:%M:%S:%f")[:-4] +
                 ' ' + obj)
             self.text_annotations.append(
-                (obj, duration_secs * Gst.SECOND, None))
+                {"text": obj, "duration": duration_secs * Gst.SECOND})
         elif type(obj) is MatchResult:
             if obj.timestamp is not None:
                 self.match_annotations.append(obj)
@@ -1965,12 +1965,9 @@ class Display(object):
         texts = self.text_annotations
         matches = []
         for x in list(texts):
-            text, duration, start_time = x
-            if start_time is None:
-                self.text_annotations.remove(x)
-                self.text_annotations.append((text, duration, now))
+            x.setdefault('start_time', now)
 
-            if now >= start_time + duration:
+            if now >= x['start_time'] + x['duration']:
                 self.text_annotations.remove(x)
         for match_result in list(self.match_annotations):
             if match_result.timestamp == now:
@@ -1983,10 +1980,9 @@ class Display(object):
             _draw_text(
                 img, datetime.datetime.now().strftime("%H:%M:%S:%f")[:-4],
                 (10, 30))
-            for i in range(len(texts)):
-                text, _, _ = texts[len(texts) - i - 1]
+            for i, x in enumerate(reversed(texts)):
                 origin = (10, (i + 2) * 30)
-                _draw_text(img, text, origin)
+                _draw_text(img, x['text'], origin)
             for match_result in matches:
                 _draw_match(img, match_result.region, match_result.match)
 

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -1950,7 +1950,8 @@ class Display(object):
             obj = (
                 datetime.datetime.now().strftime("%H:%M:%S:%f")[:-4] +
                 ' ' + obj)
-            self.text_annotations.append((obj, duration_secs, None))
+            self.text_annotations.append(
+                (obj, duration_secs * Gst.SECOND, None))
         elif type(obj) is MatchResult:
             if obj.timestamp is not None:
                 self.match_annotations.append(obj)
@@ -1969,7 +1970,7 @@ class Display(object):
                 self.text_annotations.remove(x)
                 self.text_annotations.append((text, duration, now))
 
-            if now >= start_time + (duration * Gst.SECOND):
+            if now >= start_time + duration:
                 self.text_annotations.remove(x)
         for match_result in list(self.match_annotations):
             if match_result.timestamp == now:


### PR DESCRIPTION
`stbt.press` uses `draw_text` to draw the pressed key name on the output
video stream for 3 seconds, and I always found it very confusing when
there were several keypresses in quick succession -- is the latest
keypress at the top or at the bottom? Now it is very clear.

TODO:

* [x] Rebase now that #255 has been merged.
* [x] Fix [TypeError](#issuecomment-58545894).
* [x] Add release note
* [x] Squash