### PR TITLE
.travis.yml: Pin isort at 3.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
         xdotool
         xserver-xorg-video-dummy
         xterm
- - sudo pip install isort astroid==1.2.1 pylint==1.3.1
+ - sudo pip install isort==3.9.0 astroid==1.2.1 pylint==1.3.1
  - git clone http://git.chromium.org/webm/webminspector.git ~/webminspector
  - |
      {


### PR DESCRIPTION
isort is a tool that checks that imports are sorted alphabetically and
grouped in a PEP8-compliant way. Somewhere between isort 3.9.0 and 3.9.4
a change was introduced that breaks our `make check`: Uppercase letters
now sort before all lowercase letters.
