### PR TITLE
Fix test_that_stbt_batch_reports_results_directory

### DIFF
--- a/tests/test-camera.sh
+++ b/tests/test-camera.sh
@@ -82,12 +82,11 @@ test_that_stbtgeometriccorrection_flattens_pictures_of_TVs() {
 }
 
 test_that_stbt_camera_calibrate_corrects_for_geometric_distortion() {
-    skip_if_no_stbt_plugins
+    skip_if_no_stbt_camera
+    skip_if_no_rsvg_plugins
 
     set_config camera.tv_driver assume
     set_config global.control none
-
-    skip_if_no_rsvg_plugins
 
     start_fake_video_src_launch_1080 \
         uridecodebin "uri=file://$testdir/capture-chessboard.png" \

--- a/tests/test-stbt-batch.sh
+++ b/tests/test-stbt-batch.sh
@@ -436,7 +436,7 @@ test_that_stbt_batch_propagates_exit_status_if_running_a_single_test() {
 test_that_stbt_batch_reports_results_directory() {
     create_test_repo
     export STBT_TRACING_SOCKET=$PWD/stbt_tracing_socket
-    socat UNIX-LISTEN:$STBT_TRACING_SOCKET,fork GOPEN:trace.log &
+    socat -d -d -d -D -t10 UNIX-LISTEN:$STBT_TRACING_SOCKET,fork GOPEN:trace.log &
     SOCAT_PID=$!
 
     while ! [ -e "$PWD/stbt_tracing_socket" ]; do

--- a/tests/test-stbt-batch.sh
+++ b/tests/test-stbt-batch.sh
@@ -443,7 +443,7 @@ test_that_stbt_batch_reports_results_directory() {
       sleep 0.1
     done
 
-    stbt batch run -1 tests/test.py tests/test2.py \
+    stbt batch run -1vv tests/test.py tests/test2.py \
         || fail "Tests should succeed"
 
     [ "$(grep active_results_directory trace.log | wc -l)" = 4 ] \


### PR DESCRIPTION
The [log on Travis-CI](https://travis-ci.org/stb-tester/stb-tester/builds/60657799) says:

```
test_that_stbt_batch_reports_results_directory... FAIL
Showing '/tmp/stb-tester.rpC/log':
tests/test.py ...
[2015-04-30 08:00:07.380596 +0000]  libdc1394 error: Failed to initialize libdc1394
[2015-04-30 08:00:08.034678 +0000]  stbt-run: Arguments:
[2015-04-30 08:00:08.034777 +0000]  control: test
[2015-04-30 08:00:08.034809 +0000]  save_trace: None
[2015-04-30 08:00:08.034839 +0000]  verbose: 1
[2015-04-30 08:00:08.034867 +0000]  args: []
[2015-04-30 08:00:08.034895 +0000]  source_pipeline: videotestsrc is-live=true ! video/x-raw,format=BGR,width=320,height=240
[2015-04-30 08:00:08.034928 +0000]  script: /tmp/stb-tester.rpC/tests/test.py
[2015-04-30 08:00:08.034960 +0000]  restart_source: False
[2015-04-30 08:00:08.034988 +0000]  structured_logging: None
[2015-04-30 08:00:08.035011 +0000]  sink_pipeline: fakesink sync=false
[2015-04-30 08:00:08.035036 +0000]  save_video: video.webm
[2015-04-30 08:00:08.108569 +0000]  stbt-run: Saving video to 'video.webm'
[2015-04-30 08:00:08.180459 +0000]  stbt-run: source pipeline: videotestsrc is-live=true ! video/x-raw,format=BGR,width=320,height=240 ! queue name=_stbt_user_data_queue max-size-buffers=0     max-size-bytes=0 max-size-time=10000000000 ! decodebin ! queue name=_stbt_raw_frames_queue max-size-buffers=2 ! videoconvert ! video/x-raw,format=BGR ! identity ! appsink name=appsink max-buffers=1 drop=false sync=true emit-signals=true caps=video/x-raw,format=BGR
[2015-04-30 08:00:08.180620 +0000]  stbt-run: sink pipeline: appsrc name=appsrc format=time caps=video/x-raw,format=(string)BGR ! tee name=t t. ! queue leaky=downstream ! videoconvert ! vp8enc cpu-used=6 min_quantizer=32 max_quantizer=32 ! webmmux ! filesink location=video.webm t. ! queue leaky=downstream ! videoconvert ! fakesink sync=false
[2015-04-30 08:00:08.238522 +0000]  stbt-run: Pressed gamut
[2015-04-30 08:00:08.862891 +0000]  stbt-run: Searching for /tmp/stb-tester.rpC/tests/videotestsrc-gamut.png
[2015-04-30 08:00:09.039890 +0000]  stbt-run: Match found: MatchResult(timestamp=676263828, match=True, region=Region(x=248, y=0, width=10, height=238), first_pass_result=0.992245181929, frame=320x240x3, image='videotestsrc-gamut.png')
[2015-04-30 08:00:09.040163 +0000]  stbt-run: Matched /tmp/stb-tester.rpC/tests/videotestsrc-gamut.png
[2015-04-30 08:00:09.201950 +0000]  FAIL: /tmp/stb-tester.rpC/tests/test.py: error: [Errno 32] Broken pipe
[2015-04-30 08:00:09.202514 +0000]  Traceback (most recent call last):
[2015-04-30 08:00:09.212128 +0000]    File "/home/travis/build/stb-tester/stb-tester/tests/test-install/libexec/stbt/stbt-batch.d/../stbt-run", line 106, in <module>
[2015-04-30 08:00:09.212243 +0000]      execfile(_filename)
[2015-04-30 08:00:09.212272 +0000]    File "/tmp/stb-tester.rpC/tests/test.py", line 21, in <module>
[2015-04-30 08:00:09.212301 +0000]      time.sleep(float(os.getenv("sleep", 0)))
[2015-04-30 08:00:09.212324 +0000]    File "/tmp/stb-tester.rpC/tests/test.py", line 21, in <module>
[2015-04-30 08:00:09.212346 +0000]      time.sleep(float(os.getenv("sleep", 0)))
[2015-04-30 08:00:09.212369 +0000]    File "/home/travis/build/stb-tester/stb-tester/tests/test-install/libexec/stbt/stbt-batch.d/../stbt-run", line 77, in tracefunc
[2015-04-30 08:00:09.212393 +0000]      _tracer.log_current_line(frame_.f_code.co_filename, frame_.f_lineno)
[2015-04-30 08:00:09.212417 +0000]    File "/home/travis/build/stb-tester/stb-tester/tests/test-install/libexec/stbt/_stbt/state_watch.py", line 119, in log_current_line
[2015-04-30 08:00:09.212439 +0000]      self.set({"test_run.current_line": {"file": file_, "line": line}})
[2015-04-30 08:00:09.212461 +0000]    File "/home/travis/build/stb-tester/stb-tester/tests/test-install/libexec/stbt/_stbt/state_watch.py", line 99, in set
[2015-04-30 08:00:09.212482 +0000]      self._file.write(json.dumps(message, sort_keys=True) + '\r\n')
[2015-04-30 08:00:09.212506 +0000]    File "/home/travis/build/stb-tester/stb-tester/tests/test-install/libexec/stbt/_stbt/state_watch.py", line 139, in write
[2015-04-30 08:00:09.212530 +0000]      self.socket.sendall(data)
[2015-04-30 08:00:09.212553 +0000]    File "/usr/lib/python2.7/socket.py", line 224, in meth
[2015-04-30 08:00:09.212576 +0000]      return getattr(self._sock,name)(*args)
[2015-04-30 08:00:09.212602 +0000]  error: [Errno 32] Broken pipe
[2015-04-30 08:00:09.212624 +0000]  Traceback (most recent call last):
[2015-04-30 08:00:09.212648 +0000]    File "/home/travis/build/stb-tester/stb-tester/tests/test-install/libexec/stbt/stbt-batch.d/../stbt-run", line 124, in <module>
[2015-04-30 08:00:09.212672 +0000]      _tracer.log_test_ended()
[2015-04-30 08:00:09.212696 +0000]    File "/home/travis/build/stb-tester/stb-tester/tests/test-install/libexec/stbt/_stbt/state_watch.py", line 116, in log_test_ended
[2015-04-30 08:00:09.212720 +0000]      self.set({"test_run": {}})
[2015-04-30 08:00:09.212744 +0000]    File "/home/travis/build/stb-tester/stb-tester/tests/test-install/libexec/stbt/_stbt/state_watch.py", line 99, in set
[2015-04-30 08:00:09.212768 +0000]      self._file.write(json.dumps(message, sort_keys=True) + '\r\n')
[2015-04-30 08:00:09.212791 +0000]    File "/home/travis/build/stb-tester/stb-tester/tests/test-install/libexec/stbt/_stbt/state_watch.py", line 139, in write
[2015-04-30 08:00:09.212814 +0000]      self.socket.sendall(data)
[2015-04-30 08:00:09.212838 +0000]    File "/usr/lib/python2.7/socket.py", line 224, in meth
[2015-04-30 08:00:09.212860 +0000]      return getattr(self._sock,name)(*args)
[2015-04-30 08:00:09.212884 +0000]  socket.error: [Errno 32] Broken pipe
[2015-04-30 08:00:09.329708 +0000]  sys.excepthook is missing
[2015-04-30 08:00:09.329912 +0000]  lost sys.stderr
[2015-04-30 08:00:09.330216 +0000]  sys.excepthook is missing
[2015-04-30 08:00:09.330292 +0000]  lost sys.stderr
FAILED
libdc1394 error: Failed to initialize libdc1394
error: Tests should succeed
```