### PR TITLE
stbt batch run: Store full test-pack sha in `git-commit-sha` artifact

### DIFF
--- a/stbt-batch.d/run-one
+++ b/stbt-batch.d/run-one
@@ -37,6 +37,7 @@ main() {
 
   test="$1" && shift &&
   testpath=$(realpath "$test") &&
+  test_script_dir=$(dirname "$testpath") &&
   mkdir -p "$outputdir" &&
   pushd "$outputdir" >/dev/null &&
   rundir=$(date +%Y-%m-%d_%H.%M.%S)"$tag" &&
@@ -53,11 +54,13 @@ main() {
 
   [ -n "$tag" ] && echo "Tag	${tag#-}" > extra-columns
 
-  ( cd "$(dirname "$testpath")" &&
-    git describe --always --dirty 2>/dev/null
-  ) > git-commit || rm -f git-commit
+  git -C "$test_script_dir" describe --always --dirty 2>/dev/null \
+    > git-commit || rm -f git-commit
 
-  ( cd "$(dirname "$testpath")" &&
+  git -C "$test_script_dir" rev-parse HEAD \
+    > git-commit-sha || rm -f git-commit-sha
+
+  ( cd "$test_script_dir" &&
     gitdir=$(dirname "$(realpath "$(git rev-parse --git-dir 2>/dev/null)")") &&
     echo "${testpath#$gitdir/}" || echo "$testpath"
   ) > test-name

--- a/tests/test-stbt-batch.sh
+++ b/tests/test-stbt-batch.sh
@@ -17,7 +17,7 @@ create_test_repo() {
 }
 
 validate_testrun_dir() {
-    local d="$1" testname="$2" commit="$3" extra_column="$4"
+    local d="$1" testname="$2" commit="$3" commit_sha="$4" extra_column="$5"
 
     [[ -f "$d/combined.log" ]] || fail "$d/combined.log not created"
     [[ $(cat "$d/exit-status") == 0 ]] || fail "wrong $d/exit-status"
@@ -27,6 +27,8 @@ validate_testrun_dir() {
     [[ -f "$d/thumbnail.jpg" ]] || fail "$d/thumbnail.jpg not created"
     if [[ -n "$commit" ]]; then
         [[ $(cat "$d/git-commit") == "$commit" ]] || fail "wrong $d/git-commit"
+        [[ $(cat "$d/git-commit-sha") == "$expected_commit_sha" ]] \
+            || fail "wrong $d/git-commit-sha"
     fi
     if [[ -n "$extra_column" ]]; then
         grep -q "$extra_column" "$d/extra-columns" || fail "extra column not in $d/extra-columns"
@@ -34,7 +36,7 @@ validate_testrun_dir() {
 }
 
 validate_html_report() {
-    local d="$1" testname="$2" commit="$3" extra_column="$4"
+    local d="$1" testname="$2" commit="$3" commit_sha="$4" extra_column="$5"
 
     [[ -f "$d/index.html" ]] || fail "$d/index.html not created"
     [[ -f index.html ]] || fail "index.html not created"
@@ -56,10 +58,11 @@ test_stbt_batch_run_once() {
         fail "stbt batch run failed"
     } | sed 's/^/stbt batch run: /'
 
-    local expected_commit="$(cd tests && git describe --always)"
+    local expected_commit="$(git -C tests describe --always)"
+    local expected_commit_sha="$(git -C tests rev-parse HEAD)"
 
-    validate_testrun_dir "latest-my label" test.py "$expected_commit" "my label"
-    validate_html_report "latest-my label" test.py "$expected_commit" "my label"
+    validate_testrun_dir "latest-my label" test.py "$expected_commit" "$expected_commit_sha" "my label"
+    validate_html_report "latest-my label" test.py "$expected_commit" "$expected_commit_sha" "my label"
 }
 
 test_that_stbt_batch_run_will_run_a_specific_function() {


### PR DESCRIPTION
In the results view you can search by test-pack sha, so this will allow
you to search by the complete sha.

`--abbrev=40` shows the full 40-character sha instead of abbreviating it
to the shortest unambiguous prefix (unambiguous at the time that `git
describe` was run; as more commits are added it might have become
ambiguous).

`--long` shows the sha even if the head exactly matches a tag.

I considered changing this to `git rev-parse HEAD` but then we'd lose
the "dirty" information.