### PR TITLE
ocr: Fix compatibility with tesseract 3.04

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -841,6 +841,8 @@ class DeviceUnderTest(object):
 
         _config = dict(tesseract_config or {})
         _config['tessedit_create_hocr'] = 1
+        if _tesseract_version() >= LooseVersion('3.04'):
+            _config['tessedit_create_txt'] = 0
 
         ts = _get_frame_timestamp(frame)
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -40,6 +40,9 @@ UNRELEASED
   `wait_until(is_screen_black())` when you meant to say
   `wait_until(is_screen_black)`.
 
+* Updated `stbt.ocr` and `stbt.match_text` to work with tesseract 3.04 (which
+  seems to have been released sometime around 10 July 2015).
+
 ##### Bugfixes and packaging fixes since 23
 
 ##### Developer-visible changes since 23

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -54,8 +54,17 @@ def test_that_setting_config_options_has_an_effect():
     # effect at all.  This at least excercises our code which sets config
     # options.  I'm not happy about this and I hope to be able to replace this
     # once we have more experience with these settings in the real world.
+    from _stbt.core import _tesseract_version
+    if _tesseract_version() >= distutils.version.LooseVersion('3.04'):
+        hocr_mode_config = {
+            "tessedit_create_txt": 0,
+            "tessedit_create_hocr": 1}
+    else:
+        hocr_mode_config = {
+            "tessedit_create_hocr": 1}
+
     assert (stbt.ocr(frame=cv2.imread('tests/ocr/ambig.png'),
-                     tesseract_config={"tessedit_create_hocr": 1}) !=
+                     tesseract_config=hocr_mode_config) !=
             stbt.ocr(frame=cv2.imread('tests/ocr/ambig.png')))
 
 


### PR DESCRIPTION
My debian testing machine now has tesseract 3.04 and these changes were required to get `match_text` working again.

**TODO:**

- [x] Write a release note.