### PR TITLE
core: Fix path in error message if template image not found

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -480,8 +480,8 @@ def _load_template(template):
         return _AnnotatedTemplate(template, None, None)
     else:
         template_name = _find_path(template)
-        if not os.path.isfile(template_name):
-            raise UITestError("No such template file: %s" % template_name)
+        if not template_name or not os.path.isfile(template_name):
+            raise UITestError("No such template file: %s" % template)
         image = cv2.imread(template_name, cv2.CV_LOAD_IMAGE_COLOR)
         if image is None:
             raise UITestError("Failed to load template file: %s" %
@@ -2124,14 +2124,17 @@ def _find_path(image):
             return os.path.abspath(caller_image)
 
     # Fall back to image from cwd, for convenience of the selftests
-    return os.path.abspath(image)
+    if os.path.isfile(image):
+        return os.path.abspath(image)
+
+    return None
 
 
 def _load_mask(mask):
     """Loads the given mask file and returns it as an OpenCV image."""
     mask_path = _find_path(mask)
     debug("Using mask %s" % mask_path)
-    if not os.path.isfile(mask_path):
+    if not mask_path or not os.path.isfile(mask_path):
         raise UITestError("No such mask file: %s" % mask)
     mask_image = cv2.imread(mask_path, cv2.CV_LOAD_IMAGE_GRAYSCALE)
     if mask_image is None:

--- a/tests/test-match.sh
+++ b/tests/test-match.sh
@@ -34,7 +34,10 @@ test_wait_for_match_nonexistent_template() {
     cat > test.py <<-EOF
 	wait_for_match("idontexist.png")
 	EOF
-    ! stbt run -v test.py
+    ! stbt run -v test.py &> test.log || fail "Test should have failed"
+    grep -q "No such template file: idontexist.png" test.log ||
+        fail "Expected 'No such template file: idontexist.png' but saw '$(
+            grep 'No such template file' test.log | head -n1)'"
 }
 
 test_wait_for_match_opencv_image_can_be_used_as_template() {

--- a/tests/test-motion.sh
+++ b/tests/test-motion.sh
@@ -49,10 +49,12 @@ test_wait_for_motion_nonexistent_mask() {
 	press("OK")
 	wait_for_motion(mask="idontexist.png")
 	EOF
-    timeout 10 stbt run -v test.py
+    timeout 10 stbt run -v test.py &> test.log
     local ret=$?
-    echo "return code: $ret"
-    [ $ret -ne $timedout -a $ret -ne 0 ]
+    [ $ret -ne $timedout -a $ret -ne 0 ] || fail "Unexpected exit status $ret"
+    grep -q "No such mask file: idontexist.png" test.log ||
+        fail "Expected 'No such mask file: idontexist.png' but saw '$(
+            grep 'No such mask file' test.log | head -n1)'"
 }
 
 test_wait_for_motion_with_high_noisethreshold_reports_motion() {


### PR DESCRIPTION
...in calls to `match`, `wait_for_match`, etc.

Before, this would show an absolute path from wherever the tests were
run, for example if you had the code `match("images/abc.png")` and you
ran it with `stbt batch -o /results` it would say "No such template
file: /results/2015-02-11_17.29.03/images/abc.png". Now it says "No such
template file: images/abc.png".