### PR TITLE
stbt-batch.d/run: [fix] don't be influenced by $CDPATH

### DIFF
--- a/stbt-batch.d/run.py
+++ b/stbt-batch.d/run.py
@@ -101,7 +101,7 @@ def main(argv):
         subenv['tag'] = tag
         subenv['v'] = '-vv' if args.debug else '-v'
         subenv['verbose'] = str(args.verbose)
-        subenv['outputdir'] = args.output
+        subenv['outputdir'] = os.path.abspath(args.output)
         child = None
         try:
             child = subprocess.Popen(


### PR DESCRIPTION
I encountered a failure in
`test_that_stbt_batch_run_will_run_a_specific_function`. It became apparent
that the output directory called "results" was not being created and
instead a directory of my own called "results" which exists on my $CDPATH
was being used. This means that `subprocess.Popen`, is using the
`outputdir` in the environment dictionary by effectively doing
`cd env['outputdir']`.

This makes the behaviour unpredictable, and so this commit fixes it by
setting `outputdir` to be relative to the working dir unless it is already
an absolute path. This means that the path is not up for interpretation.
