### PR TITLE
stbt batch: Fix report generation when output directory name has spaces

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -69,6 +69,9 @@ UNRELEASED
   `functools.partial` object and `wait_until` timed out. Thanks to Martyn
   Jarvis for the patch.
 
+* `stbt batch run` wasn't generating HTML reports if you gave it an `--output`
+  directory name with spaces.
+
 ##### Developer-visible changes since 23
 
 #### 23

--- a/stbt-batch.d/report
+++ b/stbt-batch.d/report
@@ -12,6 +12,8 @@
 #/ Generates a detailed report in <testrun directory>/index.html
 #/ and a summary report in <testrun directory>/../index.html.
 
+IFS=$'\n'
+
 usage() { grep '^#/' "$0" | cut -c4-; }
 
 main() {

--- a/tests/test-stbt-batch.sh
+++ b/tests/test-stbt-batch.sh
@@ -37,18 +37,19 @@ validate_testrun_dir() {
 
 validate_html_report() {
     local d="$1" testname="$2" commit="$3" commit_sha="$4" extra_column="$5"
+    local results_root=$(dirname "$d")
 
     [[ -f "$d/index.html" ]] || fail "$d/index.html not created"
-    [[ -f index.html ]] || fail "index.html not created"
+    [[ -f "$results_root/index.html" ]] || fail "$results_root/index.html not created"
     grep -q "$testname" "$d/index.html" || fail "test name not in $d/index.html"
-    grep -q "$testname" index.html || fail "test name not in index.html"
+    grep -q "$testname" "$results_root/index.html" || fail "test name not in $results_root/index.html"
     if [[ -n "$commit" ]]; then
         grep -q "$commit" "$d/index.html" || fail "git commit not in $d/index.html"
-        grep -q "$commit" index.html || fail "git commit not in index.html"
+        grep -q "$commit" "$results_root/index.html" || fail "git commit not in $results_root/index.html"
     fi
     if [[ -n "$extra_column" ]]; then
         grep -q "$extra_column" "$d/index.html" || fail "extra column not in $d/index.html"
-        grep -q "$extra_column" index.html || fail "extra column not in index.html"
+        grep -q "$extra_column" "$results_root/index.html" || fail "extra column not in $results_root/index.html"
     fi
 }
 
@@ -457,14 +458,16 @@ test_that_stbt_batch_reports_results_directory() {
 
 test_stbt_batch_output_dir() {
     create_test_repo
-    mkdir "my results"
-    stbt batch run -1 -o "my-results" tests/test.py tests/test2.py \
+    stbt batch run -1 -o "my results" tests/test.py tests/test2.py \
         || fail "Tests should succeed"
 
-    [[ -f "my-results"/index.html ]] || fail "'my-results/index.html' not created"
+    [[ -f "my results"/index.html ]] || fail "'my results/index.html' not created"
     ! [[ -f index.html ]] || fail "index.html created in current directory"
-    grep -q test.py "my-results"/*/test-name || fail "First test's results not in 'my-results'"
-    grep -q test2.py "my-results"/*/test-name || fail "Second test's results not in 'my-results'"
+    grep -q test.py "my results"/*/test-name || fail "First test's results not in 'my results'"
+    grep -q test2.py "my results"/*/test-name || fail "Second test's results not in 'my results'"
+
+    validate_testrun_dir "my results/latest" test2.py
+    validate_html_report "my results/latest" test2.py
 }
 
 test_printing_unicode_characters_in_scripts() {


### PR DESCRIPTION
The failure was at line 65 of `stbt-batch.d/report`:

61: for resultsdir in $(
62:   for rundir in "$@"; do dirname "$(abspath "$rundir")"; done | sort | uniq)
63: do
64:   (
65:     cd "$resultsdir" || die "Invalid directory '$resultsdir'"

If you used `stbt batch -o 'my results'` it would fail with:

> report: error: Invalid directory '/path/to/my'
> report: error: Invalid directory 'results'

`stbt batch run` would continue to run the tests, but no HTML report
would be generated.