### PR TITLE
Support recursive functools.partial objects in _callable_description

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,7 @@ check-nosetests: tests/ocr/menu.png
 	cp stbt-control nosetest-issue-49-workaround-stbt-control.py && \
 	PYTHONPATH=$$PWD NOSE_REDNOSE=1 \
 	nosetests --with-doctest -v --match "^test_" \
+	    --doctest-options=+ELLIPSIS \
 	    $(shell git ls-files '*.py' |\
 	      grep -v -e tests/test.py \
 	              -e tests/test2.py \

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1008,16 +1008,23 @@ def _callable_description(callable_):
     >>> _callable_description(functools.partial(functools.partial(int, base=2),
     ...                                         x='10'))
     'int'
+    >>> class T(object):
+    ...     def __call__(self): return True;
+    >>> _callable_description(T())
+    '<_stbt.core.T object at 0x...>'
     """
-    if isinstance(callable_, functools.partial):
+    if hasattr(callable_, "__name__"):
+        name = callable_.__name__
+        if name == "<lambda>":
+            try:
+                name = inspect.getsource(callable_)
+            except IOError:
+                pass
+        return name
+    elif isinstance(callable_, functools.partial):
         return _callable_description(callable_.func)
-    d = callable_.__name__
-    if d == "<lambda>":
-        try:
-            d = inspect.getsource(callable_)
-        except IOError:
-            pass
-    return d
+    else:
+        return repr(callable_)
 
 
 @contextmanager

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1005,15 +1005,13 @@ def _callable_description(callable_):
     '    lambda: stbt.press("OK"))\\n'
     >>> _callable_description(functools.partial(int, base=2))
     'int'
+    >>> _callable_description(functools.partial(functools.partial(int, base=2),
+    ...                                         x='10'))
+    'int'
     """
-    try:
-        d = callable_.__name__
-    except AttributeError:
-        if isinstance(callable_, functools.partial):
-            # functools.partial wraps the original function
-            d = callable_.func.__name__
-        else:
-            raise
+    if isinstance(callable_, functools.partial):
+        return _callable_description(callable_.func)
+    d = callable_.__name__
     if d == "<lambda>":
         try:
             d = inspect.getsource(callable_)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -59,6 +59,10 @@ UNRELEASED
 * Fixed "stb-tester fails with PyGObject 3.13" #305.  This will allow
   stb-tester to work out of the box on Ubuntu >= 14.10 and Fedora >= 21.
 
+* `wait_until` no longer raises an exception if you passed a
+  `functools.partial` object and `wait_until` timed out. Thanks to Martyn
+  Jarvis for the patch.
+
 ##### Developer-visible changes since 23
 
 #### 23


### PR DESCRIPTION
This extends the fix from #319  so that it also works with nested `functools.partial` objects.