### PR TITLE
Fix for Popen Error

### DIFF
--- a/stbt_virtual_stb.py
+++ b/stbt_virtual_stb.py
@@ -47,7 +47,7 @@ def virtual_stb(command, x_keymap=None, verbose=False):
             stderr=subprocess.STDOUT)
 
         os.environ['DISPLAY'] = display
-        child = subprocess.Popen(command)
+        child = subprocess.Popen(command, shell=True)
 
         try:
             config = {


### PR DESCRIPTION
When running on OS X this is needed otherwise it throws:
```
OSError: [Errno 2] No such file or directory
```