### PR TITLE
API: Make `MatchResult.image` match what was passed to `match`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -584,8 +584,7 @@ class MatchResult
     * `first_pass_result`: Value between 0 (poor) and 1.0 (excellent match)
       from the first pass of the two-pass templatematch algorithm.
     * `frame`: The video frame that was searched, in OpenCV format.
-    * `image`: The template image that was searched for, as given to
-      `wait_for_match` or `detect_match`.
+    * `image`: The template image that was searched for, as given to `match`.
     * `position`: `Position` of the match, the same as in `region`. Included
       for backwards compatibility; we recommend using `region` instead.
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -38,6 +38,16 @@ UNRELEASED.
   instead of at the top level of the file. See the change to `stbt run` in the
   next section for more details.
 
+* `MatchResult.image` now returns the template image name as passed to
+  `stbt.match`, rather than the absolute path to the template.  This is the
+  previously documented behaviour and allows constructs like:
+
+        m = stbt.wait_until(
+            lambda: stbt.match("success.png") or stbt.match("error.png"))
+        assert m
+        if m.image == "error.png":
+            recover()
+
 ##### User-visible changes since 0.21
 
 * `stbt run` and `stbt batch run` can now run a specific Python function in the

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -469,8 +469,8 @@ class MatchResult(object):
                 "None" if self.frame is None else "%dx%dx%d" % (
                     self.frame.shape[1], self.frame.shape[0],
                     self.frame.shape[2]),
-                self.image if isinstance(self.image, numpy.ndarray)
-                else "<Custom Image>"))
+                "<Custom Image>" if isinstance(self.image, numpy.ndarray)
+                else repr(self.image)))
 
     @property
     def position(self):

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -430,8 +430,7 @@ class MatchResult(object):
     * `first_pass_result`: Value between 0 (poor) and 1.0 (excellent match)
       from the first pass of the two-pass templatematch algorithm.
     * `frame`: The video frame that was searched, in OpenCV format.
-    * `image`: The template image that was searched for, as given to
-      `wait_for_match` or `detect_match`.
+    * `image`: The template image that was searched for, as given to `match`.
     * `position`: `Position` of the match, the same as in `region`. Included
       for backwards compatibility; we recommend using `region` instead.
     """
@@ -481,7 +480,8 @@ class MatchResult(object):
         return self.match
 
 
-class _AnnotatedTemplate(namedtuple('_AnnotatedTemplate', 'image filename')):
+class _AnnotatedTemplate(namedtuple('_AnnotatedTemplate',
+                                    'image name filename')):
     @property
     def friendly_name(self):
         return self.filename or '<Custom Image>'
@@ -491,7 +491,7 @@ def _load_template(template):
     if isinstance(template, _AnnotatedTemplate):
         return template
     if isinstance(template, numpy.ndarray):
-        return _AnnotatedTemplate(template, None)
+        return _AnnotatedTemplate(template, None, None)
     else:
         template_name = _find_path(template)
         if not os.path.isfile(template_name):
@@ -500,7 +500,7 @@ def _load_template(template):
         if image is None:
             raise UITestError("Failed to load template file: %s" %
                               template_name)
-        return _AnnotatedTemplate(image, template_name)
+        return _AnnotatedTemplate(image, template, template_name)
 
 
 def _crop(frame, region):
@@ -560,7 +560,7 @@ def match(image, frame=None, match_parameters=None, region=Region.ALL):
         result = MatchResult(
             _get_frame_timestamp(frame), matched, match_region,
             first_pass_certainty, numpy.copy(npframe),
-            (template.filename or template.image))
+            (template.name or template.image))
 
     if grabbed_from_live:
         _display.draw(result, None)

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -9,3 +9,12 @@ def black(width=1280, height=720):
 
 def test_that_matchresult_image_matches_template_passed_to_match():
     assert stbt.match("black.png", frame=black()).image == "black.png"
+
+
+def test_that_matchresult_str_image_matches_template_passed_to_match():
+    assert "image=\'black.png\'" in str(stbt.match("black.png", frame=black()))
+
+
+def test_that_matchresult_str_image_matches_template_passed_to_match_custom():
+    assert "image=<Custom Image>" in str(
+        stbt.match(black(30, 30), frame=black()))

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -1,0 +1,11 @@
+import numpy
+
+import stbt
+
+
+def black(width=1280, height=720):
+    return numpy.zeros((height, width, 3), dtype=numpy.uint8)
+
+
+def test_that_matchresult_image_matches_template_passed_to_match():
+    assert stbt.match("black.png", frame=black()).image == "black.png"


### PR DESCRIPTION
`MatchResult.image` now returns the template image name as passed to `stbt.match`, rather than the absolute path to the template.  This is the previously documented behaviour and allows constructs like:

    m = stbt.wait_until(
        lambda: stbt.match("success.png") or stbt.match("error.png"))
    assert m
    if m.image == "error.png":
        recover()

This is technically a breaking change but I don't expect that it will break any user scripts.
