### PR TITLE
stbt: Check that Gst 1.0 is available

### DIFF
--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -42,6 +42,8 @@ from _stbt.config import ConfigurationError, get_config
 from _stbt.gst_hacks import gst_iterate, map_gst_buffer
 from _stbt.logging import debug, ddebug, warn
 
+gi.require_version("Gst", "1.0")
+
 __all__ = [
     "as_precondition",
     "ConfigurationError",


### PR DESCRIPTION
This commit enables stbt initialization to be clearly failed if Gst 1.0 is not available because some environments may have both Gst 0.10 and Gst 1.0.