### PR TITLE
debs: Fix build-dependencies

### DIFF
--- a/extra/debian/control
+++ b/extra/debian/control
@@ -36,9 +36,8 @@ Build-Depends: curl,
                tesseract-ocr,
                tesseract-ocr-deu,
                tesseract-ocr-eng,
+               v4l-utils,
                xdotool
-               tesseract-ocr,
-               v4l-utils
 
 Package: stb-tester
 Architecture: any


### PR DESCRIPTION
bd356cb seems to have introduced a typo, presumably due to a rebasing problem in the list of build dependencies in the Debian control file. This commit fixes it.

This patch emphasises the need for automated tests for our Debian/Ubuntu packaging. much like we already have for Fedora.
