### PR TITLE
stbt batch summary chart: Logarithmic y axis (test duration)

### DIFF
--- a/stbt-batch.d/templates/index.html
+++ b/stbt-batch.d/templates/index.html
@@ -291,6 +291,7 @@
 <script src="http://cdn.jsdelivr.net/jqplot/1.0.8/plugins/jqplot.highlighter.min.js"></script>
 <script src="http://cdn.jsdelivr.net/jqplot/1.0.8/plugins/jqplot.canvasTextRenderer.min.js"></script>
 <script src="http://cdn.jsdelivr.net/jqplot/1.0.8/plugins/jqplot.canvasAxisLabelRenderer.min.js"></script>
+<script src="http://cdn.jsdelivr.net/jqplot/1.0.8/plugins/jqplot.logAxisRenderer.min.js"></script>
 <script>
   $(document).ready(function() {
     var plot1;
@@ -355,6 +356,7 @@
           }
         },
         yaxis: {
+          renderer: $.jqplot.LogAxisRenderer,
           labelRenderer: $.jqplot.CanvasAxisLabelRenderer,
           labelOptions: {
             fontFamily: 'sans-serif',


### PR DESCRIPTION
When a freak test ran for 10 (!) hours, every other test ended up flat
against the bottom of the chart, so the chart was next to useless. With
a logarithmic scale, the chart is useful when mixing long- and short-
running tests in the same report.

Before: 
![before](https://cloud.githubusercontent.com/assets/12424/4774768/8b1b7254-5bb0-11e4-8eef-73534bb49614.png)

After:
![after](https://cloud.githubusercontent.com/assets/12424/4774771/91e4e7f0-5bb0-11e4-9328-c446b686855d.png)
