### PR TITLE
Require the right gi module versions before importing them to avoid warning messages

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -31,14 +31,14 @@ import cv2
 import gi
 import numpy
 from enum import IntEnum
+
+gi.require_version("Gst", "1.0")
 from gi.repository import GLib, GObject, Gst  # pylint: disable=E0611
 
 from _stbt import logging, utils
 from _stbt.config import ConfigurationError, get_config
 from _stbt.gst_hacks import gst_iterate, map_gst_sample
 from _stbt.logging import ddebug, debug, warn
-
-gi.require_version("Gst", "1.0")
 
 if getattr(gi, "version_info", (0, 0, 0)) < (3, 12, 0):
     GObject.threads_init()

--- a/_stbt/gst_hacks.py
+++ b/_stbt/gst_hacks.py
@@ -3,6 +3,9 @@ import platform
 from contextlib import contextmanager
 from os.path import dirname
 
+import gi
+
+gi.require_version("Gst", "1.0")
 from gi.repository import Gst  # pylint: disable=E0611
 
 # Here we are using ctypes to call `gst_buffer_map` and `gst_buffer_unmap`

--- a/_stbt/gst_utils.py
+++ b/_stbt/gst_utils.py
@@ -1,5 +1,8 @@
 import sys
 
+import gi
+
+gi.require_version("Gst", "1.0")
 from gi.repository import GObject, Gst  # pylint: disable=E0611
 
 Gst.init([])

--- a/stbt-camera.d/stbt-camera-calibrate.py
+++ b/stbt-camera.d/stbt-camera-calibrate.py
@@ -510,6 +510,7 @@ v4l2videosrc = 'v4l2src device=%(v4l2_device)s extra-controls=%(v4l2_ctls)s'
 
 
 def list_cameras():
+    gi.require_version('GUdev', '1.0')
     from gi.repository import GUdev  # pylint: disable=E0611
     client = GUdev.Client.new(['video4linux/usb_device'])
     devices = client.query_by_subsystem('video4linux')

--- a/stbt-camera.d/stbt-camera-calibrate.py
+++ b/stbt-camera.d/stbt-camera-calibrate.py
@@ -12,7 +12,10 @@ from contextlib import contextmanager
 from os.path import dirname
 
 import cv2
+import gi
 import numpy
+
+gi.require_version("Gst", "1.0")
 from gi.repository import Gst  # pylint: disable=E0611
 
 import _stbt.core

--- a/stbt-camera.d/stbt-camera-validate.py
+++ b/stbt-camera.d/stbt-camera-validate.py
@@ -9,7 +9,10 @@ import sys
 from collections import namedtuple
 from os.path import abspath, dirname
 
+import gi
 import numpy
+
+gi.require_version("Gst", "1.0")
 from gi.repository import Gst  # pylint: disable=E0611
 
 from _stbt import tv_driver

--- a/tests/fake-video-src.py
+++ b/tests/fake-video-src.py
@@ -5,6 +5,9 @@ import os
 import sys
 import threading
 
+import gi
+
+gi.require_version("Gst", "1.0")
 from gi.repository import Gst
 
 from _stbt import gst_utils, utils


### PR DESCRIPTION
At
```py
  from gi.repository import Gst
```
the warning
```
  PyGIWarning: Gst was imported without specifying a version first. Use
  gi.require_version('Gst', '1.0') before import to ensure that the
  right version gets loaded.
```
is printed to standard error using gi 3.18.2 (GStreamer 1.6.2).

Add `require_version` before the import to avoid the warning message.