### PR TITLE
tests/test-ocr: work around Gstreamer bug in `textoverlay` element

### DIFF
--- a/tests/test-ocr.sh
+++ b/tests/test-ocr.sh
@@ -14,6 +14,7 @@ test_ocr_on_live_video() {
     stbt run -v \
         --source-pipeline="videotestsrc pattern=black ! \
                 video/x-raw,format=BGR ! \
-                textoverlay text=Hello\ there font-desc=Sans\ 48" \
+                textoverlay text=Hello\ there font-desc=Sans\ 48 ! \
+                video/x-raw,format=BGR" \
         test.py
 }


### PR DESCRIPTION
Having upgraded from Fedora 20 to Fedora 21, I found that the selftest
`test_ocr_on_live_video` was failing. I tracked the issue down to a
pipeline failure to negotiate, and I think the issue is that the
`textoverlay` element is not passing on the caps correctly. Although this
is unconfirmed, I found that re-setting the caps after the `textoverlay`
element fixes the problem. It also still works on Fedora 20.

The differences in the Gstreamer package which supplies `textoverlay`
I tested were:
gstreamer1-plugins-base-1.2.4-1.fc20.x86_64 (18/04/2014)
gstreamer1-plugins-base-1.4.5-1.fc21.x86_64 (18/12/2014)
This includes 16 patches to the relevant source code, but I'm not savvy
enough to identify the problem or whether the issue has subsequently been
fixed.
