### PR TITLE
stbt batch run: Add --no-html-report option

### DIFF
--- a/stbt-batch.d/run-one
+++ b/stbt-batch.d/run-one
@@ -12,6 +12,7 @@
 #
 # Input environment variables:
 #
+# * $do_html_report ("true" or "false")
 # * $tag
 # * $v
 # * $verbose
@@ -63,7 +64,9 @@ main() {
 
   printf "%s\n" "$@" > test-args
 
-  "$runner"/report --html-only . >/dev/null
+  if $do_html_report; then
+    "$runner"/report --html-only . >/dev/null
+  fi
 
   user_command pre_run start
 
@@ -117,7 +120,9 @@ main() {
     user_command recover || touch unrecoverable-error
   fi
 
-  "$runner"/report --html-only . >/dev/null
+  if $do_html_report; then
+    "$runner"/report --html-only . >/dev/null
+  fi
 
   cd ..
   send_state_change active_results_directory null

--- a/stbt-batch.d/run.py
+++ b/stbt-batch.d/run.py
@@ -51,6 +51,12 @@ def main(argv):
         '--shuffle', action="store_true", help=(
             "Run the test cases in a random order attempting to spend the same "
             "total amount of time executing each test case."))
+    parser.add_argument(
+        '--no-html-report', action='store_true', help="""
+            Don't generate an HTML report after each testrun; generating the
+            report can be slow if there are many results in the output
+            directory. You can still generate the HTML reports afterwards with
+            'stbt batch report'.""")
     parser.add_argument('test_name', nargs=argparse.REMAINDER)
     args = parser.parse_args(argv[1:])
 
@@ -98,6 +104,7 @@ def main(argv):
             break
         run_count += 1
         subenv = dict(os.environ)
+        subenv['do_html_report'] = "false" if args.no_html_report else "true"
         subenv['tag'] = tag
         subenv['v'] = '-vv' if args.debug else '-v'
         subenv['verbose'] = str(args.verbose)


### PR DESCRIPTION
Previously we generate an HTML report before each testrun (so that the
report shows a "running..." row for the current test) and again after
the testrun (to update that row with the test's result). This report
generation gets slower as you have more results because it scans all the
results in the output directory each time.

If you have your own reporting system (such as the stb-tester ONE's
database-backed results system), this report generation is superfluous
and only slows things down.

Apart from the "index.html" inside the testrun directory and the
"index.html" one directory above it (at the root of the output
directory), no other files are affected. That is, the result format on
disk hasn't changed.