### PR TITLE
stbt-batch: Fix inconsistency in help message

### DIFF
--- a/stbt-batch
+++ b/stbt-batch
@@ -11,7 +11,7 @@
 #/     report      Re-generate the report for previous test runs
 #/     instaweb    Start a web server to view & edit the report
 #/
-#/ For help on a specific subcommand do 'stbt batch <subcommand> --help'.
+#/ For help on a specific subcommand do 'stbt batch <subcommand> -h'.
 
 usage() { grep '^#/' "$0" | cut -c4-; }
 


### PR DESCRIPTION
The help message of `stbt batch` says that "For help on a specific
subcommand do `stbt batch <subcommand> --help`". However, running
`stbt batch run --help` exits with status code 1 saying
"Invalid option '--'. Use '-h' for help."

Advise users to use `stbt batch <subcommand> -h` to avoid this error.