### PR TITLE
stbt-run: Save last used frame on failure as screenshot.png

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -927,7 +927,8 @@ def save_frame(image, filename):
     Takes an image obtained from `get_frame` or from the `screenshot`
     property of `MatchTimeout` or `MotionTimeout`.
     """
-    cv2.imwrite(filename, image)
+    with _numpy_from_sample(image, readonly=True) as imagebuf:
+        cv2.imwrite(filename, imagebuf)
 
 
 def wait_until(callable_, timeout_secs=10, interval_secs=0):
@@ -1289,6 +1290,7 @@ class Display(object):
         self.novideo = False
         self.lock = threading.RLock()  # Held by whoever is consuming frames
         self.last_sample = Queue.Queue(maxsize=1)
+        self.last_used_sample = None
         self.source_pipeline = None
         self.start_timestamp = None
         self.underrun_timeout = None
@@ -1409,6 +1411,9 @@ class Display(object):
             raise NoVideo("No video")
         if isinstance(gst_sample, Exception):
             raise UITestError(str(gst_sample))
+
+        if isinstance(gst_sample, Gst.Sample):
+            self.last_used_sample = gst_sample
 
         return gst_sample
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -30,6 +30,14 @@ UNRELEASED
   absolute coordinates within the image instead of adjusting the edge by a
   relative number of pixels.
 
+* `stbt run` will now save a screenshot at the end of all failing test runs,
+  rather than just those which failed due to an exception with a screenshot
+  attached.
+
+* The screenshot that `stbt batch run` saves is now more likely to be relevant
+  to the issue seen.  We now save the last frame that the test-script saw
+  rather than just saving a screenshot after the end of the test-run.
+
 * `stbt lint` will complain if you don't use the return value from
   `is_screen_black`, `match`, `match_text`, `ocr`, or `wait_until`. When the
   return value from `wait_until` isn't used in an `if` statement or assigned to

--- a/stbt-run
+++ b/stbt-run
@@ -112,7 +112,14 @@ except Exception as e:  # pylint: disable=W0703
     sys.stdout.write("FAIL: %s: %s: %s\n" % (
         args.script, type(e).__name__, error_message))
     if hasattr(e, "screenshot") and e.screenshot is not None:
-        stbt.save_frame(e.screenshot, "screenshot.png")
+        screenshot = e.screenshot
+    elif stbt._dut._display:  # pylint: disable=W0212
+        screenshot = stbt._dut._display.last_used_sample  # pylint: disable=W0212
+    else:
+        screenshot = None
+
+    if screenshot is not None:
+        stbt.save_frame(screenshot, "screenshot.png")
         sys.stderr.write("Saved screenshot to '%s'.\n" % ("screenshot.png"))
     traceback.print_exc(file=sys.stderr)
     if isinstance(e, (stbt.UITestFailure, AssertionError)):

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -428,10 +428,11 @@ def init_run(
         gst_source_pipeline, gst_sink_pipeline, control_uri, save_video=False,
         restart_source=False, transformation_pipeline='identity'):
     global _dut
-    _dut = _stbt.core.new_device_under_test_from_config(
+    dut = _stbt.core.new_device_under_test_from_config(
         gst_source_pipeline, gst_sink_pipeline, control_uri, save_video,
         restart_source, transformation_pipeline)
-    _dut.__enter__()
+    dut.__enter__()
+    _dut = dut
 
 
 def teardown_run():

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -12,7 +12,8 @@ test_invalid_source_pipeline() {
     stbt run -v --source-pipeline viddily-boo test.py &> stbt.log
     tail -n1 stbt.log | grep -q 'no element "viddily-boo"' ||
         fail "The last error message in '$scratchdir/stbt.log' wasn't the" \
-            "expected 'no element \"viddily-boo\"'"
+            "expected 'no element \"viddily-boo\"', " \
+            "it was '$(tail -n1 stbt.log)'"
 }
 
 test_get_frame_and_save_frame() {


### PR DESCRIPTION
stbt-run knows that a test has failed/errored if the test script raises an exception.  When `wait_for_match`, `wait_for_motion`, etc. fail they attach the frame that caused the failure to the exception that they raise.  stbt-run is expecting this so can save the exception for later inspection and debugging.

However: if users are using the more modern style of:

    assert wait_until(lambda: match(...))

then the exception is raised by the assert, which has no knowledge of the frame that caused the assert.  In this case `stbt batch run` will grab a screenshot of whatever happens to be on screen when the test finishes.  This screenshot often doesn't exhibit the issue that caused the test to fail/error in the first place.

This commit makes the assumption that the last frame that the test script actually used is the one that exhibited the issue and saves that instead.

**TODO:**

- [x] Tests
- [x] Release notes