### PR TITLE
Work around regression in PyGObject 3.13

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -35,7 +35,7 @@ from gi.repository import GLib, GObject, Gst  # pylint: disable=E0611
 
 from _stbt import logging, utils
 from _stbt.config import ConfigurationError, get_config
-from _stbt.gst_hacks import gst_iterate, map_gst_buffer
+from _stbt.gst_hacks import gst_iterate, map_gst_sample
 from _stbt.logging import ddebug, debug, warn
 
 gi.require_version("Gst", "1.0")
@@ -1237,7 +1237,7 @@ def _numpy_from_sample(sample, readonly=False):
     if not readonly:
         flags |= Gst.MapFlags.WRITE
 
-    with map_gst_buffer(sample.get_buffer(), flags) as buf:
+    with map_gst_sample(sample, flags) as buf:
         array = numpy.frombuffer((buf), dtype=numpy.uint8)
         array.flags.writeable = not readonly
         if caps.get_structure(0).get_value('format') in ['BGR', 'RGB']:

--- a/_stbt/gst_hacks.py
+++ b/_stbt/gst_hacks.py
@@ -36,18 +36,22 @@ _libgst.gst_buffer_map.restype = ctypes.c_int
 _libgst.gst_buffer_unmap.argtypes = [ctypes.c_void_p, _GstMapInfo_p]
 _libgst.gst_buffer_unmap.restype = None
 
+_libgst.gst_sample_get_buffer.argtypes = [ctypes.c_void_p]
+_libgst.gst_sample_get_buffer.restype = ctypes.c_void_p
+
+_libgst.gst_mini_object_is_writable.argtypes = [ctypes.c_void_p]
+_libgst.gst_mini_object_is_writable.restype = ctypes.c_int
+
 
 @contextmanager
-def map_gst_buffer(buf, flags):
-    if not isinstance(buf, Gst.Buffer):
-        raise TypeError("map_gst_buffer must take a Gst.Buffer")
-    if flags & Gst.MapFlags.WRITE and not buf.mini_object.is_writable():
+def _map_gst_buffer(pbuffer, flags):
+    if pbuffer is None:
+        raise TypeError("Cannot pass NULL to _map_gst_buffer")
+    if flags & Gst.MapFlags.WRITE \
+            and _libgst.gst_mini_object_is_writable(pbuffer) == 0:
         raise ValueError(
             "Writable array requested but buffer is not writeable")
 
-    # hashing a GObject actually gives the address (pointer) of the C struct
-    # that backs it!:
-    pbuffer = hash(buf)
     mapping = _GstMapInfo()
     success = _libgst.gst_buffer_map(pbuffer, mapping, flags)
     if not success:
@@ -59,22 +63,55 @@ def map_gst_buffer(buf, flags):
         _libgst.gst_buffer_unmap(pbuffer, mapping)
 
 
-def test_map_buffer_reading_data():
+def map_gst_sample(sample, flags):
+    """
+    This function exists because of a change in behaviour of pygobject 3.13 that
+    broke our ability to get a writable buffer from a GstSample.
+
+    See https://bugzilla.gnome.org/show_bug.cgi?id=736896 for more information.
+    """
+    if not isinstance(sample, Gst.Sample):
+        raise TypeError("map_gst_sample must take a Gst.Sample.  Received a %s"
+                        % str(type(sample)))
+
+    # hashing a GObject actually gives the address (pointer) of the C struct
+    # that backs it!:
+    pbuffer = _libgst.gst_sample_get_buffer(hash(sample))
+    if pbuffer is None:
+        raise ValueError(
+            "map_gst_sample: Provided GstSample doesn't contain a buffer")
+
+    return _map_gst_buffer(pbuffer, flags)
+
+
+def test_map_sample_reading_data():
     Gst.init([])
 
-    b = Gst.Buffer.new_wrapped("hello")
-    with map_gst_buffer(b, Gst.MapFlags.READ) as a:
+    s = Gst.Sample.new(Gst.Buffer.new_wrapped("hello"), None, None, None)
+    with map_gst_sample(s, Gst.MapFlags.READ) as a:
         assert 'hello' == ''.join(chr(x) for x in a)
 
 
-def test_map_buffer_modifying_data():
+def test_map_sample_modifying_data():
     Gst.init([])
 
-    b = Gst.Buffer.new_wrapped("hello")
-    with map_gst_buffer(b, Gst.MapFlags.WRITE | Gst.MapFlags.READ) as a:
+    s = Gst.Sample.new(Gst.Buffer.new_wrapped("hello"), None, None, None)
+    with map_gst_sample(s, Gst.MapFlags.WRITE | Gst.MapFlags.READ) as a:
         a[2] = 1
 
-    assert b.extract_dup(0, 5) == "he\x01lo"
+    assert s.get_buffer().extract_dup(0, 5) == "he\x01lo"
+
+
+def test_map_sample_without_buffer():
+    Gst.init([])
+
+    sample = Gst.Sample.new(None, None, None, None)
+    try:
+        # pylint: disable=E1120
+        with map_gst_sample(sample, Gst.MapFlags.READ):
+            assert False
+    except ValueError:
+        pass
 
 
 def gst_iterate(gst_iterator):

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -53,6 +53,9 @@ UNRELEASED
 
 ##### Bugfixes and packaging fixes since 23
 
+* Fixed "stb-tester fails with PyGObject 3.13" #305.  This will allow
+  stb-tester to work out of the box on Ubuntu >= 14.10 and Fedora >= 21.
+
 ##### Developer-visible changes since 23
 
 #### 23


### PR DESCRIPTION
Preventing stb-tester from working on Ubuntu >= 14.04 and Fedora >= 21.

`map_gst_sample` was failing with:

    Traceback(most recent call last):
      File"/usr/libexec/stbt/stbt/__init__.py", line 1920, in on_new_sample
        self.push_sample(sample)
      File"/usr/libexec/stbt/stbt/__init__.py", line 1984, in push_sample
        with _numpy_from_sample(sample)as img:
      File"/usr/lib64/python2.7/contextlib.py", line 17, in __enter__
        returnself.gen.next()
      File"/usr/libexec/stbt/stbt/__init__.py", line 1708, in _numpy_from_sample
        with map_gst_buffer(sample.get_buffer(), flags) as buf:
      File"/usr/lib64/python2.7/contextlib.py", line 17, in __enter__
        return self.gen.next()
      File"/usr/libexec/stbt/_stbt/gst_hacks.py", line 47, in map_gst_buffer
        "Writable array requested but buffer is not writeable")
    ValueError: Writable array requested but buffer is not writeable

PyGObject changed the behaviour of `Gst.Sample.get_buffer` to take a reference to the buffer it returns with `gst_mini_object_ref`.  to prevent use-after-free bugs if the `Gst.Buffer` is used after the `Gst.Sample` goes out of scope.  Unfortunately `gst_mini_object_ref` isn't just a reference-counting increment, it also marks the object as read-only. This makes it impossible to get a writable handle to the `Gst.Buffer` owned by the `Gst.Sample`.

In this commit we work around this by using the C API directly via ctypes as we had to for `map_gst_buffer()` (see f0c5b31).

See the upstream bug ticket: https://bugzilla.gnome.org/show_bug.cgi?id=736896

Fixes: #305