### PR TITLE
Fix wait_for_motion visualisation with recent numpy

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -732,7 +732,7 @@ class DeviceUnderTest(object):
                         frame,
                         numpy.multiply(
                             numpy.ones(frame.shape, dtype=numpy.uint8),
-                            (0, 0, 255),  # bgr
+                            numpy.array((0, 0, 255), dtype=numpy.uint8),  # bgr
                             dtype=numpy.uint8),
                         mask=cv2.dilate(
                             thresholded,


### PR DESCRIPTION
On my machine with numpy 1.10.4 the `wait_for_motion` tests were failing
with:

    Traceback (most recent call last):
     /usr/lib/python2.7/dist-packages/nose/case.py line 197 in runTest
       self.test(*self.arg)
     .../_stbt/core.py line 2385 in test_wait_for_motion_half_motion_int
       dut.wait_for_motion(consecutive_frames=2)
     .../_stbt/core.py line 827 in wait_for_motion
       for res in self.detect_motion(timeout_secs, noise_threshold, mask):
     .../_stbt/core.py line 736 in detect_motion
       dtype=numpy.uint8),
    TypeError: Cannot cast ufunc multiply input from dtype('int64') to dtype('uint8') with casting rule 'same_kind'

This is due to a change to the default casting rule in 1.10.  The
[release notes] say:

> **Default casting rule change**
>
> Default casting for inplace operations has changed to `'same_kind'`.

[release notes]: https://github.com/numpy/numpy/blob/master/doc/release/1.10.0-notes.rst#default-casting-rule-change