### PR TITLE
stbt batch run: Avoid directory name clashes

### DIFF
--- a/stbt-batch.d/run-one
+++ b/stbt-batch.d/run-one
@@ -39,7 +39,10 @@ main() {
   mkdir -p "$outputdir" &&
   pushd "$outputdir" >/dev/null &&
   rundir=$(date +%Y-%m-%d_%H.%M.%S)"$tag" &&
-  mkdir "$rundir" &&
+  { mkdir "$rundir" ||
+    # Avoid directory name clashes if the previous test took <1s to run
+    { sleep 1 && mkdir "$rundir"; }
+  } &&
   send_state_change active_results_directory "\"$outputdir/$rundir\"" &&
   rm -f current"$tag" && ln -s "$rundir" current"$tag" &&
   cd "$rundir" &&


### PR DESCRIPTION
...if the previous test took <1s to run.

You're unlikely to ever see this issue in real usage, but it shows up
from time to time in stb-tester's selftests.