### PR TITLE
Mainloop handling refactoring

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1641,6 +1641,7 @@ class Display(object):
                     debug("Timeout waiting for sink EOS")
             else:
                 debug("Sending EOS to sink pipeline failed")
+            self.sink_pipeline.set_state(Gst.State.NULL)
 
         self.mainloop.__exit__(None, None, None)
 

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1635,14 +1635,14 @@ class Display(object):
                 debug("teardown: Source pipeline did not teardown gracefully")
             source.set_state(Gst.State.NULL)
             source = None
-        if not self.novideo:
-            debug("teardown: Sending eos")
-            if self.appsrc.emit("end-of-stream") == Gst.FlowReturn.OK:
-                if not self.received_eos.wait(10):
-                    debug("Timeout waiting for sink EOS")
-            else:
-                debug("Sending EOS to sink pipeline failed")
-            self.sink_pipeline.set_state(Gst.State.NULL)
+
+        debug("teardown: Sending eos")
+        if self.appsrc.emit("end-of-stream") == Gst.FlowReturn.OK:
+            if not self.received_eos.wait(10):
+                debug("Timeout waiting for sink EOS")
+        else:
+            debug("Sending EOS to sink pipeline failed")
+        self.sink_pipeline.set_state(Gst.State.NULL)
 
         self.mainloop.__exit__(None, None, None)
 

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1491,13 +1491,13 @@ class Display(object):
 
     def draw(self, obj, duration_secs):
         with self.annotations_lock:
-            if type(obj) in (str, unicode):
+            if isinstance(obj, str) or isinstance(obj, unicode):
                 obj = (
                     datetime.datetime.now().strftime("%H:%M:%S.%f")[:-4] +
                     ' ' + obj)
                 self.text_annotations.append(
                     {"text": obj, "duration": duration_secs * Gst.SECOND})
-            elif type(obj) is MatchResult:
+            elif isinstance(obj, MatchResult):
                 if obj.timestamp is not None:
                     self.match_annotations.append(obj)
             else:

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1547,8 +1547,9 @@ class Display(object):
 
     def on_error(self, pipeline, _bus, message):
         assert message.type == Gst.MessageType.ERROR
-        Gst.debug_bin_to_dot_file_with_ts(
-            pipeline, Gst.DebugGraphDetails.ALL, "ERROR")
+        if pipeline is not None:
+            Gst.debug_bin_to_dot_file_with_ts(
+                pipeline, Gst.DebugGraphDetails.ALL, "ERROR")
         err, dbg = message.parse_error()
         self.tell_user_thread(
             UITestError("%s: %s\n%s\n" % (err, err.message, dbg)))

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1636,9 +1636,11 @@ class Display(object):
             source = None
         if not self.novideo:
             debug("teardown: Sending eos")
-            self.appsrc.emit("end-of-stream")
-            if not self.received_eos.wait(10):
-                debug("Timeout waiting for sink EOS")
+            if self.appsrc.emit("end-of-stream") == Gst.FlowReturn.OK:
+                if not self.received_eos.wait(10):
+                    debug("Timeout waiting for sink EOS")
+            else:
+                debug("Sending EOS to sink pipeline failed")
 
         self.mainloop.__exit__(None, None, None)
 


### PR DESCRIPTION
Some refactorings I made while working on dual camera support so we can have two `DeviceUnderTest` objects at the same time.

This should help towards librification (#297) too.