### PR TITLE
Travis: Cope with ftpmirror.gnu.org being down

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,16 +41,21 @@ install:
         xterm
  - sudo pip install isort astroid==1.2.1 pylint==1.3.1
  - git clone http://git.chromium.org/webm/webminspector.git ~/webminspector
- - wget http://ftpmirror.gnu.org/parallel/parallel-20140522.tar.bz2 &&
-   tar -xvf parallel-20140522.tar.bz2 &&
-   cd parallel-20140522/ &&
-   ./configure --prefix=/usr/local &&
-   make &&
-   sudo make install &&
-   cd .. &&
-   rm -Rf parallel-20140522/ &&
-   mkdir $HOME/.parallel &&
-   touch $HOME/.parallel/will-cite  # Silence citation warning
+ - |
+     {
+       wget http://ftpmirror.gnu.org/parallel/parallel-20140522.tar.bz2 ||
+       wget http://ftp.gnu.org/gnu/parallel/parallel-20140522.tar.bz2 ||
+       exit 0;
+     } &&
+     tar -xvf parallel-20140522.tar.bz2 &&
+     cd parallel-20140522/ &&
+     ./configure --prefix=/usr/local &&
+     make &&
+     sudo make install &&
+     cd .. &&
+     rm -Rf parallel-20140522/ &&
+     mkdir $HOME/.parallel &&
+     touch $HOME/.parallel/will-cite  # Silence citation warning
  - make enable_stbt_camera=yes
 
 script:


### PR DESCRIPTION
Sometimes builds fail because ftpmirror.gnu.org is down.  With this change Travis will fall-back to downloading GNU parallel from main GNU FTP site instead if the mirrors fail.  Failing that we don't bother with GNU parallel at all and gracefully degrade to running the tests in series.
