### PR TITLE
Tests: Fix make check with numpy 1.10

### DIFF
--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -475,7 +475,7 @@ test_template_annotation_with_ndarray_template() {
     cat > test.py <<-EOF &&
 	import stbt, numpy as np
 	template = np.ones(shape=(100, 100, 3), dtype=np.uint8)
-	template *= [0, 255, 0]  # green
+	template *= np.array([0, 255, 0], dtype=np.uint8)  # green
 	stbt.save_frame(template, 'template.png')
 	for _ in stbt.detect_match(template):
 	    pass


### PR DESCRIPTION
This is another fix in the vein of e40ea49.  Without this change the
`test_template_annotation_with_ndarray_template` test would hang
indefinitely with numpy 1.10.  This is due to a change to the default
casting rule.  The [release notes] say:

> **Default casting rule change**
>
> Default casting for inplace operations has changed to `'same_kind'`.

[release notes]: https://github.com/numpy/numpy/blob/master/doc/release/1.10.0-notes.rst#default-casting-rule-change