### PR TITLE
New API stbt.Region.replace

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -203,6 +203,8 @@ class Region(namedtuple('Region', 'x y right bottom')):
     True
     >>> a.width, a.extend(x=3).width, a.extend(right=-3).width
     (8, 5, 5)
+    >>> print c.replace(bottom=10)
+    Region(x=10, y=4, width=3, height=6)
     >>> print Region.intersect(a, b)
     Region(x=4, y=4, width=4, height=4)
     >>> Region.intersect(a, b) == Region.intersect(b, a)
@@ -331,6 +333,20 @@ class Region(namedtuple('Region', 'x y right bottom')):
         """
         return Region.from_extents(
             self.x + x, self.y + y, self.right + right, self.bottom + bottom)
+
+    def replace(self, x=None, y=None, right=None, bottom=None):
+        """
+        :returns: A new region with the edges of the region set to the given
+            coordinates.
+
+        This is similar to `extend`, but it takes absolute coordinates within
+        the image instead of adjusting by a relative number of pixels.
+        """
+        kwargs = dict(
+            (k, v) for k, v in [
+                ("x", x), ("y", y), ("right", right), ("bottom", bottom)]
+            if v is not None)
+        return self._replace(**kwargs)
 
     def translate(self, x=0, y=0):
         """

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -25,6 +25,11 @@ UNRELEASED
 
 ##### User-visible changes since 23
 
+* Added new API `stbt.Region.replace` to set any of the edges of a region to
+  the given coordinates. It is similar to `Region.extend`, but it takes
+  absolute coordinates within the image instead of adjusting the edge by a
+  relative number of pixels.
+
 * `stbt lint` will complain if you don't use the return value from
   `is_screen_black`, `match`, `match_text`, `ocr`, or `wait_until`. When the
   return value from `wait_until` isn't used in an `if` statement or assigned to


### PR DESCRIPTION
This is similar to `Region.extend`, but it takes absolute coordinates
within the image instead of adjusting by a relative number of pixels.

It just delegates to the private `namedtuple._replace` method (`Region`
is a subclass of `namedtuple`). We have found it quite useful in some
of the test cases we write, and this saves us from having to use a
private method.

TODO:

- [x] Release notes.