### PR TITLE
core: Support functools.partial objects in _callable_description

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1003,8 +1003,17 @@ def _callable_description(callable_):
     >>> _callable_description(
     ...     lambda: stbt.press("OK"))
     '    lambda: stbt.press("OK"))\\n'
+    >>> _callable_description(functools.partial(int, base=2))
+    'int'
     """
-    d = callable_.__name__
+    try:
+        d = callable_.__name__
+    except AttributeError:
+        if isinstance(callable_, functools.partial):
+            # functools.partial wraps the original function
+            d = callable_.func.__name__
+        else:
+            raise
     if d == "<lambda>":
         try:
             d = inspect.getsource(callable_)


### PR DESCRIPTION
`functools.partial` creates `partial` objects that behave like a function.
However, unlike a function, they do not have a `__name__` attribute created
automatically[1]. This results in `_callable_description` raising an
`AttributeError` if `callable_` is a partial object.

This commit adds support for `functools.partial` objects in
`_callable_description`.

[1] https://docs.python.org/2/library/functools.html#partial-objects