### PR TITLE
Refactor: Use builtin `enumerate(...)` rather than `zip(range, ...)`

### DIFF
--- a/stbt-camera.d/stbt-camera-calibrate.py
+++ b/stbt-camera.d/stbt-camera-calibrate.py
@@ -9,7 +9,6 @@ import sys
 import time
 from collections import namedtuple
 from contextlib import contextmanager
-from itertools import count, izip
 from os.path import dirname
 
 import cv2
@@ -314,7 +313,7 @@ def v4l2_ctls(device, data=None):
 
 def pop_with_progress(iterator, total, width=20, stream=sys.stderr):
     stream.write('\n')
-    for n, v in izip(range(0, total), iterator):
+    for n, v in enumerate(iterator):
         progress = (n * width) // total
         stream.write(
             '[%s] %8d / %d\r' % (
@@ -539,7 +538,7 @@ def setup(source_pipeline):
             sys.stderr.write("No Cameras Detected\n\n")
         else:
             sys.stderr.write("Detected cameras:\n\n")
-        for n, (name, dev_file, source_pipeline) in zip(count(1), cameras):
+        for n, (name, dev_file, source_pipeline) in enumerate(cameras):
             sys.stderr.write(
                 "    %i. %s\n"
                 "\n"

--- a/tests/validate-ocr.py
+++ b/tests/validate-ocr.py
@@ -76,7 +76,7 @@ def main(argv):
     for root, _dirs, dfiles in os.walk(args.corpus):
         files += [root + '/' + f for f in dfiles if f.endswith('.png.txt')]
 
-    for n, f in zip(range(len(files)), files):
+    for n, f in enumerate(files):
         sys.stderr.write("%i / %i Complete\r" % (n, len(files)))
 
         imgname = f[:-len('.txt')]


### PR DESCRIPTION
I had added a few instances of enumerating elements in a list for iteration
with:

```
for n, x in izip(range(len(l), l):
    ...
```

This is a much less clear than using the `enumerate` builtin and requires
importing `izip`.  I had used `izip` and `range` because I didn't know
about `enumerate` at the time.
