### PR TITLE
librification: Remove global state from _stbt

### DIFF
--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -15,7 +15,6 @@ import _stbt.core
 from _stbt.core import \
     as_precondition, \
     debug, \
-    get_config, \
     ConfigurationError, \
     MatchParameters, \
     MatchResult, \
@@ -429,6 +428,18 @@ def is_screen_black(frame=None, mask=None, threshold=None):
     explicitly by the caller.
     """
     return _dut.is_screen_black(frame, mask, threshold)
+
+
+def get_config(section, key, default=None, type_=str):
+    """Read the value of `key` from `section` of the stbt config file.
+
+    See 'CONFIGURATION' in the stbt(1) man page for the config file search
+    path.
+
+    Raises `ConfigurationError` if the specified `section` or `key` is not
+    found, unless `default` is specified (in which case `default` is returned).
+    """
+    return _dut.get_config(section, key, default, type_)
 
 
 def init_run(


### PR DESCRIPTION
The `get/set_config` mechanism is a way of storing state in configuration files.  This state is global, meaning that you couldn't have different devices under test configured separately in the same process.

This commit fixes that issue by pulling a config object into the `DeviceUnderTest` class.  This is a fairly blunt approach but it works for now.  Perhaps in the future the specific keys that the `DeviceUnderTest` class needs can be directly injected.

I'm not 100% sold on this change yet, but I've created this PR as a place to discuss.  This is obviously related to #297, although I'm not planning on ticking all the rest of the items from there off immediately.