### PR TITLE
Debian packaging fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .stbt-prefix
 debian-packages
 defaults.conf
+extra/debian/changelog
 extra/fedora/stb-tester.spec
 extra/stb-tester*.debian.tar.xz
 extra/vm/.vagrant

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,8 +85,11 @@ Here are a few guidelines to keep in mind when submitting a pull request:
 
         * Debian:
 
-            * Build the package with `make deb`. (TODO: Docker script to build
-              the deb if your host system isn't Debian/Ubuntu.)
+            * Build the package with `make deb`. If you don't have an Ubuntu
+              14.04 host you can use `extra/debian/ubuntu-shell.sh -c "make
+              deb"` which spins up an Ubuntu container using docker (it will
+              leave the packages in `debian-packages/` under the stb-tester git
+              checkout on the host.
 
             * Test the deb package by running `make check-ubuntu`. It will use
               docker to install the deb package inside a pristine Ubuntu

--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ install-docs: stbt.1
 
 ### Debian Packaging #########################################################
 
-ubuntu_releases ?= trusty utopic
+ubuntu_releases ?= trusty vivid wily
 DPKG_OPTS?=
 debian_base_release=1
 debian_architecture=$(shell dpkg --print-architecture 2>/dev/null)

--- a/extra/debian/Dockerfile.in
+++ b/extra/debian/Dockerfile.in
@@ -1,0 +1,17 @@
+# Docker container running Ubuntu 14.04 for building & testing stb-tester debs
+# on Ubuntu.
+
+FROM ubuntu:14.04
+MAINTAINER David Röthlisberger "david@stb-tester.com"
+
+# Build dependencies:
+RUN apt-get update && \
+    apt-get install -y build-essential devscripts @BUILDDEPENDS@
+
+RUN adduser --gecos "" stb-tester && \
+    echo  "stb-tester	ALL=(ALL:ALL)	NOPASSWD:ALL" >/etc/sudoers.d/stb-tester
+
+USER stb-tester
+ENV HOME /home/stb-tester
+ENV LANG C.UTF-8
+WORKDIR /home/stb-tester

--- a/extra/debian/ubuntu-shell.sh
+++ b/extra/debian/ubuntu-shell.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Gives you a bash shell in an Ubuntu 14.04 container, with your stb-tester
+# working copy available at (and $PWD set to) /home/stb-tester.
+
+build_docker_image() {
+    deps=$(sed -n '/^Build-Depends:/,/^$/ p' control |
+           sed -e 's/Build-Depends://' -e 's/(.*)//' |
+           tr -s '\n,' ' ')
+    cat Dockerfile.in |
+    sed "s/@BUILDDEPENDS@/$deps/" |
+    docker build -t stbtester/stb-tester-ubuntu-build-environment -
+}
+
+set -ex
+
+cd "$(dirname "$0")"
+
+build_docker_image
+
+exec docker run -ti --rm \
+    -v "$PWD"/../..:/home/stb-tester \
+    -v "$HOME"/.gitconfig:/home/stb-tester/.gitconfig:ro \
+    -v "$HOME"/.gnupg:/home/stb-tester/.gnupg \
+    stbtester/stb-tester-ubuntu-build-environment \
+    /bin/bash "$@"


### PR DESCRIPTION
While trying to publish ppa packages for Ubuntu 15.04 and 15.10, I've run across an issue that caused `extra/debian/build-source-package.sh` to fail: Somewhere between Ubuntu 14.04 and 15.04, `dpkg` defaults to creating `.tar.xz` files instead of `.tar.gz` files, but our script expected the latter.

This pull request adds a script to build the packages in a docker container (Ubuntu 14.04) to avoid such incompatibilities. Similar to what we already have for building Fedora packages.

TODO:

- [x] Get the new packages actually published (dput says "Successfully uploaded packages" but I've yet to see them appear on launchpad).