### PR TITLE
.travis.yml: Force apt to behave non-interactively

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ services:
 install:
  - cat /etc/os-release
  - export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ - export DEBIAN_FRONTEND=noninteractive
  - sudo apt-get update
- - sudo apt-get install
+ - sudo apt-get -y install
         expect
         expect-dev
         gir1.2-gstreamer-1.0


### PR DESCRIPTION
Travis started presenting an apt-get prompt, then timing out after 10
minutes of inactivity. Presumably they've changed their configuration
so we need to specify noninteractive mode ourselves.