### PR TITLE
Makefile: Add `make shell`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ extra/stb-tester*.debian.tar.xz
 extra/vm/.vagrant
 irnetbox-proxyc
 nosetest-issue-49-workaround-stbt-control.py
+pip/
 rpmbuild
 stb-tester-*.tar.gz
 stb-tester_*.deb

--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,22 @@ sq = $(subst ','\'',$(1)) # function to escape single quotes (')
 TAGS:
 	etags stbt/**.py _stbt/**.py
 
-shell:
+pip/usr/local/bin/parallel:
+	cd pip && \
+	{ \
+	    wget http://ftpmirror.gnu.org/parallel/parallel-20140522.tar.bz2 || \
+	    wget http://ftp.gnu.org/gnu/parallel/parallel-20140522.tar.bz2 || \
+	    exit 0; \
+	} && \
+	tar -xvf parallel-20140522.tar.bz2 && \
+	cd parallel-20140522/ && \
+	./configure --prefix=$(CURDIR)/pip/usr/local && \
+	make && \
+	make install && \
+	rm -rf $(CURDIR)/pip/parallel-20140522.tar.bz2 $(CURDIR)/pip/parallel-20140522 && \
+	parallel --bibtex
+
+shell: pip/usr/local/bin/parallel
 	pip install --root=$(CURDIR)/pip \
 	    astroid==1.2.1 \
 	    isort==3.9.0 \

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ check: check-pylint check-nosetests check-integrationtests check-bashcompletion
 check-nosetests: tests/ocr/menu.png
 	# Workaround for https://github.com/nose-devs/nose/issues/49:
 	cp stbt-control nosetest-issue-49-workaround-stbt-control.py && \
-	PYTHONPATH=$$PWD NOSE_REDNOSE=1 \
+	PYTHONPATH=$$PWD:$$PYTHONPATH NOSE_REDNOSE=1 \
 	nosetests --with-doctest -v --match "^test_" \
 	    --doctest-options=+ELLIPSIS \
 	    $(shell git ls-files '*.py' |\
@@ -171,7 +171,7 @@ check-hardware: install-for-test
 	tests/run-tests.sh -i tests/hardware/test-hardware.sh
 check-pylint:
 	printf "%s\n" $(PYTHON_FILES) \
-	| PYTHONPATH=$$PWD $(parallel) extra/pylint.sh
+	| PYTHONPATH=$$PWD:$$PYTHONPATH $(parallel) extra/pylint.sh
 check-bashcompletion:
 	@echo Running stbt-completion unit tests
 	@bash -c ' \
@@ -234,6 +234,18 @@ sq = $(subst ','\'',$(1)) # function to escape single quotes (')
 
 TAGS:
 	etags stbt/**.py _stbt/**.py
+
+shell:
+	pip install --root=$(CURDIR)/pip \
+	    astroid==1.2.1 \
+	    isort==3.9.0 \
+	    pylint==1.3.1 \
+	    rednose \
+	    responses==0.5.1
+	PATH=$(CURDIR)/pip/usr/local/bin:$$PATH \
+	PYTHONPATH=$(CURDIR)/pip/usr/local/lib/python2.7/dist-packages/:$$PYTHONPATH \
+	exec bash -i
+
 
 ### Documentation ############################################################
 


### PR DESCRIPTION
This is intended as a kind of virtualenv-lite.  It installs the
dev-dependencies that often change in incompatible ways into a
subdirectory pinned at the versions we use in CI.

Unlike a virtualenv we rely on the system packages for our runtime
dependencies because they are more stable and we want to be compatible
with these packages on as many systems as practical.
