### PR TITLE
stbt run: Print details of failed assert statement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,10 @@ check-nosetests: tests/ocr/menu.png
 	# Workaround for https://github.com/nose-devs/nose/issues/49:
 	cp stbt-control nosetest-issue-49-workaround-stbt-control.py && \
 	PYTHONPATH=$$PWD nosetests --with-doctest -v --match "^test_" \
-	    $(shell git ls-files '*.py' | grep -v tests/test.py) \
+	    $(shell git ls-files '*.py' |\
+	      grep -v -e tests/test.py \
+	              -e tests/test2.py \
+	              -e tests/test_functions.py) \
 	    nosetest-issue-49-workaround-stbt-control.py && \
 	rm nosetest-issue-49-workaround-stbt-control.py
 check-integrationtests: install-for-test

--- a/stbt-completion
+++ b/stbt-completion
@@ -494,6 +494,7 @@ _stbt_test_filename_possibly_with_test_functions() {
                 _stbt_filename_possibly_with_test_functions) <<-EOF ||
 	tests/test_functions.py::test_that_this_test_is_run 
 	tests/test_functions.py::test_that_does_nothing 
+	tests/test_functions.py::test_that_asserts_the_impossible 
 	EOF
     _stbt_fail "unexpected completions for file with 'test_' functions"
     echo _stbt_filename_possibly_with_test_functions: ok
@@ -508,6 +509,7 @@ _stbt_test_filename_possibly_with_test_functions() {
                 _stbt_filename_possibly_with_test_functions) <<-EOF ||
 	test_that_this_test_is_run 
 	test_that_does_nothing 
+	test_that_asserts_the_impossible 
 EOF
     _stbt_fail "unexpected completions for file + ambiguous function prefix"
     echo _stbt_filename_possibly_with_test_functions: ok

--- a/stbt-run
+++ b/stbt-run
@@ -82,7 +82,11 @@ try:
         sys.path.insert(0, os.path.dirname(os.path.abspath(args.script)))
         execfile(args.script)
 except Exception as e:  # pylint: disable=W0703
-    sys.stdout.write("FAIL: %s: %s: %s\n" % (args.script, type(e).__name__, e))
+    error_message = str(e)
+    if not error_message and isinstance(e, AssertionError):
+        error_message = traceback.extract_tb(sys.exc_info()[2])[-1][3]
+    sys.stdout.write("FAIL: %s: %s: %s\n" % (
+        args.script, type(e).__name__, error_message))
     if hasattr(e, "screenshot") and e.screenshot is not None:
         stbt.save_frame(e.screenshot, "screenshot.png")
         sys.stderr.write("Saved screenshot to '%s'.\n" % ("screenshot.png"))

--- a/tests/test-stbt-batch.sh
+++ b/tests/test-stbt-batch.sh
@@ -482,3 +482,9 @@ test_that_tests_reading_from_stdin_dont_mess_up_batch_run_test_list() {
     ls -d ????-??-??_??.??.??* > testruns
     [[ $(cat testruns | wc -l) -eq 2 ]] || fail "Expected 2 test runs"
 }
+
+test_that_stbt_batch_failure_reason_shows_the_failing_assert_statement() {
+    create_test_repo
+    stbt batch run -1 tests/test_functions.py::test_that_asserts_the_impossible
+    assert grep -q "AssertionError: assert 1 + 1 == 3" latest/failure-reason
+}

--- a/tests/test-stbt-run.sh
+++ b/tests/test-stbt-run.sh
@@ -64,6 +64,14 @@ test_that_stbt_run_treats_failing_assertions_as_test_errors() {
     assert grep -q "FAIL: test.py: AssertionError: My assertion" test.log
 }
 
+test_that_stbt_run_prints_assert_statement_if_no_assertion_message_given() {
+    cat > test.py <<-EOF
+	assert 1 + 1 == 3
+	EOF
+    stbt run -v test.py &> test.log
+    assert grep -q "FAIL: test.py: AssertionError: assert 1 + 1 == 3" test.log
+}
+
 test_that_stbt_run_saves_screenshot_on_match_timeout() {
     cat > test.py <<-EOF
 	wait_for_match(

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -4,3 +4,7 @@ def test_that_this_test_is_run():
 
 def test_that_does_nothing():
     pass
+
+
+def test_that_asserts_the_impossible():
+    assert 1 + 1 == 3


### PR DESCRIPTION
`assert` takes an optional error message, and if you don't specify it,
then the `str(AssertionError)` is blank. In the `stbt batch` report,
you just see "AssertionError:" as the failure reason.

With this commit, the failure reason will show the line of code that
raised the `AssertionError`, but only if the `assert` statement was not
given an explicit error message.

This isn't perfect: For multi-line `assert` statements, you'll only see
the last line. But it's still very useful in most cases.