### PR TITLE
Makefile: List debian/ubuntu packages that are missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -360,7 +360,13 @@ stbt-camera.d/gst/stbt-gst-plugins.so: stbt-camera.d/gst/stbtgeometriccorrection
                                        stbt-camera.d/gst/stbtcontraststretch_orc.h \
                                        VERSION
 	@if ! pkg-config --exists $(PKG_DEPS); then \
-		printf "Please install packages $(PKG_DEPS)"; exit 1; fi
+		printf "Please install packages $(PKG_DEPS)\n"; \
+		if which apt-file >/dev/null 2>&1; then \
+			PACKAGES=$$(printf "/%s.pc\n" $(PKG_DEPS) | apt-file search -fl) ; \
+			echo Try apt install $$PACKAGES; \
+		fi; \
+		exit 1; \
+	fi
 	gcc -shared -o $@ $(filter %.c %.o,$^) -fPIC  -Wall -Werror $(CFLAGS) \
 		$(LDFLAGS) $$(pkg-config --libs --cflags $(PKG_DEPS)) \
 		-DVERSION=\"$(VERSION)\"


### PR DESCRIPTION
This is a small help as I was building stb-tester on my new laptop.  Now when `make enable_stbt_camera=yes` fails it prints:

    Please install packages gstreamer-1.0 gstreamer-app-1.0 gstreamer-video-1.0 opencv orc-0.4
    Try apt install libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev libopencv-dev liborc-0.4-dev
    Makefile:362: recipe for target 'stbt-camera.d/gst/stbt-gst-plugins.so' failed
    make: *** [stbt-camera.d/gst/stbt-gst-plugins.so] Error 1

Which saves some time working out which debian packages provide the given pkg-config packages.