### PR TITLE
test_clock_visualisation: Fix skipping logic broken in 68983e0

### DIFF
--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -397,10 +397,14 @@ test_press_visualisation() {
 }
 
 test_clock_visualisation() {
-    python -c "import stbt, distutils, sys; sys.exit( \
+    PYTHONPATH="$srcdir" python -c "import stbt, distutils, sys; sys.exit( \
         0 if stbt._tesseract_version() >= distutils.version.LooseVersion('3.03')
-        else 1)" \
-    || skip "Requires tesseract >= 3.03 for 'tesseract_user_patterns'"
+        else 77)"
+    case $? in
+        0) true;;
+        77) skip "Requires tesseract >= 3.03 for 'tesseract_user_patterns'";;
+        *) fail "Probing tesseract version failed";;
+    esac
 
     cat > test.py <<-EOF &&
 	import time


### PR DESCRIPTION
In 68983e0 we stopped running integration tests with `PYTHONPATH` set.

test_clock_visualisation requires tesseract 3.03, and at the beginning of the test we check this by running a little Python snippet.  The return code of this snippet was to distinguish between tesseract versions, but it didn't make a distinction between version 3.02 being installed and any other miscellaneous error.  This silently caused this test to be skipped.

This commit fixes this issue.  Thankfully the test still passes.