### PR TITLE
stbt-run: Don't install a trace handler if it's not necessary

### DIFF
--- a/_stbt/pylint_plugin.py
+++ b/_stbt/pylint_plugin.py
@@ -44,7 +44,7 @@ class StbtChecker(BaseChecker):
     }
 
     def visit_const(self, node):
-        if (type(node.value) is str and
+        if (isinstance(node.value, str) and
                 re.search(r'.+\.png$', node.value) and
                 not _is_calculated_value(node) and
                 not _is_pattern_value(node) and
@@ -56,7 +56,7 @@ class StbtChecker(BaseChecker):
     def visit_callfunc(self, node):
         if re.search(r"\b(is_screen_black|match|match_text|ocr|wait_until)$",
                      node.func.as_string()):
-            if type(node.parent) == Discard:
+            if isinstance(node.parent, Discard):
                 for inferred in node.func.infer():
                     if inferred.root().name in ('stbt', '_stbt.core'):
                         self.add_message(
@@ -69,7 +69,7 @@ class StbtChecker(BaseChecker):
                     # Note that when `infer()` fails it returns `YES` which
                     # returns True to everything (including `callable()`).
                     if inferred.callable() and not (
-                            type(arg) is CallFunc and inferred == YES):
+                            isinstance(arg, CallFunc) and inferred == YES):
                         break
                 else:
                     self.add_message('E7003', node=node, args=arg.as_string())
@@ -77,9 +77,9 @@ class StbtChecker(BaseChecker):
 
 def _is_calculated_value(node):
     return (
-        type(node.parent) is BinOp or
-        (type(node.parent) is CallFunc and
-         type(node.parent.func) is Getattr and
+        isinstance(node.parent, BinOp) or
+        (isinstance(node.parent, CallFunc) and
+         isinstance(node.parent.func, Getattr) and
          node.parent.func.attrname == 'join'))
 
 
@@ -93,7 +93,7 @@ def _is_whitelisted_name(filename):
 
 def _in_whitelisted_functions(node):
     return (
-        type(node.parent) is CallFunc and
+        isinstance(node.parent, CallFunc) and
         node.parent.func.as_string() in (
             "cv2.imwrite",
             "re.match",

--- a/_stbt/state_watch.py
+++ b/_stbt/state_watch.py
@@ -7,7 +7,6 @@ from cStringIO import StringIO
 
 from _stbt import utils
 
-
 _TRACER = None
 
 

--- a/_stbt/utils.py
+++ b/_stbt/utils.py
@@ -1,9 +1,9 @@
 import errno
 import os
+import sys
 import tempfile
 from contextlib import contextmanager
 from shutil import rmtree
-import sys
 
 
 def mkdir_p(d):

--- a/_stbt/utils.py
+++ b/_stbt/utils.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 from contextlib import contextmanager
 from shutil import rmtree
+import sys
 
 
 def mkdir_p(d):
@@ -27,3 +28,31 @@ def named_temporary_directory(
         yield dirname
     finally:
         rmtree(dirname)
+
+
+def import_by_filename(filename_):
+    module_dir, module_file = os.path.split(filename_)
+    module_name, module_ext = os.path.splitext(module_file)
+    if module_ext != '.py':
+        raise ImportError("Invalid module filename '%s'" % filename_)
+    sys.path = [os.path.abspath(module_dir)] + sys.path
+    return __import__(module_name)
+
+
+def parse_test_uri(test_uri):
+    """Deconstruct a given `test_uri` into its component parts.
+
+    Returns (<str> abspath, <str> function name, <callable> function).
+
+    If `test_uri` is simply a filepath then the return is
+    (abspath(`test_uri`), "", None)
+    """
+    if '::' in test_uri:
+        filename, funcname = test_uri.split('::', 1)
+        absfilename = os.path.abspath(filename)
+        module = import_by_filename(filename)
+        function = getattr(module, funcname)
+    else:
+        absfilename = os.path.abspath(test_uri)
+        funcname, function = "", None
+    return absfilename, funcname, function

--- a/stbt-run
+++ b/stbt-run
@@ -14,6 +14,7 @@ import traceback
 import _stbt.core
 import stbt
 from _stbt.state_watch import new_state_sender
+from _stbt.utils import parse_test_uri
 
 parser = _stbt.core.argparser()
 parser.prog = 'stbt run'
@@ -72,14 +73,6 @@ def _print_exc_utf8(file_=None):
         traceback._some_str = _old_some_str
 
 
-def import_by_filename(filename_):
-    module_dir, module_file = os.path.split(filename_)
-    module_name, module_ext = os.path.splitext(module_file)
-    if module_ext != '.py':
-        raise ImportError("Invalid module filename '%s'" % filename_)
-    sys.path = [os.path.abspath(module_dir)] + sys.path
-    return __import__(module_name)
-
 _tracer = None
 try:
     # pylint: disable=W0611
@@ -90,25 +83,19 @@ try:
         stbt.get_config('global', 'transformation_pipeline'))
     _tracer = new_state_sender(args.save_trace)  # pylint: disable=W0212
 
-    _absfilename = None
+    _absfilename, funcname, function = parse_test_uri(args.script)
 
     def tracefunc(frame_, event, _):
         if event == "line" and frame_.f_code.co_filename == _absfilename:
             _tracer.log_current_line(frame_.f_code.co_filename, frame_.f_lineno)
         return tracefunc
 
-    if '::' in args.script:
-        _filename, funcname = args.script.split('::', 1)
-        _absfilename = os.path.abspath(_filename)
-        module = import_by_filename(_filename)
-        function = getattr(module, funcname)
-        _tracer.log_test_starting(args.script, _filename, funcname,
+    if function is not None:
+        _tracer.log_test_starting(args.script, _absfilename, funcname,
                                   function.func_code.co_firstlineno)
         sys.settrace(tracefunc)
         function()
     else:
-        _filename = os.path.abspath(args.script)
-        _absfilename = os.path.abspath(_filename)
         _tracer.log_test_starting(args.script, args.script, "", 1)
         sys.settrace(tracefunc)
 
@@ -122,8 +109,8 @@ try:
             debug, UITestError, UITestFailure, MatchTimeout, MotionTimeout,
             ConfigurationError)
         __file__ = args.script
-        sys.path.insert(0, os.path.dirname(_filename))
-        execfile(_filename)
+        sys.path.insert(0, os.path.dirname(_absfilename))
+        execfile(_absfilename)
 except Exception as e:  # pylint: disable=W0703
     from kitchen.text.converters import exception_to_bytes
     error_message = exception_to_bytes(e)

--- a/stbt-run
+++ b/stbt-run
@@ -13,8 +13,10 @@ import traceback
 
 import _stbt.core
 import stbt
-from _stbt.state_watch import new_state_sender
+from _stbt import state_watch
 from _stbt.utils import parse_test_uri
+
+TO_SOCKET = 'TO_SOCKET'
 
 parser = _stbt.core.argparser()
 parser.prog = 'stbt run'
@@ -23,7 +25,7 @@ parser.add_argument(
     '--save-video', help='Record video to the specified file', metavar='FILE',
     default=stbt.get_config('run', 'save_video'))
 parser.add_argument(
-    '--save-trace', metavar='FILE', default=None,
+    '--save-trace', metavar='FILE', nargs='?', const=TO_SOCKET,
     help='Write state to this file, as xz compressed newline-seperated JSON')
 parser.add_argument(
     'script', metavar='FILE[::TESTCASE]', help=(
@@ -73,7 +75,6 @@ def _print_exc_utf8(file_=None):
         traceback._some_str = _old_some_str
 
 
-_tracer = None
 try:
     # pylint: disable=W0611
 
@@ -81,24 +82,17 @@ try:
         args.source_pipeline, args.sink_pipeline, args.control,
         args.save_video, args.restart_source,
         stbt.get_config('global', 'transformation_pipeline'))
-    _tracer = new_state_sender(args.save_trace)  # pylint: disable=W0212
 
     _absfilename, funcname, function = parse_test_uri(args.script)
 
-    def tracefunc(frame_, event, _):
-        if event == "line" and frame_.f_code.co_filename == _absfilename:
-            _tracer.log_current_line(frame_.f_code.co_filename, frame_.f_lineno)
-        return tracefunc
+    if args.save_trace:
+        trace_file = \
+            args.save_trace if args.save_trace is not TO_SOCKET else None
+        state_watch.activate(args.script, trace_file=trace_file)
 
     if function is not None:
-        _tracer.log_test_starting(args.script, _absfilename, funcname,
-                                  function.func_code.co_firstlineno)
-        sys.settrace(tracefunc)
         function()
     else:
-        _tracer.log_test_starting(args.script, args.script, "", 1)
-        sys.settrace(tracefunc)
-
         # pylint: disable=W0612
         from stbt import (
             # For backwards compatibility. We want to encourage people to expli-
@@ -134,8 +128,5 @@ except Exception as e:  # pylint: disable=W0703
     else:
         sys.exit(2)  # Error
 finally:
-    sys.settrace(None)
-    if _tracer:
-        _tracer.log_test_ended()
-        _tracer.close()
+    state_watch.deactivate()
     stbt.teardown_run()

--- a/tests/test-stbt-run.sh
+++ b/tests/test-stbt-run.sh
@@ -223,7 +223,7 @@ assert_correct_unicode_error() {
 		FAIL: test.py: AssertionError: ü
 		Traceback (most recent call last):
 		  File ".../stbt-run", line ..., in <module>
-		    execfile(_filename)
+		    execfile(_absfilename)
 		  File "...", line 2, in <module>
 		    assert False, $u"ü"
 		AssertionError: ü

--- a/tests/test-stbt-run.sh
+++ b/tests/test-stbt-run.sh
@@ -212,7 +212,7 @@ test_that_stbt_run_tracing_is_written_to_socket() {
     SOCAT_PID=$!
     sleep 1
 
-    run_state_test || fail "Test failed"
+    run_state_test --save-trace -- || fail "Test failed"
     kill "$SOCAT_PID"
     grep -q "state_change" "trace.jsonl" || fail "state_change not written"
     diff expected_states <(state_printer <"trace.jsonl") || fail "Wrong states"

--- a/tests/test_stbt_utils.py
+++ b/tests/test_stbt_utils.py
@@ -1,0 +1,28 @@
+from fnmatch import fnmatch
+from tempfile import NamedTemporaryFile
+
+from _stbt import utils
+
+
+def test_parse_test_uri__just_filepath():
+    with NamedTemporaryFile(prefix='my_test_', suffix='.py') as test_file:
+        abspath, funcname, func = utils.parse_test_uri(test_file.name)
+
+    assert fnmatch(abspath, '*/my_test_*.py')
+    assert funcname == ''
+    assert func is None
+
+
+def test_parse_test_uri__module_and_function():
+    with NamedTemporaryFile(prefix='my_test_', suffix='.py') as test_file:
+        test_file.file.writelines([
+            'def test_make_snafucate():',
+            '    pass',
+        ])
+        test_file.file.flush()
+        abspath, funcname, func = \
+            utils.parse_test_uri("%s::test_make_snafucate" % test_file.name)
+
+    assert fnmatch(abspath, '*/my_test_*.py')
+    assert funcname == 'test_make_snafucate'
+    assert callable(func) and func.func_name == 'test_make_snafucate'


### PR DESCRIPTION
We're attempting to forward-port our own patches onto a new version of STBT, and in doing so found a clash between our trace and stbt's build in tracer (https://github.com/stb-tester/stb-tester/commit/fa60ea989c9d87e82af04eaaab76cfe6409d194b). The other commits are tidy-ups.

I wasn't able to get `make check` to pass fully because of failures with the virtual-stb tests: 

> /usr/libexec/Xorg.wrap: Only console users are allowed to run the X server
