### PR TITLE
tests: Fix intermittent failure of test_that_press_waits...

### DIFF
--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -526,8 +526,8 @@ test_draw_text() {
 test_that_press_waits_between_subsequent_presses() {
     cat > test.py <<-EOF &&
 	import stbt, datetime
-	stbt.press('OK')
 	time1 = datetime.datetime.now()
+	stbt.press('OK')
 	stbt.press('OK', interpress_delay_secs=0.5)
 	time2 = datetime.datetime.now()
 	assert time2 - time1 >= datetime.timedelta(seconds=0.5), (


### PR DESCRIPTION
This was occasionally failing with:

> AssertionError: Expected: >= 0:00:00.5, got: 0:00:00.493187 between presses

press's timer starts inside the call to `press`, and the test's own
timer started after that, so there was a race condition.