### PR TITLE
Add stbt-docker: Used when video-capture hardware isn't required

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ INSTALL_CORE_FILES = \
     stbt-batch.d/templates/testrun.html \
     stbt-config \
     stbt-control \
+    stbt-docker \
     stbt-lint \
     stbt-match \
     stbt-power \

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -45,6 +45,13 @@ UNRELEASED
       real hardware.  This approach can be particularly useful to reduce the
       cost of test maintainance.
 
+* New command `stbt docker`.  This is intended to make it easier to run stbt
+  when physical hardware is not required.  This makes it easier to run
+  selftests on your test-packs in CI using Jenkins and to make it easier to use
+  `stbt auto-selftest` and other development tools on Microsoft Windows and
+  Mac OS X.  It is intended to be copied into the test-packs themselves and only
+  depends on a working Python and docker installation.
+
 * The `stbt templatematch` command-line tool has been renamed to `stbt match`
   (for consistency with the Python API terminology). The old name remains as an
   alias, for backwards compatibility.

--- a/stbt-docker
+++ b/stbt-docker
@@ -98,10 +98,25 @@ def container_to_host_path(path):
     path = os.path.abspath(path)
     container = which_docker_container_am_i_running_in()
     if not container:
-        # Running on host (but not necessicarily the same host as the docker
-        # daemon)
+        # We're running on Linux, but not inside a docker container.  We assume
+        # that paths that we see are the same as paths that the docker daemon
+        # sees.  This will break if:
+        #
+        # * The docker daemon is not running on the same machine as us and the
+        #   remote machine doesn't have our files mounted in exactly the same
+        #   locations.
+        # * The docker container to be created is running in a sufficiently
+        #   different mount namespace to us.
         return path
     else:
+        # We're running in a docker container.  We assume that we're being
+        # supervised by the same docker daemon as the deamon we'll talk to.
+        # This will break if:
+        #
+        # * We're not being supervised by the same docker daemon as we'll be
+        #   asking to do the running.  This could be because there are multiple
+        #   docker daemons running on this machine or we're talking to a remote
+        #   docker daemon on a cluster somewhere.
         this_container = json.loads(subprocess.check_output(
             DOCKER + ['inspect', container]))[0]
         best_match = None
@@ -191,6 +206,23 @@ def build_docker_image(test_pack, stbt_version):
     return docker_image
 
 
+def self_uid_gid():
+    """
+    This returns the UID and GID of the user who invoked this program from the
+    perspective of inside the docker container.
+    """
+    if sys.platform.startswith("linux"):
+        # We assume that the docker daemon has the same understanding of UIDs
+        # and GIDs as us.  This breaks if:
+        #
+        # * The docker daemon is not running on the same machine as us
+        # * The docker container to be created is running in a different user
+        #   namespace to us.
+        # * We are or the docker container will be under some sort of filesystem
+        #   UID/GID mapping
+        return (os.getuid(), os.getgid())
+    else:
+        raise Exception("Don't have support for Windows or MacOS X")
 def main(argv):
     parser = argparse.ArgumentParser(
         epilog=__doc__,
@@ -250,6 +282,8 @@ def main(argv):
     # actions can't mess up another's:
     cache_volume = ("stbt-cache-" +
                     re.sub('[^a-zA-Z0-9_.-]', '_', getpass.getuser()))
+
+    inner_uid, inner_gid = self_uid_gid()
 
     # We use /bin/dash here because many programs (including make) get confused
     # if they are running as pid 1.

--- a/stbt-docker
+++ b/stbt-docker
@@ -58,6 +58,7 @@ import sys
 import tarfile
 import tempfile
 from cStringIO import StringIO
+from textwrap import dedent
 
 DOCKER = os.environ.get("DOCKER", "docker")
 
@@ -180,13 +181,20 @@ def main(argv):
     # if they are running as pid 1.
     os.execvp(
         DOCKER,
-        [DOCKER, 'run', '-i', '--rm',
+        [DOCKER, 'run', '-i', '--rm', '-u', '0:0',
          '-v', '%s:/var/lib/stbt/.cache' % os.path.join(root, '.stbt/cache'),
          '-v', '%s:/var/lib/stbt/test-pack' % root,
          '-e', 'STBT_CONFIG_FILE=/var/lib/stbt/test-pack/.stbt.conf'] + tty_arg
         + shlex.split(os.environ.get('DOCKER_OPTS', '')) +
-        [docker_image, '/bin/dash', '-c',
-         'cd {cwd} && "$0" "$@"'.format(cwd=pipes.quote(innerdir))] + cmd)
+        [docker_image, '/bin/dash', '-c', dedent("""\
+         find /var/lib/stbt -xdev -path /var/lib/stbt/test-pack -prune \\
+              -o -print0 | xargs -0 chown -f {uid}:{gid} &&
+         sed -i s/stb-tester:x:1000:1000/stb-tester:x:{uid}:{gid}/ /etc/passwd &&
+         sed -i s/stb-tester:x:1000/stb-tester:x:{gid}/ /etc/group &&
+         cd {cwd} &&
+         sudo -u stb-tester -E -- "$0" "$@" """).format(
+            uid=os.getuid(), gid=os.getgid(), cwd=pipes.quote(innerdir))]
+        + cmd)
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv))

--- a/stbt-docker
+++ b/stbt-docker
@@ -94,6 +94,16 @@ def which_docker_container_am_i_running_in():
                 return m.group(1)
 
 
+def native_to_unix_path(path):
+    if os.name == "nt":
+        drive, path = os.path.splitdrive(path)
+        if drive:
+            path = "/" + drive[0].lower() + path
+        return path.replace("\\", "/")
+    else:
+        return path
+
+
 def container_to_host_path(path):
     path = os.path.abspath(path)
     if not sys.platform.startswith('linux'):
@@ -112,7 +122,7 @@ def container_to_host_path(path):
         # * We're trying to mount a volume that is not mounted through to the
         #   VM.  I think this means that it must be under '/Users' on Mac OS or
         #   c:\Users on Windows.
-        return path
+        return native_to_unix_path(path)
 
     container = which_docker_container_am_i_running_in()
     if not container:
@@ -224,6 +234,35 @@ def build_docker_image(test_pack, stbt_version):
     return docker_image
 
 
+def read_stbt_conf(root):
+    """
+    git for Windows converts symlinks into normal files, but we still need to
+    traverse them for the purposes of loading .stbt.conf.
+    """
+    root = os.path.abspath(root)
+    cp = ConfigParser.ConfigParser()
+    filename = os.path.join(root, '.stbt.conf')
+    for _ in range(10):
+        try:
+            cp.read(filename)
+            return os.path.relpath(filename, root), cp
+        except ConfigParser.MissingSectionHeaderError:
+            if os.name == "posix":
+                # POSIX systems can support symlinks so something else must have
+                # gone wrong.
+                raise
+            with open(filename) as f:
+                link = f.read()
+            filename = os.path.normpath(os.path.join(
+                os.path.dirname(filename), link))
+            if not filename.startswith(root):
+                raise Exception("Traversing .stbt.conf symlinks failed: "
+                                "symlink points outside of test-pack")
+
+    raise Exception(
+        "Traversing .stbt.conf symlinks failed: Symlink depth too great")
+
+
 def self_uid_gid():
     """
     This returns the UID and GID of the user who invoked this program from the
@@ -273,9 +312,8 @@ def main(argv):
             """))
         return 1
 
-    cp = ConfigParser.ConfigParser()
-    cp.read(os.path.join(root, '.stbt.conf'))
-    stbt_version = cp.get('test_pack', 'stbt_version')
+    config_filename, config = read_stbt_conf(root)
+    stbt_version = config.get('test_pack', 'stbt_version')
     if stbt_version not in STBT_VERSION_WHITELIST:
         sys.stderr.write(dedent("""\
             error: This version of stbt-docker does not support stbt_version {v}.
@@ -316,8 +354,8 @@ def main(argv):
 
     # We use /bin/dash here because many programs (including make) get confused
     # if they are running as pid 1.
-    os.execvp(
-        DOCKER[0], DOCKER +
+    cmdline = (
+        DOCKER +
         ['run', '-i', '--rm', '-u', '0:0',
          '-v', '%s:/var/lib/stbt/.cache' % cache_volume,
          '-v', '%s:/var/lib/stbt/test-pack' % container_to_host_path(root)]
@@ -331,8 +369,14 @@ def main(argv):
          sudo -u stb-tester -E -- \\
              env STBT_CONFIG_FILE={config_filename} \\
              "$0" "$@" """).format(
-            uid=os.getuid(), gid=os.getgid(), cwd=pipes.quote(innerdir))]
+            uid=inner_uid, gid=inner_gid, cwd=pipes.quote(innerdir),
+            config_filename=pipes.quote(config_filename))]
         + cmd)
+
+    if os.name == "posix":
+        os.execvp(cmdline[0], cmdline)
+    else:
+        return subprocess.call(cmdline)
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv))

--- a/stbt-docker
+++ b/stbt-docker
@@ -96,6 +96,24 @@ def which_docker_container_am_i_running_in():
 
 def container_to_host_path(path):
     path = os.path.abspath(path)
+    if not sys.platform.startswith('linux'):
+        # We assume that the files we can see are mounted on the (linux) system
+        # that is running the target docker daemon, and mounted into the same
+        # location.  This is how docker-toolbox sets itself up with docker
+        # daemon running on boot2docker linux in a VirtualBox VM on the MacOS/
+        # Windows host.  docker-toolbox will mount filesystems from the VM host
+        # via vboxfs.  This will break if:
+        #
+        # * This is not docker-toolbox after-all, or at least is not set up
+        #   in a compatible way with it.  Perhaps we're talking to a remote
+        #   docker on some cluster somewhere.
+        # * Docker changes the way they do the mounts in some later version of
+        #   docker-toolbox
+        # * We're trying to mount a volume that is not mounted through to the
+        #   VM.  I think this means that it must be under '/Users' on Mac OS or
+        #   c:\Users on Windows.
+        return path
+
     container = which_docker_container_am_i_running_in()
     if not container:
         # We're running on Linux, but not inside a docker container.  We assume
@@ -222,7 +240,18 @@ def self_uid_gid():
         #   UID/GID mapping
         return (os.getuid(), os.getgid())
     else:
-        raise Exception("Don't have support for Windows or MacOS X")
+        # We assume docker was installed with docker-toolbox.  This means there
+        # is a VirtualBox VM running boot2docker linux with the docker daemon on
+        # top.  This mounts filesystems from the VM host via vboxfs with
+        # UID=1000 and GID=50.  This breaks if:
+        #
+        # * This is not docker-toolbox after-all.  Perhaps we're talking to a
+        #   remote docker on some cluster somewhere.
+        # * Docker change the way they do the mounts in some later version of
+        #   docker-toolbox
+        return 1000, 50
+
+
 def main(argv):
     parser = argparse.ArgumentParser(
         epilog=__doc__,

--- a/stbt-docker
+++ b/stbt-docker
@@ -67,6 +67,7 @@ See also:
 import argparse
 import ConfigParser
 import errno
+import getpass
 import hashlib
 import json
 import os
@@ -237,23 +238,25 @@ def main(argv):
 
     cmd = [args.command] + args.arguments
 
-    try:
-        os.makedirs(os.path.join(root, '.stbt/cache'))
-    except OSError:
-        # Directory already exists
-        pass
-
     tty_arg = ['-t'] if sys.stdin.isatty() else []
 
     innerdir = '/var/lib/stbt/test-pack/' + os.path.relpath(os.curdir, root)
+
+    # cache_volume refers to a docker named volume that will be created
+    # on-demand if it doesn't exist.  We want the stbt cache to be stored on a
+    # native docker volume because we need it to be fast and we want it to
+    # support linux filesystem semantics so don't want to go through some sort
+    # of translation layer.  We give each user their own volume so one person's
+    # actions can't mess up another's:
+    cache_volume = ("stbt-cache-" +
+                    re.sub('[^a-zA-Z0-9_.-]', '_', getpass.getuser()))
 
     # We use /bin/dash here because many programs (including make) get confused
     # if they are running as pid 1.
     os.execvp(
         DOCKER[0], DOCKER +
         ['run', '-i', '--rm', '-u', '0:0',
-         '-v', '%s:/var/lib/stbt/.cache' % container_to_host_path(
-             os.path.join(root, '.stbt/cache')),
+         '-v', '%s:/var/lib/stbt/.cache' % cache_volume,
          '-v', '%s:/var/lib/stbt/test-pack' % container_to_host_path(root),
          '-e', 'STBT_CONFIG_FILE=/var/lib/stbt/test-pack/.stbt.conf'] + tty_arg
         + shlex.split(os.environ.get('DOCKER_OPTS', '')) +

--- a/stbt-docker
+++ b/stbt-docker
@@ -1,0 +1,192 @@
+#!/usr/bin/env python
+
+#
+# This file is a part of stb-tester but it is intended to be distributed
+# independently checked into test-packs.  See
+# https://github.com/stb-tester/stb-tester/ for the canonical source.
+#
+# Copyright 2015-16 stb-tester.com Ltd.
+#
+# License: LGPL v2.1 or (at your option) any later version (see
+# https://github.com/stb-tester/stb-tester/blob/master/LICENSE for details).
+#
+
+"""
+Runs the stbt command in a docker container, set-up like an stb-tester ONE but
+without video capture or IR control.  This is intended to be used as the "stbt"
+command on MacOS and Windows allowing people to do local development and testing
+(pylint, running selftests, etc.) when video-capture is not needed.
+
+Usage:
+
+    $ stbt-docker stbt lint tests/tests.py
+    ********** module tests
+    E: 22, 4: No name '_load_template' in module 'stbt' (no-name-in-module)
+
+    $ stbt-docker python -m doctest tests/tests.py
+    ...
+
+    $ stbt-docker
+    Python 2.7.6 (default, Jun 22 2015, 17:58:13)
+    [GCC 4.8.2] on linux2
+    Type "help", "copyright", "credits" or "license" for more information.
+    >>> import stbt
+    >>> stbt.match(...)
+
+Environment variables:
+
+* `DOCKER` - The location of the `docker` binary defaults to "`docker`"
+* `DOCKER_OPTS` - provide additional arguments to `docker run`.  For instance
+  `DOCKER_OPTS="--memory=2g"` will limit stbt to using 2GB of memory.  Shell
+  escaping is used to allow specifiying arguments with spaces in.
+
+This program is built with portability in mind so it should run on Mac OS and
+Windows.  The only dependencies are Python and docker.  It is also
+self-contained and relocatable so it can be deployed as a single file with no
+dependency on anything else in stbt.
+"""
+
+import argparse
+import ConfigParser
+import errno
+import hashlib
+import os
+import pipes
+import shlex
+import subprocess
+import sys
+import tarfile
+import tempfile
+from cStringIO import StringIO
+
+DOCKER = os.environ.get("DOCKER", "docker")
+
+
+def find_test_pack_root():
+    root = os.getcwd()
+    while root != '/':
+        if os.path.exists(os.path.join(root, '.stbt.conf')):
+            return root
+        root = os.path.split(root)[0]
+
+
+def dict_to_tarball(d):
+    with tempfile.NamedTemporaryFile() as tarball:
+        with tarfile.open(fileobj=tarball, mode='w') as t:
+            for filename, contents in d.items():
+                ti = tarfile.TarInfo(name=filename)
+                ti.size = len(contents)
+                t.addfile(ti, StringIO(contents))
+        return open(tarball.name, 'r')
+
+DOCKERFILE = """
+FROM {base_image}
+
+RUN mkdir -p /var/lib/stbt/test-pack/config/setup
+ADD setup /var/lib/stbt/test-pack/config/setup/setup
+RUN cd /var/lib/stbt/test-pack && \\
+    sudo chown stb-tester:stb-tester config/setup/setup && \\
+    chmod a+x config/setup/setup && \\
+    config/setup/setup
+"""
+
+
+class DockerNotInstalledError(RuntimeError):
+    pass
+
+
+def build_docker_image(test_pack):
+    cp = ConfigParser.ConfigParser()
+    cp.read(os.path.join(test_pack, '.stbt.conf'))
+    stbt_version = cp.get('test_pack', 'stbt_version')
+
+    base_image = "stbtester/stbt-one-test-pack-base-%s:v24.4" % stbt_version
+    try:
+        with open(os.path.join(test_pack, 'config/setup/setup')) as f:
+            setup = f.read()
+    except IOError as e:
+        if e.errno in [errno.EEXIST, errno.ENOENT]:
+            # No customisation of docker container required
+            return base_image
+        else:
+            raise
+
+    dockerfile = DOCKERFILE.format(base_image=base_image)
+    md5 = hashlib.md5()
+    md5.update(stbt_version)
+    md5.update(setup)
+    docker_image = "stb-tester-test-pack-%s" % md5.hexdigest()
+
+    try:
+        subprocess.check_output([DOCKER, 'inspect', docker_image],
+                                stderr=subprocess.STDOUT)
+        # Customised docker container is already cached
+        return docker_image
+    except subprocess.CalledProcessError:
+        pass
+    except OSError:
+        raise DockerNotInstalledError()
+
+    docker_build_context = {
+        'Dockerfile': dockerfile,
+        'setup': setup,
+    }
+    with dict_to_tarball(docker_build_context) as f:
+        subprocess.check_call(
+            [DOCKER, 'build', '-t', docker_image, '-'],
+            stdout=sys.stderr, stdin=f)
+
+    return docker_image
+
+
+def main(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('command', nargs='?')
+    parser.add_argument('argument', nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv[1:])
+
+    root = find_test_pack_root()
+    if root is None:
+        sys.stderr.write(
+            "This command must be run within a test pack.  Couldn't find a "
+            ".stbt.conf in this or any parent directory.\n")
+        return 1
+
+    try:
+        docker_image = build_docker_image(root)
+    except DockerNotInstalledError:
+        sys.stderr.write(
+            "%s failed:\n%s requires docker.  Install docker, or if it is "
+            "already installed set $DOCKER to the location of the docker "
+            "executable.\n" % (" ".join(argv), os.path.basename(argv[0])))
+        return 1
+
+    if args.command is None:
+        cmd = ['python']
+    else:
+        cmd = [args.command] + args.argument
+
+    try:
+        os.makedirs(os.path.join(root, '.stbt/cache'))
+    except OSError:
+        # Directory already exists
+        pass
+
+    tty_arg = ['-t'] if sys.stdin.isatty() else []
+
+    innerdir = '/var/lib/stbt/test-pack/' + os.path.relpath(os.curdir, root)
+
+    # We use /bin/dash here because many programs (including make) get confused
+    # if they are running as pid 1.
+    os.execvp(
+        DOCKER,
+        [DOCKER, 'run', '-i', '--rm',
+         '-v', '%s:/var/lib/stbt/.cache' % os.path.join(root, '.stbt/cache'),
+         '-v', '%s:/var/lib/stbt/test-pack' % root,
+         '-e', 'STBT_CONFIG_FILE=/var/lib/stbt/test-pack/.stbt.conf'] + tty_arg
+        + shlex.split(os.environ.get('DOCKER_OPTS', '')) +
+        [docker_image, '/bin/dash', '-c',
+         'cd {cwd} && "$0" "$@"'.format(cwd=pipes.quote(innerdir))] + cmd)
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/stbt-docker
+++ b/stbt-docker
@@ -50,8 +50,10 @@ import argparse
 import ConfigParser
 import errno
 import hashlib
+import json
 import os
 import pipes
+import re
 import shlex
 import subprocess
 import sys
@@ -61,6 +63,38 @@ from cStringIO import StringIO
 from textwrap import dedent
 
 DOCKER = shlex.split(os.environ.get("DOCKER", "docker"))
+
+
+def which_docker_container_am_i_running_in():
+    with open('/proc/self/cgroup') as f:
+        for line in f:
+            m = (re.search(r'docker/([0-9a-f]{64})$', line)
+                 or re.search(r'docker-([0-9a-f]{64})\.scope$', line))
+            if m:
+                return m.group(1)
+
+
+def container_to_host_path(path):
+    path = os.path.abspath(path)
+    container = which_docker_container_am_i_running_in()
+    if not container:
+        # Running on host (but not necessicarily the same host as the docker
+        # daemon)
+        return path
+    else:
+        this_container = json.loads(subprocess.check_output(
+            DOCKER + ['inspect', container]))[0]
+        best_match = None
+        for cpath, hpath in this_container['Volumes'].items():
+            rel = os.path.relpath(path, cpath)
+            if '..' not in rel:
+                if best_match is None or len(rel) < len(best_match[1]):
+                    best_match = (hpath, rel)
+        if best_match:
+            return os.path.join(*best_match)
+        else:
+            raise RuntimeError(
+                "Requested container path %s is not in a volume" % path)
 
 
 def find_test_pack_root():
@@ -182,8 +216,9 @@ def main(argv):
     os.execvp(
         DOCKER[0], DOCKER +
         ['run', '-i', '--rm', '-u', '0:0',
-         '-v', '%s:/var/lib/stbt/.cache' % os.path.join(root, '.stbt/cache'),
-         '-v', '%s:/var/lib/stbt/test-pack' % root,
+         '-v', '%s:/var/lib/stbt/.cache' % container_to_host_path(
+             os.path.join(root, '.stbt/cache')),
+         '-v', '%s:/var/lib/stbt/test-pack' % container_to_host_path(root),
          '-e', 'STBT_CONFIG_FILE=/var/lib/stbt/test-pack/.stbt.conf'] + tty_arg
         + shlex.split(os.environ.get('DOCKER_OPTS', '')) +
         [docker_image, '/bin/dash', '-c', dedent("""\

--- a/stbt-docker
+++ b/stbt-docker
@@ -60,7 +60,7 @@ import tempfile
 from cStringIO import StringIO
 from textwrap import dedent
 
-DOCKER = os.environ.get("DOCKER", "docker")
+DOCKER = shlex.split(os.environ.get("DOCKER", "docker"))
 
 
 def find_test_pack_root():
@@ -119,7 +119,7 @@ def build_docker_image(test_pack):
     docker_image = "stb-tester-test-pack-%s" % md5.hexdigest()
 
     try:
-        subprocess.check_output([DOCKER, 'inspect', docker_image],
+        subprocess.check_output(DOCKER + ['inspect', docker_image],
                                 stderr=subprocess.STDOUT)
         # Customised docker container is already cached
         return docker_image
@@ -134,7 +134,7 @@ def build_docker_image(test_pack):
     }
     with dict_to_tarball(docker_build_context) as f:
         subprocess.check_call(
-            [DOCKER, 'build', '-t', docker_image, '-'],
+            DOCKER + ['build', '-t', docker_image, '-'],
             stdout=sys.stderr, stdin=f)
 
     return docker_image
@@ -180,8 +180,8 @@ def main(argv):
     # We use /bin/dash here because many programs (including make) get confused
     # if they are running as pid 1.
     os.execvp(
-        DOCKER,
-        [DOCKER, 'run', '-i', '--rm', '-u', '0:0',
+        DOCKER[0], DOCKER +
+        ['run', '-i', '--rm', '-u', '0:0',
          '-v', '%s:/var/lib/stbt/.cache' % os.path.join(root, '.stbt/cache'),
          '-v', '%s:/var/lib/stbt/test-pack' % root,
          '-e', 'STBT_CONFIG_FILE=/var/lib/stbt/test-pack/.stbt.conf'] + tty_arg

--- a/stbt-docker
+++ b/stbt-docker
@@ -1,9 +1,14 @@
 #!/usr/bin/env python
 
 #
-# This file is a part of stb-tester but it is intended to be distributed
-# independently checked into test-packs.  See
+# This file is part of stb-tester but it is intended to be distributed
+# independently, checked into test-packs. See
 # https://github.com/stb-tester/stb-tester/ for the canonical source.
+#
+# This program is built with portability in mind so it should run on Mac OS and
+# Windows. The only dependencies are Python and docker. It is also
+# self-contained and relocatable so it can be deployed as a single file with no
+# dependency on anything else in stbt.
 #
 # Copyright 2015-16 stb-tester.com Ltd.
 #
@@ -11,22 +16,30 @@
 # https://github.com/stb-tester/stb-tester/blob/master/LICENSE for details).
 #
 
-"""
-Runs the stbt command in a docker container, set-up like an stb-tester ONE but
-without video capture or IR control.  This is intended to be used as the "stbt"
-command on MacOS and Windows allowing people to do local development and testing
-(pylint, running selftests, etc.) when video-capture is not needed.
+# pylint:disable=line-too-long
+r"""
+"stbt-docker" runs the specified command in a docker container that is set up
+like an stb-tester ONE but without video-capture or infrared hardware.
+
+The docker container will have stbt and all its dependencies installed,
+as well as your test-pack's own dependencies as specified in
+"config/setup/setup". This makes it easier to run stbt commands on a CI server
+or on a developer's PC for local test-script development, when video-capture
+is not needed: For example to run pylint, stbt auto-selftest, etc.
+
+Run this command from an stb-tester test-pack. The test-pack will be mounted
+into the docker container as "/var/lib/stbt/test-pack".
 
 Usage:
 
-    $ stbt-docker stbt lint tests/tests.py
-    ********** module tests
-    E: 22, 4: No name '_load_template' in module 'stbt' (no-name-in-module)
+    $ ./stbt-docker stbt lint --errors-only tests/roku.py
+    ********** module roku
+    E:284,12: "wait_until" return value not used (missing "assert"?) (stbt-unused-return-value)
 
-    $ stbt-docker python -m doctest tests/tests.py
+    $ ./stbt-docker python -m doctest tests/roku.py
     ...
 
-    $ stbt-docker
+    $ ./stbt-docker
     Python 2.7.6 (default, Jun 22 2015, 17:58:13)
     [GCC 4.8.2] on linux2
     Type "help", "copyright", "credits" or "license" for more information.
@@ -35,16 +48,18 @@ Usage:
 
 Environment variables:
 
-* `DOCKER` - The location of the `docker` binary defaults to "`docker`"
-* `DOCKER_OPTS` - provide additional arguments to `docker run`.  For instance
-  `DOCKER_OPTS="--memory=2g"` will limit stbt to using 2GB of memory.  Shell
-  escaping is used to allow specifiying arguments with spaces in.
+* DOCKER - The location of the docker binary. Defaults to "docker".
+* DOCKER_OPTS - Additional arguments to "docker run". Shell escaping will be
+  unescaped once, so that you can specify arguments with spaces. For example:
+  DOCKER_OPTS="--memory=2g --volume=/path\ with\ spaces\ on\ host:/path\ in\ container"
 
-This program is built with portability in mind so it should run on Mac OS and
-Windows.  The only dependencies are Python and docker.  It is also
-self-contained and relocatable so it can be deployed as a single file with no
-dependency on anything else in stbt.
+See also:
+
+* https://stb-tester.com/manual/advanced-configuration#customising-the-test-run-environment
+* https://github.com/stb-tester/stb-tester-test-pack
+
 """
+# pylint:enable=line-too-long
 
 import argparse
 import ConfigParser
@@ -173,7 +188,9 @@ def build_docker_image(test_pack, stbt_version):
 
 
 def main(argv):
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        epilog=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('command', nargs='?')
     parser.add_argument('argument', nargs=argparse.REMAINDER)
     args = parser.parse_args(argv[1:])

--- a/stbt-docker
+++ b/stbt-docker
@@ -193,7 +193,7 @@ def main(argv):
     cp = ConfigParser.ConfigParser()
     cp.read(os.path.join(root, '.stbt.conf'))
     stbt_version = cp.get('test_pack', 'stbt_version')
-    if not stbt_version in STBT_VERSION_WHITELIST:
+    if stbt_version not in STBT_VERSION_WHITELIST:
         sys.stderr.write(
             "This version of stbt-docker does not support stbt_version %r.  "
             "Update to a newer version with:\n"

--- a/stbt-docker
+++ b/stbt-docker
@@ -63,6 +63,7 @@ from cStringIO import StringIO
 from textwrap import dedent
 
 DOCKER = shlex.split(os.environ.get("DOCKER", "docker"))
+STBT_VERSION_WHITELIST = {"0.21", "22", "23", "24"}
 
 
 def which_docker_container_am_i_running_in():
@@ -131,11 +132,7 @@ class DockerNotInstalledError(RuntimeError):
     pass
 
 
-def build_docker_image(test_pack):
-    cp = ConfigParser.ConfigParser()
-    cp.read(os.path.join(test_pack, '.stbt.conf'))
-    stbt_version = cp.get('test_pack', 'stbt_version')
-
+def build_docker_image(test_pack, stbt_version):
     base_image = "stbtester/stbt-one-test-pack-base-%s:v24.4" % stbt_version
     try:
         with open(os.path.join(test_pack, 'config/setup/setup')) as f:
@@ -185,11 +182,27 @@ def main(argv):
     if root is None:
         sys.stderr.write(
             "This command must be run within a test pack.  Couldn't find a "
-            ".stbt.conf in this or any parent directory.\n")
+            ".stbt.conf in this or any parent directory.\n"
+            "\n"
+            "To create a new test pack run:\n"
+            "\n"
+            "    git clone -o pristine "
+            "https://github.com/stb-tester/stb-tester-test-pack\n")
+        return 1
+
+    cp = ConfigParser.ConfigParser()
+    cp.read(os.path.join(root, '.stbt.conf'))
+    stbt_version = cp.get('test_pack', 'stbt_version')
+    if not stbt_version in STBT_VERSION_WHITELIST:
+        sys.stderr.write(
+            "This version of stbt-docker does not support stbt_version %r.  "
+            "Update to a newer version with:\n"
+            "\n"
+            "    curl -f -o %s https://stb-tester.com/stbt-docker\n")
         return 1
 
     try:
-        docker_image = build_docker_image(root)
+        docker_image = build_docker_image(root, stbt_version)
     except DockerNotInstalledError:
         sys.stderr.write(
             "%s failed:\n%s requires docker.  Install docker, or if it is "

--- a/stbt-docker
+++ b/stbt-docker
@@ -39,12 +39,15 @@ Usage:
     $ ./stbt-docker python -m doctest tests/roku.py
     ...
 
-    $ ./stbt-docker
+    $ ./stbt-docker python
     Python 2.7.6 (default, Jun 22 2015, 17:58:13)
     [GCC 4.8.2] on linux2
     Type "help", "copyright", "credits" or "license" for more information.
     >>> import stbt
     >>> stbt.match(...)
+
+    $ ./stbt-docker bash
+    stb-tester@97f85a1a4eea:~/test-pack$ ...
 
 Environment variables:
 
@@ -191,8 +194,8 @@ def main(argv):
     parser = argparse.ArgumentParser(
         epilog=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument('command', nargs='?')
-    parser.add_argument('argument', nargs=argparse.REMAINDER)
+    parser.add_argument('command')
+    parser.add_argument('arguments', nargs=argparse.REMAINDER)
     args = parser.parse_args(argv[1:])
 
     root = find_test_pack_root()
@@ -232,10 +235,7 @@ def main(argv):
             """))
         return 1
 
-    if args.command is None:
-        cmd = ['python']
-    else:
-        cmd = [args.command] + args.argument
+    cmd = [args.command] + args.arguments
 
     try:
         os.makedirs(os.path.join(root, '.stbt/cache'))

--- a/stbt-docker
+++ b/stbt-docker
@@ -197,34 +197,39 @@ def main(argv):
 
     root = find_test_pack_root()
     if root is None:
-        sys.stderr.write(
-            "This command must be run within a test pack.  Couldn't find a "
-            ".stbt.conf in this or any parent directory.\n"
-            "\n"
-            "To create a new test pack run:\n"
-            "\n"
-            "    git clone -o pristine "
-            "https://github.com/stb-tester/stb-tester-test-pack\n")
+        sys.stderr.write(dedent("""\
+            error: stbt-docker must be run within a test pack.
+            Couldn't find ".stbt.conf" in this or any parent directory.
+
+            To create a new test pack run the following command:
+
+                git clone -o pristine https://github.com/stb-tester/stb-tester-test-pack
+
+            """))
         return 1
 
     cp = ConfigParser.ConfigParser()
     cp.read(os.path.join(root, '.stbt.conf'))
     stbt_version = cp.get('test_pack', 'stbt_version')
     if stbt_version not in STBT_VERSION_WHITELIST:
-        sys.stderr.write(
-            "This version of stbt-docker does not support stbt_version %r.  "
-            "Update to a newer version with:\n"
-            "\n"
-            "    curl -f -o %s https://stb-tester.com/stbt-docker\n")
+        sys.stderr.write(dedent("""\
+            error: This version of stbt-docker does not support stbt_version {v}.
+
+            To update stbt-docker run the following command:
+
+                curl -f -o {argv0} https://stb-tester.com/stbt-docker
+
+            """).format(v=stbt_version, argv0=argv[0]))
         return 1
 
     try:
         docker_image = build_docker_image(root, stbt_version)
     except DockerNotInstalledError:
-        sys.stderr.write(
-            "%s failed:\n%s requires docker.  Install docker, or if it is "
-            "already installed set $DOCKER to the location of the docker "
-            "executable.\n" % (" ".join(argv), os.path.basename(argv[0])))
+        sys.stderr.write(dedent("""\
+            error: stbt-docker requires docker. Install docker, or if it is
+            already installed set $DOCKER to the location of the docker
+            executable.
+            """))
         return 1
 
     if args.command is None:

--- a/stbt-docker
+++ b/stbt-docker
@@ -121,10 +121,9 @@ FROM {base_image}
 
 RUN mkdir -p /var/lib/stbt/test-pack/config/setup
 ADD setup /var/lib/stbt/test-pack/config/setup/setup
-RUN cd /var/lib/stbt/test-pack && \\
-    sudo chown stb-tester:stb-tester config/setup/setup && \\
-    chmod a+x config/setup/setup && \\
-    config/setup/setup
+RUN sudo chown stb-tester:stb-tester /var/lib/stbt/test-pack/config/setup/setup
+RUN chmod a+x /var/lib/stbt/test-pack/config/setup/setup
+RUN /var/lib/stbt/test-pack/config/setup/setup
 """
 
 

--- a/stbt-docker
+++ b/stbt-docker
@@ -257,16 +257,17 @@ def main(argv):
         DOCKER[0], DOCKER +
         ['run', '-i', '--rm', '-u', '0:0',
          '-v', '%s:/var/lib/stbt/.cache' % cache_volume,
-         '-v', '%s:/var/lib/stbt/test-pack' % container_to_host_path(root),
-         '-e', 'STBT_CONFIG_FILE=/var/lib/stbt/test-pack/.stbt.conf'] + tty_arg
-        + shlex.split(os.environ.get('DOCKER_OPTS', '')) +
+         '-v', '%s:/var/lib/stbt/test-pack' % container_to_host_path(root)]
+        + tty_arg + shlex.split(os.environ.get('DOCKER_OPTS', '')) +
         [docker_image, '/bin/dash', '-c', dedent("""\
          find /var/lib/stbt -xdev -path /var/lib/stbt/test-pack -prune \\
               -o -print0 | xargs -0 chown -f {uid}:{gid} &&
          sed -i s/stb-tester:x:1000:1000/stb-tester:x:{uid}:{gid}/ /etc/passwd &&
          sed -i s/stb-tester:x:1000/stb-tester:x:{gid}/ /etc/group &&
          cd {cwd} &&
-         sudo -u stb-tester -E -- "$0" "$@" """).format(
+         sudo -u stb-tester -E -- \\
+             env STBT_CONFIG_FILE={config_filename} \\
+             "$0" "$@" """).format(
             uid=os.getuid(), gid=os.getgid(), cwd=pipes.quote(innerdir))]
         + cmd)
 

--- a/stbt-docker
+++ b/stbt-docker
@@ -111,6 +111,8 @@ def dict_to_tarball(d):
             for filename, contents in d.items():
                 ti = tarfile.TarInfo(name=filename)
                 ti.size = len(contents)
+                ti.uid = os.getuid()
+                ti.gid = os.getgid()
                 t.addfile(ti, StringIO(contents))
         return open(tarball.name, 'r')
 

--- a/stbt.sh.in
+++ b/stbt.sh.in
@@ -11,6 +11,7 @@
 #/     batch          Run testcases repeatedly, create html report
 #/     config         Print configuration value
 #/     control        Send remote control signals
+#/     docker         Run stbt command in a docker container
 #/     lint           Static analysis of testcases
 #/     match          Compare two images
 #/     power          Control networked power switch
@@ -57,7 +58,7 @@ case "$cmd" in
         usage; exit 0;;
     -v|--version)
         echo "stb-tester $STBT_VERSION"; exit 0;;
-    run|record|batch|config|control|lint|power|screenshot|match|tv)
+    run|record|batch|config|control|docker|lint|power|screenshot|match|tv)
         exec @LIBEXECDIR@/stbt/stbt-"$cmd" "$@";;
     templatematch)  # for backwards compatibility
         exec @LIBEXECDIR@/stbt/stbt-match "$@";;

--- a/tests/test-packs/bad-setup-script/.stbt.conf
+++ b/tests/test-packs/bad-setup-script/.stbt.conf
@@ -1,0 +1,1 @@
+config/stbt.conf

--- a/tests/test-packs/bad-setup-script/config/setup/setup
+++ b/tests/test-packs/bad-setup-script/config/setup/setup
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+echo 1 | sudo tee /etc/setup-revision
+pwd | sudo tee /etc/setup-pwd
+whoami | sudo tee /etc/setup-whoami
+echo "$0" "$@" | sudo tee /etc/setup-args
+
+# setup scripts are intended to be deterministic.  $RANDOM would be a really
+# bad idea in a real setup script but I use it here to check caching.
+echo "$RANDOM" | sudo tee /etc/setup-id
+
+# Used by test_that_if_setup_fails_no_tests_are_run
+echo "This is going to fail"
+false

--- a/tests/test-packs/bad-setup-script/config/stbt.conf
+++ b/tests/test-packs/bad-setup-script/config/stbt.conf
@@ -1,0 +1,5 @@
+[test_pack]
+stbt_version = 0.21
+
+[my]
+sunshine = you

--- a/tests/test-packs/empty-test-pack/.stbt.conf
+++ b/tests/test-packs/empty-test-pack/.stbt.conf
@@ -1,0 +1,1 @@
+config/stbt.conf

--- a/tests/test-packs/empty-test-pack/config/stbt.conf
+++ b/tests/test-packs/empty-test-pack/config/stbt.conf
@@ -1,0 +1,2 @@
+[test_pack]
+stbt_version = 0.21

--- a/tests/test-packs/setup-script/.stbt.conf
+++ b/tests/test-packs/setup-script/.stbt.conf
@@ -1,0 +1,1 @@
+config/stbt.conf

--- a/tests/test-packs/setup-script/config/setup/setup
+++ b/tests/test-packs/setup-script/config/setup/setup
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+echo 1 | sudo tee /etc/setup-revision
+pwd | sudo tee /etc/setup-pwd
+whoami | sudo tee /etc/setup-whoami
+echo "$0" "$@" | sudo tee /etc/setup-args
+
+# setup scripts are intended to be deterministic.  $RANDOM would be a really
+# bad idea in a real setup script but I use it here to check caching.
+echo "$RANDOM" | sudo tee /etc/setup-id

--- a/tests/test-packs/setup-script/config/stbt.conf
+++ b/tests/test-packs/setup-script/config/stbt.conf
@@ -1,0 +1,5 @@
+[test_pack]
+stbt_version = 0.21
+
+[my]
+sunshine = you

--- a/tests/test-stbt-docker.sh
+++ b/tests/test-stbt-docker.sh
@@ -1,0 +1,72 @@
+# Run with ./run-tests.sh
+
+skip_if_no_docker() {
+    which docker >/dev/null 2>&1 || skip "docker is not installed"
+    docker version >/dev/null 2>&1 || skip "docker does not work"
+}
+
+load_test_pack() {
+    skip_if_no_docker
+
+    cp -r "$testdir/test-packs/$1" . &&
+    cd "$1" || fail "Loading test pack $1 failed"
+}
+
+test_stbt_docker_fails_with_no_test_pack() {
+    skip_if_no_docker
+
+    ! stbt docker true || fail
+}
+
+test_stbt_docker_exec_runs_command_with_no_setup_script() {
+    load_test_pack empty-test-pack
+    stbt docker echo -n hello >output || fail "Command should have succeeded"
+
+    [ "$(cat output)" = "hello" ] || fail "Command not run"
+}
+
+test_stbt_docker_exec_runs_command_with_setup_script() {
+    load_test_pack setup-script
+    stbt docker echo -n hello >output || fail "Command should have succeeded"
+
+    [ "$(cat output)" = "hello" ] || fail "Command not run"
+}
+
+test_that_stbt_docker_exec_fails_with_bad_test_pack()
+{
+    load_test_pack bad-setup-script
+    ! stbt docker true || fail "Command should have failed"
+}
+
+test_your_files_are_available_in_stbt_docker() {
+    load_test_pack empty-test-pack
+    stbt docker test -e config/stbt.conf || fail "Command should have succeeded"
+}
+
+test_that_path_within_container_is_same_as_outside() {
+    load_test_pack empty-test-pack
+
+    stbt docker bash -c '[ $PWD = /var/lib/stbt/test-pack ]' \
+    || fail "Directory doesnt match"
+
+    cd config
+    stbt docker bash -c '[ $PWD = /var/lib/stbt/test-pack/config ]' \
+    || fail "Directory doesnt match"
+}
+
+test_that_docker_opts_passes_arguments_through_to_docker_run() {
+    load_test_pack empty-test-pack
+    export DOCKER_OPTS="-e HELLO=goodbye\\ cruel\\ world"
+    stbt docker bash -c 'echo -e $HELLO >output'
+
+    [ "$(cat output)" = "goodbye cruel world" ] \
+    || fail "DOCKER_OPTS has no effect"
+}
+
+test_that_stbt_docker_with_no_arguments_gives_python_interpreter() {
+    load_test_pack empty-test-pack
+    stbt docker >output <<-EOF
+		print "hello",
+		EOF
+    [ "$(cat output)" = "hello" ] || fail "Not Python interpreter"
+}

--- a/tests/test-stbt-docker.sh
+++ b/tests/test-stbt-docker.sh
@@ -69,14 +69,6 @@ test_that_docker_opts_passes_arguments_through_to_docker_run() {
     || fail "DOCKER_OPTS has no effect"
 }
 
-test_that_stbt_docker_with_no_arguments_gives_python_interpreter() {
-    load_test_pack empty-test-pack
-    stbt docker >output <<-EOF
-		print "hello",
-		EOF
-    [ "$(cat output)" = "hello" ] || fail "Not Python interpreter"
-}
-
 test_that_with_different_uid_we_still_have_permissions_to_files() {
     [ -n "$TRAVIS" ] || skip "Test will only run on Travis because it involves changing system state"
 


### PR DESCRIPTION
Runs the stbt command in a docker container, set-up like an stb-tester ONE but without video capture or IR control.  This is intended to be used as the "stbt" command on MacOS and Windows allowing people to do local development and testing (pylint, running selftests, etc.) when video-capture is not needed.

Usage:

    $ stbt-docker lint tests/tests.py
    ********** module tests
    E: 22, 4: No name '_load_template' in module 'stbt' (no-name-in-module)

    $ stbt-docker exec python -m doctest tests/tests.py
    ...

    $ stbt-docker exec
    Python 2.7.6 (default, Jun 22 2015, 17:58:13)
    [GCC 4.8.2] on linux2
    Type "help", "copyright", "credits" or "license" for more information.
    >>>

Environment variables:

* `DOCKER` - The location of the `docker` binary defaults to "`docker`"
* `DOCKER_OPTS` - provide additional arguments to `docker run`.  For instance `DOCKER_OPTS="--memory=2g"` will limit stbt to using 2GB of memory.  Shell escaping is used to allow specifiying arguments with spaces in.

This program is built with portability in mind so it should run on Mac OS and Windows.  The only dependencies are Python and docker.  It is also self-contained and relocatable so it can be deployed as a single file with no dependency on anything else in stbt.

~~In the future it might be worth re-writing this in Go so we can drop the Python dependency too.~~

This was inspired by writing the blog post on auto-regression tests.  I was concerned that we were recommending an approach without making it easy for our users to execute on it.

This is a generalisation of a `docker-env` script I've been using to create a more consistent selftest environment.

This could also be used to make virtual-stb merge-able sooner (#174).

TODO:

- [x] Write tests
- [x] ~~Merge #303 so we can run the tests on Travis~~ - I'm skipping the tests if docker is not available instead.  It's better to decouple these sorts of things.
- [x] Figure out permissions and how volumes work on MacOS and Windows
- [x] Figure out how it works if the outer UID is not 1000
- [x] Automated test for UID/GID switching?
- [x] ~~Maybe it would be better to `git clone` into the container rather than using host volumes?~~ - Nope, see comment below
- [x] Write release note
- [x] Change command-line API as per [this comment](#issuecomment-191826936).
- [x] Change command-line API when no arguments as per [this comment](#issuecomment-215490797).
- [x] Decide which URL to use for upgrades, as per [this comment thread](#discussion-diff-54333636) *(Now that it's going into its own repo, the URL will be `raw.github.com/...`)*
- [x] Add support for Windows and Mac OS X with docker-toolbox.
- [ ] Remove it from `stbt.sh.in` -- we'll use it with `$test_pack/stbt-docker` not `stbt docker`. This is because stbt-docker will have a different release cycle than stb-tester.
    - [ ] Check all the documentation to make sure it isn't saying `stbt docker`.
- [x] Move to seperate repo