### PR TITLE
stbt batch: Fix test scripts messing up test list by reading from stdin

### DIFF
--- a/stbt-batch.d/run
+++ b/stbt-batch.d/run
@@ -67,7 +67,7 @@ main() {
   while true; do
     while IFS=$'\t' read -a test; do
       run_count=$((run_count+1))
-      run "${test[@]}";
+      run "${test[@]}" </dev/null;
       last_exit_status=$?
       [ "$last_exit_status" = 0 ] || failure_count=$((failure_count+1))
       should_i_continue || break 2

--- a/tests/test-stbt-batch.sh
+++ b/tests/test-stbt-batch.sh
@@ -468,3 +468,17 @@ test_stbt_batch_printing_unicode_characters_in_scripts() {
     LANG=en_GB.utf8 unbuffer bash -c 'stbt run tests/test.py 2>/dev/null' &&
     stbt batch run -1 tests/test.py
 }
+
+test_that_tests_reading_from_stdin_dont_mess_up_batch_run_test_list() {
+    cat >test.py <<-EOF
+		import sys
+		in_text = sys.stdin.read()
+		assert in_text == "", "Stdin said \"%s\"" % in_text
+		EOF
+
+    stbt batch run -1 test.py test.py \
+    || fail "Expected test to pass"
+
+    ls -d ????-??-??_??.??.??* > testruns
+    [[ $(cat testruns | wc -l) -eq 2 ]] || fail "Expected 2 test runs"
+}


### PR DESCRIPTION
`stbt batch run` parses its arguments into a list of test cases (with `parse_test_args` which is then piped into a while loop which executes each test in order.  If one of the test cases were to read from stdin the list of tests would be consumed by the test case, not by the test-runner causing all subsequent tests to be skipped.

This commit fixes that bug by redirecting stdin to `/dev/null` for test runs.