### PR TITLE
stbt batch run: Fix and test `--shuffle` option

### DIFF
--- a/stbt-batch.d/run.py
+++ b/stbt-batch.d/run.py
@@ -105,7 +105,7 @@ def main(argv):
         child = None
         try:
             child = subprocess.Popen(
-                ["%s/run-one" % runner] + test, stdin=DEVNULL_R, env=subenv,
+                ("%s/run-one" % runner,) + test, stdin=DEVNULL_R, env=subenv,
                 preexec_fn=lambda: os.setpgid(0, 0))
             last_exit_status = child.wait()
         except SystemExit:
@@ -164,26 +164,26 @@ def listsplit(l, v):
 def parse_test_args(args):
     """
     >>> parse_test_args(['test 1.py', 'test2.py', 'test3.py'])
-    [['test 1.py'], ['test2.py'], ['test3.py']]
+    [('test 1.py',), ('test2.py',), ('test3.py',)]
     >>> parse_test_args(['test1.py', 'test2.py'])
-    [['test1.py'], ['test2.py']]
+    [('test1.py',), ('test2.py',)]
     >>> parse_test_args(['test1.py', '--'])
-    [['test1.py']]
+    [('test1.py',)]
     >>> parse_test_args(['test1.py', '--', 'test2.py'])
-    [['test1.py'], ['test2.py']]
+    [('test1.py',), ('test2.py',)]
     >>> parse_test_args(['test1.py', '--', 'test2.py', '--'])
-    [['test1.py'], ['test2.py']]
+    [('test1.py',), ('test2.py',)]
     >>> parse_test_args(['test1.py', 'test2.py'])
-    [['test1.py'], ['test2.py']]
+    [('test1.py',), ('test2.py',)]
     >>> parse_test_args(
     ...     ['test1.py', 'arg1', 'arg2', '--', 'test2.py', 'arg', '--',
     ...      'test3.py'])
-    [['test1.py', 'arg1', 'arg2'], ['test2.py', 'arg'], ['test3.py']]
+    [('test1.py', 'arg1', 'arg2'), ('test2.py', 'arg'), ('test3.py',)]
     """
     if '--' in args:
-        return listsplit(args, '--')
+        return [tuple(x) for x in listsplit(args, '--')]
     else:
-        return [[x] for x in args]
+        return [(x,) for x in args]
 
 
 def loop_tests(test_cases, repeat=True):

--- a/tests/test-stbt-batch.sh
+++ b/tests/test-stbt-batch.sh
@@ -468,3 +468,12 @@ test_that_stbt_batch_failure_reason_shows_the_failing_assert_statement() {
     stbt batch run -1 tests/test_functions.py::test_that_asserts_the_impossible
     assert grep -q "AssertionError: assert 1 + 1 == 3" latest/failure-reason
 }
+
+test_that_stbt_batch_run_shuffle_runs_tests() {
+    create_test_repo
+    stbt batch run -1 --shuffle \
+        tests/test_functions.py::test_that_does_nothing \
+        tests/test_functions.py::test_that_this_test_is_run
+    ls -d ????-??-??_??.??.??* > testruns
+    [[ $(cat testruns | wc -l) -eq 2 ]] || fail "Expected 2 test runs"
+}


### PR DESCRIPTION
`stbt batch run --shuffle` was failing with

    TypeError: unhashable type: 'list'

This was not caught by the unit-tests because they don't use realistic test functions/arguments.

Before this commit each test case was a Python list which cannot be used as a key in a dictionary.  Now they are tuples so the dictionary of test-case to time-spent is now valid.