### PR TITLE
stbt.match: Fix error message for greyscale images

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1674,7 +1674,7 @@ def _match(image, template, match_parameters, template_name):
         raise ValueError("Source image must be larger than template image")
     if any(template.shape[x] < 1 for x in (0, 1)):
         raise ValueError("Template image must contain some data")
-    if template.shape[2] != 3:
+    if len(template.shape) != 3 or template.shape[2] != 3:
         raise ValueError("Template image must be 3 channel BGR")
     if template.dtype != numpy.uint8:
         raise ValueError("Template image must be 8-bits per channel")

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -1,6 +1,9 @@
+import cv2
 import numpy
+from nose.tools import raises
 
 import stbt
+from _stbt.core import _load_template
 
 
 def black(width=1280, height=720):
@@ -18,3 +21,9 @@ def test_that_matchresult_str_image_matches_template_passed_to_match():
 def test_that_matchresult_str_image_matches_template_passed_to_match_custom():
     assert "image=<Custom Image>" in str(
         stbt.match(black(30, 30), frame=black()))
+
+
+@raises(ValueError)
+def test_that_match_rejects_greyscale_template():
+    grey = cv2.cvtColor(_load_template("black.png").image, cv2.cv.CV_BGR2GRAY)
+    stbt.match(grey, frame=black())


### PR DESCRIPTION
This was raising "IndexError: tuple index out of range" instead of the
desired "ValueError: Template image must be 3 channel BGR".

Fixes #310.