### PR TITLE
stbt lint: Check missing `assert` before `wait_until`

### DIFF
--- a/_stbt/pylint_plugin.py
+++ b/_stbt/pylint_plugin.py
@@ -8,7 +8,7 @@ Intended to be used by "stbt lint".
 
 Documentation on Abstract Syntax Tree traversal with python/pylint:
 
-* http://www.logilab.org/card/pylint_manual#writing-your-own-checker
+* http://docs.pylint.org/extend.html#writing-your-own-checker
 * http://hg.logilab.org/review/pylint/file/default/examples/custom.py
 * http://docs.python.org/2/library/ast.html
 

--- a/_stbt/pylint_plugin.py
+++ b/_stbt/pylint_plugin.py
@@ -57,7 +57,10 @@ class StbtChecker(BaseChecker):
         if re.search(r"\b(is_screen_black|match|match_text|ocr|wait_until)$",
                      node.func.as_string()):
             if type(node.parent) == Discard:
-                self.add_message('E7002', node=node, args=node.func.as_string())
+                for inferred in node.func.infer():
+                    if inferred.root().name in ('stbt', '_stbt.core'):
+                        self.add_message(
+                            'E7002', node=node, args=node.func.as_string())
 
         if re.search(r"\bwait_until", node.func.as_string()):
             if node.args:

--- a/_stbt/pylint_plugin.py
+++ b/_stbt/pylint_plugin.py
@@ -74,6 +74,7 @@ def _in_whitelisted_functions(node):
     return (
         type(node.parent) is CallFunc and
         node.parent.func.as_string() in (
+            "cv2.imwrite",
             "re.match",
             "re.search",
             "stbt.save_frame",

--- a/_stbt/pylint_plugin.py
+++ b/_stbt/pylint_plugin.py
@@ -34,10 +34,9 @@ class StbtChecker(BaseChecker):
                   '(and similar functions) does not exist on disk.'),
         'E7002': ('"%s" return value not used (missing "assert"?)',
                   'stbt-unused-return-value',
-                  "When the return value from stbt's "
-                  "wait_until/match/is_screen_black isn't used in an 'if' "
-                  "statement or assigned to a variable, you've probably "
-                  "forgotten to use 'assert'."),
+                  "This function does not raise an exception on failure but "
+                  "you aren't using its return value. Perhaps you've forgotten "
+                  'to use "assert".'),
         'E7003': ('"wait_until" argument "%s" isn\'t callable',
                   'stbt-wait-until-callable',
                   '"wait_until" takes a callable (such as a function or a '

--- a/_stbt/pylint_plugin.py
+++ b/_stbt/pylint_plugin.py
@@ -31,10 +31,11 @@ class StbtChecker(BaseChecker):
                   'stbt-missing-image',
                   'Used when the image path given to `stbt.wait_for_match` '
                   '(and similar functions) does not exist on disk.'),
-        'E7002': ('"wait_until" return value not used (missing "assert"?)',
-                  'stbt-bare-wait-until',
-                  "When the return value from 'wait_until' isn't used in an "
-                  "'if' statement or assigned to a variable, you've probably "
+        'E7002': ('"%s" return value not used (missing "assert"?)',
+                  'stbt-unused-return-value',
+                  "When the return value from stbt's "
+                  "wait_until/match/is_screen_black isn't used in an 'if' "
+                  "statement or assigned to a variable, you've probably "
                   "forgotten to use 'assert'."),
     }
 
@@ -49,9 +50,10 @@ class StbtChecker(BaseChecker):
             self.add_message('E7001', node=node, args=node.value)
 
     def visit_callfunc(self, node):
-        if re.search(r"\bwait_until$", node.func.as_string()):
+        if re.search(r"\b(is_screen_black|match|match_text|ocr|wait_until)$",
+                     node.func.as_string()):
             if type(node.parent) == Discard:
-                self.add_message('E7002', node=node)
+                self.add_message('E7002', node=node, args=node.func.as_string())
 
 
 def _is_calculated_value(node):

--- a/_stbt/pylint_plugin.py
+++ b/_stbt/pylint_plugin.py
@@ -66,7 +66,8 @@ class StbtChecker(BaseChecker):
                 for inferred in arg.infer():
                     # Note that when `infer()` fails it returns `YES` which
                     # returns True to everything (including `callable()`).
-                    if inferred.callable():
+                    if inferred.callable() and not (
+                            type(arg) is CallFunc and inferred == YES):
                         break
                 else:
                     self.add_message('E7003', node=node, args=arg.as_string())

--- a/_stbt/pylint_plugin.py
+++ b/_stbt/pylint_plugin.py
@@ -17,18 +17,9 @@ Documentation on Abstract Syntax Tree traversal with python/pylint:
 import os
 import re
 
+from astroid.node_classes import BinOp, CallFunc, Discard, Getattr
 from pylint.checkers import BaseChecker
-
-# Install `pylint` to get `logilab.astng` or `astroid` modules.
-
-# pylint: disable=E0611,F0401
-try:  # >= pylint 1.0
-    from pylint.interfaces import IAstroidChecker
-    from astroid.node_classes import BinOp, CallFunc, Discard, Getattr
-except ImportError:  # < pylint 1.0
-    from pylint.interfaces import IASTNGChecker as IAstroidChecker
-    from logilab.astng.node_classes import BinOp, CallFunc, Discard, Getattr
-# pylint: enable=E0611,F0401
+from pylint.interfaces import IAstroidChecker
 
 
 class StbtChecker(BaseChecker):
@@ -37,6 +28,7 @@ class StbtChecker(BaseChecker):
     msgs = {
         # Range 70xx reserved for custom checkers: www.logilab.org/ticket/68057
         'E7001': ('Image "%s" not found on disk',
+                  'stbt-missing-image',
                   'Used when the image path given to `stbt.wait_for_match` '
                   '(and similar functions) does not exist on disk.'),
         'E7002': ('"wait_until" return value not used (missing "assert"?)',

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,31 @@ necessary.
 For installation instructions see [Getting Started](
 https://github.com/stb-tester/stb-tester/wiki/Getting-started-with-stb-tester).
 
+#### 24
+
+UNRELEASED
+
+##### Breaking changes since 23
+
+* `stbt lint` no longer works with pylint < 1.0. If your distro provides an
+  older pylint, we recommend installing a newer pylint from PyPI.
+
+##### User-visible changes since 23
+
+* `stbt lint` will complain if you don't use the return value from
+  `is_screen_black`, `match`, `match_text`, `ocr`, or `wait_until`. When the
+  return value from `wait_until` isn't used in an `if` statement or assigned to
+  a variable, you've probably forgotten to use `assert`.
+
+* `stbt lint` will complain if its argument isn't callable (such as a function
+  or a lambda expression). This will catch mistakes like
+  `wait_until(is_screen_black())` when you meant to say
+  `wait_until(is_screen_black)`.
+
+##### Bugfixes and packaging fixes since 23
+
+##### Developer-visible changes since 23
+
 #### 23
 
 New `stbt batch run --shuffle` option to run test cases in a random order.

--- a/tests/test-stbt-lint.sh
+++ b/tests/test-stbt-lint.sh
@@ -77,3 +77,29 @@ test_that_stbt_lint_checks_uses_of_stbt_return_values() {
 	EOF
     diff -u lint.expected lint.log
 }
+
+test_that_stbt_lint_checks_that_wait_until_argument_is_callable() {
+    cat > test.py <<-EOF &&
+	from stbt import is_screen_black, press, wait_until
+	
+	def return_a_function():
+	    return lambda: True
+	
+	def test_something():
+	    press('KEY_POWER')
+	    assert wait_until(is_screen_black)
+	    assert wait_until(is_screen_black())
+	    assert wait_until(return_a_function())
+	    assert wait_until(return_a_function()())
+	    assert wait_until(lambda: True)
+	    assert wait_until((lambda: True)())
+	EOF
+    stbt lint --errors-only test.py > lint.log
+
+    cat > lint.expected <<-'EOF'
+	************* Module test
+	E: 11,11: "wait_until" argument "return_a_function()()" isn't callable (stbt-wait-until-callable)
+	E: 13,11: "wait_until" argument "lambda : True()" isn't callable (stbt-wait-until-callable)
+	EOF
+    diff -u lint.expected lint.log
+}

--- a/tests/test-stbt-lint.sh
+++ b/tests/test-stbt-lint.sh
@@ -98,6 +98,7 @@ test_that_stbt_lint_checks_that_wait_until_argument_is_callable() {
 
     cat > lint.expected <<-'EOF'
 	************* Module test
+	E:  9,11: "wait_until" argument "is_screen_black()" isn't callable (stbt-wait-until-callable)
 	E: 11,11: "wait_until" argument "return_a_function()()" isn't callable (stbt-wait-until-callable)
 	E: 13,11: "wait_until" argument "lambda : True()" isn't callable (stbt-wait-until-callable)
 	EOF

--- a/tests/test-stbt-lint.sh
+++ b/tests/test-stbt-lint.sh
@@ -53,8 +53,8 @@ test_pylint_plugin_on_itself() {
 
 test_that_stbt_lint_checks_uses_of_stbt_return_values() {
     cat > test.py <<-EOF &&
-	import stbt
-	from stbt import match, press, wait_until
+	import re, stbt
+	from stbt import is_screen_black, match, match_text, ocr, press, wait_until
 	
 	def test_something():
 	    assert wait_until(lambda: True)
@@ -65,7 +65,11 @@ test_that_stbt_lint_checks_uses_of_stbt_return_values() {
 	    something_else_that_ends_in_wait_until()  # pylint:disable=E0602
 	    assert match('$testdir/videotestsrc-redblue.png')
 	    match('$testdir/videotestsrc-redblue.png')
+	    re.match('foo', 'bah')
 	    press('KEY_OK')
+	    is_screen_black()
+	    match_text('hello')
+	    ocr()
 	EOF
     stbt lint --errors-only test.py > lint.log
 
@@ -74,6 +78,9 @@ test_that_stbt_lint_checks_uses_of_stbt_return_values() {
 	E:  8, 4: "wait_until" return value not used (missing "assert"?) (stbt-unused-return-value)
 	E:  9, 4: "stbt.wait_until" return value not used (missing "assert"?) (stbt-unused-return-value)
 	E: 12, 4: "match" return value not used (missing "assert"?) (stbt-unused-return-value)
+	E: 15, 4: "is_screen_black" return value not used (missing "assert"?) (stbt-unused-return-value)
+	E: 16, 4: "match_text" return value not used (missing "assert"?) (stbt-unused-return-value)
+	E: 17, 4: "ocr" return value not used (missing "assert"?) (stbt-unused-return-value)
 	EOF
     diff -u lint.expected lint.log
 }

--- a/tests/test-stbt-lint.sh
+++ b/tests/test-stbt-lint.sh
@@ -38,8 +38,9 @@ test_that_stbt_lint_ignores_regular_expressions() {
 
 test_that_stbt_lint_ignores_images_created_by_the_stbt_script() {
     cat > test.py <<-EOF &&
-	import stbt
+	import cv2, stbt
 	stbt.save_frame(stbt.get_frame(), 'i-dont-exist-yet.png')
+	cv2.imwrite('neither-do-i.png', stbt.get_frame())
 	EOF
     stbt lint --errors-only test.py
 }


### PR DESCRIPTION
...plus some minor fixes.

Forgetting the `assert` before `wait_until` has bitten me several times already in testcases I've written.

Note that this breaks compatibility with pylint < 1.0 (see the first commit for details). I think it's worth it. On Travis we've been installing a newer pylint from PyPI since d4a450c.

TODO:

- [x] Also check `is_screen_black`, `match`, `match_text`, and `ocr`.
- [x] Also check that the argument to `wait_for_match` is a callable.