### PR TITLE
Refactor image debug logging to use ImageLogger class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ INSTALL_CORE_FILES = \
     _stbt/control.py \
     _stbt/core.py \
     _stbt/gst_hacks.py \
+    _stbt/gst_utils.py \
     _stbt/irnetbox.py \
     _stbt/logging.py \
     _stbt/power.py \
@@ -331,7 +332,6 @@ $(info Smart TV support disabled)
 endif
 
 stbt_camera_files=\
-	_stbt/gst_utils.py \
 	_stbt/tv_driver.py \
 	stbt-camera \
 	stbt-camera.d/chessboard-720p-40px-border-white.png \

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -41,8 +41,6 @@ from _stbt.logging import ddebug, debug, warn
 gi.require_version("Gst", "1.0")
 from gi.repository import GLib, GObject, Gst  # isort:skip pylint: disable=E0611
 
-if getattr(gi, "version_info", (0, 0, 0)) < (3, 12, 0):
-    GObject.threads_init()
 Gst.init(None)
 
 warnings.filterwarnings(

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -35,7 +35,9 @@ from kitchen.text.converters import to_bytes
 
 from _stbt import logging, utils
 from _stbt.config import ConfigurationError, get_config
-from _stbt.gst_hacks import gst_iterate, map_gst_sample
+from _stbt.gst_hacks import gst_iterate
+from _stbt.gst_utils import (get_frame_timestamp, gst_sample_make_writable,
+                             numpy_from_sample)
 from _stbt.logging import ddebug, debug, warn
 
 gi.require_version("Gst", "1.0")
@@ -637,7 +639,7 @@ class DeviceUnderTest(object):
         if grabbed_from_live:
             frame = self._display.get_sample()
 
-        with _numpy_from_sample(frame, readonly=True) as npframe:
+        with numpy_from_sample(frame, readonly=True) as npframe:
             region = Region.intersect(_image_region(npframe), region)
 
             matched, match_region, first_pass_certainty = _match(
@@ -646,7 +648,7 @@ class DeviceUnderTest(object):
 
             match_region = match_region.translate(region.x, region.y)
             result = MatchResult(
-                _get_frame_timestamp(frame), matched, match_region,
+                get_frame_timestamp(frame), matched, match_region,
                 first_pass_certainty, numpy.copy(npframe),
                 (template.name or template.image))
 
@@ -689,7 +691,7 @@ class DeviceUnderTest(object):
             _log_image, directory="stbt-debug/detect_motion")
 
         for sample in self._display.gst_samples(timeout_secs):
-            with _numpy_from_sample(sample, readonly=True) as frame:
+            with numpy_from_sample(sample, readonly=True) as frame:
                 frame_gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
             log(frame_gray, "source")
 
@@ -725,7 +727,7 @@ class DeviceUnderTest(object):
 
             # Visualisation: Highlight in red the areas where we detected motion
             if motion:
-                with _numpy_from_sample(sample) as frame:
+                with numpy_from_sample(sample) as frame:
                     cv2.add(
                         frame,
                         numpy.multiply(
@@ -868,7 +870,7 @@ class DeviceUnderTest(object):
         if _tesseract_version() >= LooseVersion('3.04'):
             _config['tessedit_create_txt'] = 0
 
-        ts = _get_frame_timestamp(frame)
+        ts = get_frame_timestamp(frame)
 
         xml, region = _tesseract(frame, region, mode, lang, _config,
                                  user_words=text.split())
@@ -902,7 +904,7 @@ class DeviceUnderTest(object):
         return self._display.frames(timeout_secs)
 
     def get_frame(self):
-        with _numpy_from_sample(
+        with numpy_from_sample(
                 self._display.get_sample(), readonly=True) as frame:
             return frame.copy()
 
@@ -913,7 +915,7 @@ class DeviceUnderTest(object):
             mask = _load_mask(mask)
         if frame is None:
             frame = self._display.get_sample()
-        with _numpy_from_sample(frame, readonly=True) as f:
+        with numpy_from_sample(frame, readonly=True) as f:
             greyframe = cv2.cvtColor(f, cv2.COLOR_BGR2GRAY)
         _, greyframe = cv2.threshold(
             greyframe, threshold, 255, cv2.THRESH_BINARY)
@@ -940,7 +942,7 @@ def save_frame(image, filename):
     Takes an image obtained from `get_frame` or from the `screenshot`
     property of `MatchTimeout` or `MotionTimeout`.
     """
-    with _numpy_from_sample(image, readonly=True) as imagebuf:
+    with numpy_from_sample(image, readonly=True) as imagebuf:
         cv2.imwrite(filename, imagebuf)
 
 
@@ -1314,107 +1316,6 @@ def _mainloop():
               "is still alive!" if thread.isAlive() else "ok"))
 
 
-def _gst_sample_make_writable(sample):
-    if sample.get_buffer().mini_object.is_writable():
-        return sample
-    else:
-        return Gst.Sample.new(
-            sample.get_buffer().copy_region(
-                Gst.BufferCopyFlags.FLAGS | Gst.BufferCopyFlags.TIMESTAMPS |
-                Gst.BufferCopyFlags.META | Gst.BufferCopyFlags.MEMORY, 0,
-                sample.get_buffer().get_size()),
-            sample.get_caps(),
-            sample.get_segment(),
-            sample.get_info())
-
-
-@contextmanager
-def _numpy_from_sample(sample, readonly=False):
-    """
-    Allow the contents of a GstSample to be read (and optionally changed) as a
-    numpy array.  The provided numpy array is a view onto the contents of the
-    GstBuffer in the sample provided.  The data is only valid within the `with:`
-    block where this contextmanager is used so the provided array should not
-    be referenced outside the `with:` block.  If you want to use it elsewhere
-    either copy the data with `numpy.ndarray.copy()` or reference the GstSample
-    directly.
-
-    A `numpy.ndarray` may be passed as sample, in which case this
-    contextmanager is a no-op.  This makes it easier to create functions which
-    will accept either numpy arrays or GstSamples providing a migration path
-    for reducing copying in stb-tester.
-
-    :param sample:   Either a GstSample or a `numpy.ndarray` containing the data
-                     you wish to manipulate as a `numpy.ndarray`
-    :param readonly: bool. Determines whether you want to just read or change
-                     the data contained within sample.  If True the GstSample
-                     passed must be writeable or ValueError will be raised.
-                     Use `stbt.gst_sample_make_writable` to get a writable
-                     `GstSample`.
-
-    >>> s = Gst.Sample.new(Gst.Buffer.new_wrapped("hello"),
-    ...                    Gst.Caps.from_string("video/x-raw"), None, None)
-    >>> with _numpy_from_sample(s) as a:
-    ...     print a
-    [104 101 108 108 111]
-    """
-    if isinstance(sample, numpy.ndarray):
-        yield sample
-        return
-    if not isinstance(sample, Gst.Sample):
-        raise TypeError("numpy_from_gstsample must take a Gst.Sample or a "
-                        "numpy.ndarray.  Received a %s" % str(type(sample)))
-
-    caps = sample.get_caps()
-    flags = Gst.MapFlags.READ
-    if not readonly:
-        flags |= Gst.MapFlags.WRITE
-
-    with map_gst_sample(sample, flags) as buf:
-        array = numpy.frombuffer((buf), dtype=numpy.uint8)
-        array.flags.writeable = not readonly
-        if caps.get_structure(0).get_value('format') in ['BGR', 'RGB']:
-            array.shape = (caps.get_structure(0).get_value('height'),
-                           caps.get_structure(0).get_value('width'),
-                           3)
-        yield array
-
-
-def test_that_mapping_a_sample_readonly_gives_a_readonly_array():
-    Gst.init([])
-    s = Gst.Sample.new(Gst.Buffer.new_wrapped("hello"),
-                       Gst.Caps.from_string("video/x-raw"), None, None)
-    with _numpy_from_sample(s, readonly=True) as ro:
-        try:
-            ro[0] = 3
-            assert False, 'Writing elements should have thrown'
-        except (ValueError, RuntimeError):
-            # Different versions of numpy raise different exceptions
-            pass
-
-
-def test_passing_a_numpy_ndarray_as_sample_is_a_noop():
-    a = numpy.ndarray((5, 2))
-    with _numpy_from_sample(a) as m:
-        assert a is m
-
-
-def test_that_dimensions_of_array_are_according_to_caps():
-    s = Gst.Sample.new(Gst.Buffer.new_wrapped(
-        "row 1 4 px  row 2 4 px  row 3 4 px  "),
-        Gst.Caps.from_string("video/x-raw,format=BGR,width=4,height=3"),
-        None, None)
-    with _numpy_from_sample(s, readonly=True) as a:
-        assert a.shape == (3, 4, 3)
-
-
-def _get_frame_timestamp(frame):
-    if isinstance(frame, Gst.Sample):
-        return frame.get_buffer().pts
-    else:
-        return None
-
-
 class Display(object):
     def __init__(self, user_source_pipeline, user_sink_pipeline,
                  mainloop, save_video="",
@@ -1551,7 +1452,7 @@ class Display(object):
 
     def frames(self, timeout_secs=None):
         for sample in self.gst_samples(timeout_secs=timeout_secs):
-            with _numpy_from_sample(sample, readonly=True) as frame:
+            with numpy_from_sample(sample, readonly=True) as frame:
                 copy = frame.copy()
             yield (copy, sample.get_buffer().pts)
 
@@ -1575,7 +1476,7 @@ class Display(object):
                             timeout_secs * Gst.SECOND))
                         return
 
-                sample = _gst_sample_make_writable(sample)
+                sample = gst_sample_make_writable(sample)
                 try:
                     yield sample
                 finally:
@@ -1645,8 +1546,8 @@ class Display(object):
                 if now >= match_result.timestamp:
                     self.match_annotations.remove(match_result)
 
-        sample = _gst_sample_make_writable(sample)
-        with _numpy_from_sample(sample) as img:
+        sample = gst_sample_make_writable(sample)
+        with numpy_from_sample(sample) as img:
             _draw_text(
                 img, datetime.datetime.now().strftime("%H:%M:%S.%f")[:-4],
                 (10, 30), (255, 255, 255))
@@ -2075,7 +1976,7 @@ def _log_image(image, name, directory):
     except OSError:
         warn("Failed to create directory '%s'; won't save debug images." % d)
         return
-    with _numpy_from_sample(image, readonly=True) as img:
+    with numpy_from_sample(image, readonly=True) as img:
         if img.dtype == numpy.float32:
             img = cv2.convertScaleAbs(img, alpha=255)
         cv2.imwrite(os.path.join(d, name) + ".png", img)
@@ -2345,7 +2246,7 @@ def _tesseract(frame, region, mode, lang, _config,
     if _config is None:
         _config = {}
 
-    with _numpy_from_sample(frame, readonly=True) as f:
+    with numpy_from_sample(frame, readonly=True) as f:
         frame_region = Region(0, 0, f.shape[1], f.shape[0])
         intersection = Region.intersect(frame_region, region)
         if intersection is None:
@@ -2511,7 +2412,7 @@ def _fake_frames_at_half_motion():
             for i in range(10):
                 buf = Gst.Buffer.new_wrapped(data[(i // 2) % 2].flatten())
                 buf.pts = i * 1000000000
-                yield _gst_sample_make_writable(
+                yield gst_sample_make_writable(
                     Gst.Sample.new(buf, Gst.Caps.from_string(
                         'video/x-raw,format=BGR,width=2,height=2'), None, None))
 

--- a/_stbt/gst_utils.py
+++ b/_stbt/gst_utils.py
@@ -1,11 +1,116 @@
 import sys
+from contextlib import contextmanager
 
 import gi
+import numpy
+
+from .gst_hacks import map_gst_sample
 
 gi.require_version("Gst", "1.0")
 from gi.repository import GObject, Gst  # isort:skip pylint: disable=E0611
 
 Gst.init([])
+
+
+@contextmanager
+def numpy_from_sample(sample, readonly=False):
+    """
+    Allow the contents of a GstSample to be read (and optionally changed) as a
+    numpy array.  The provided numpy array is a view onto the contents of the
+    GstBuffer in the sample provided.  The data is only valid within the `with:`
+    block where this contextmanager is used so the provided array should not
+    be referenced outside the `with:` block.  If you want to use it elsewhere
+    either copy the data with `numpy.ndarray.copy()` or reference the GstSample
+    directly.
+
+    A `numpy.ndarray` may be passed as sample, in which case this
+    contextmanager is a no-op.  This makes it easier to create functions which
+    will accept either numpy arrays or GstSamples providing a migration path
+    for reducing copying in stb-tester.
+
+    :param sample:   Either a GstSample or a `numpy.ndarray` containing the data
+                     you wish to manipulate as a `numpy.ndarray`
+    :param readonly: bool. Determines whether you want to just read or change
+                     the data contained within sample.  If True the GstSample
+                     passed must be writeable or ValueError will be raised.
+                     Use `gst_sample_make_writable` to get a writable
+                     `GstSample`.
+
+    >>> s = Gst.Sample.new(Gst.Buffer.new_wrapped("hello"),
+    ...                    Gst.Caps.from_string("video/x-raw"), None, None)
+    >>> with numpy_from_sample(s) as a:
+    ...     print a
+    [104 101 108 108 111]
+    """
+    if isinstance(sample, numpy.ndarray):
+        yield sample
+        return
+    if not isinstance(sample, Gst.Sample):
+        raise TypeError("numpy_from_gstsample must take a Gst.Sample or a "
+                        "numpy.ndarray.  Received a %s" % str(type(sample)))
+
+    caps = sample.get_caps()
+    flags = Gst.MapFlags.READ
+    if not readonly:
+        flags |= Gst.MapFlags.WRITE
+
+    with map_gst_sample(sample, flags) as buf:
+        array = numpy.frombuffer((buf), dtype=numpy.uint8)
+        array.flags.writeable = not readonly
+        if caps.get_structure(0).get_value('format') in ['BGR', 'RGB']:
+            array.shape = (caps.get_structure(0).get_value('height'),
+                           caps.get_structure(0).get_value('width'),
+                           3)
+        yield array
+
+
+def test_that_mapping_a_sample_readonly_gives_a_readonly_array():
+    Gst.init([])
+    s = Gst.Sample.new(Gst.Buffer.new_wrapped("hello"),
+                       Gst.Caps.from_string("video/x-raw"), None, None)
+    with numpy_from_sample(s, readonly=True) as ro:
+        try:
+            ro[0] = 3
+            assert False, 'Writing elements should have thrown'
+        except (ValueError, RuntimeError):
+            # Different versions of numpy raise different exceptions
+            pass
+
+
+def test_passing_a_numpy_ndarray_as_sample_is_a_noop():
+    a = numpy.ndarray((5, 2))
+    with numpy_from_sample(a) as m:
+        assert a is m
+
+
+def test_that_dimensions_of_array_are_according_to_caps():
+    s = Gst.Sample.new(Gst.Buffer.new_wrapped(
+        "row 1 4 px  row 2 4 px  row 3 4 px  "),
+        Gst.Caps.from_string("video/x-raw,format=BGR,width=4,height=3"),
+        None, None)
+    with numpy_from_sample(s, readonly=True) as a:
+        assert a.shape == (3, 4, 3)
+
+
+def gst_sample_make_writable(sample):
+    if sample.get_buffer().mini_object.is_writable():
+        return sample
+    else:
+        return Gst.Sample.new(
+            sample.get_buffer().copy_region(
+                Gst.BufferCopyFlags.FLAGS | Gst.BufferCopyFlags.TIMESTAMPS |
+                Gst.BufferCopyFlags.META | Gst.BufferCopyFlags.MEMORY, 0,
+                sample.get_buffer().get_size()),
+            sample.get_caps(),
+            sample.get_segment(),
+            sample.get_info())
+
+
+def get_frame_timestamp(frame):
+    if isinstance(frame, Gst.Sample):
+        return frame.get_buffer().pts
+    else:
+        return None
 
 
 def frames_to_video(outfilename, frames, caps="image/svg",

--- a/stbt-camera.d/stbt_camera_calibrate.py
+++ b/stbt-camera.d/stbt_camera_calibrate.py
@@ -164,21 +164,21 @@ class NoChessboardError(Exception):
 
 
 def _find_chessboard(appsink, timeout=10):
+    from _stbt.gst_utils import numpy_from_sample
+
     sys.stderr.write("Searching for chessboard\n")
     success = False
     endtime = time.time() + timeout
     while not success and time.time() < endtime:
         sample = appsink.emit("pull-sample")
-        with _stbt.core._numpy_from_sample(sample, readonly=True) \
-                as input_image:
+        with numpy_from_sample(sample, readonly=True) as input_image:
             success, corners = cv2.findChessboardCorners(
                 input_image, (29, 15), flags=cv2.cv.CV_CALIB_CB_ADAPTIVE_THRESH)
 
     if success:
         # Refine the corner measurements (not sure why this isn't built into
         # findChessboardCorners?
-        with _stbt.core._numpy_from_sample(sample, readonly=True) \
-                as input_image:
+        with numpy_from_sample(sample, readonly=True) as input_image:
             grey_image = cv2.cvtColor(input_image, cv2.COLOR_BGR2GRAY)
 
         cv2.cornerSubPix(grey_image, corners, (5, 5), (-1, -1),

--- a/stbt-camera.d/stbt_camera_validate.py
+++ b/stbt-camera.d/stbt_camera_validate.py
@@ -88,7 +88,7 @@ def length(vec):
 
 
 def svg_to_array(svg):
-    from _stbt.core import _numpy_from_sample
+    from _stbt.gst_utils import numpy_from_sample
     pipeline = Gst.parse_launch(
         'appsrc name="src" caps="image/svg" ! rsvgdec ! '
         'videoconvert ! appsink caps="video/x-raw,format=BGR" name="sink"')
@@ -101,7 +101,7 @@ def svg_to_array(svg):
     src.emit("end-of-stream")
     pipeline.set_state(Gst.State.NULL)
     pipeline.get_state(0)
-    with _numpy_from_sample(sample, readonly=True) as frame:
+    with numpy_from_sample(sample, readonly=True) as frame:
         return frame.copy()
 
 

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -241,7 +241,7 @@ test_that_is_screen_black_writes_debugging_information() {
     [ -e "stbt-debug/is_screen_black/00001/source.png" ] \
         || fail "source debug image not written"
     [ -e "stbt-debug/is_screen_black/00001/non-black-regions-after-masking.png" ] \
-        || fail "source debug image not written"
+        || fail "masked debug image not written"
 }
 
 test_that_is_screen_black_with_mask_writes_debugging_information() {
@@ -259,9 +259,9 @@ test_that_is_screen_black_with_mask_writes_debugging_information() {
     [ -e "stbt-debug/is_screen_black/00001/source.png" ] \
         || fail "source debug image not written"
     [ -e "stbt-debug/is_screen_black/00001/mask.png" ] \
-        || fail "source debug image not written"
+        || fail "mask debug image not written"
     [ -e "stbt-debug/is_screen_black/00001/non-black-regions-after-masking.png" ] \
-        || fail "source debug image not written"
+        || fail "masked debug image not written"
 }
 
 test_that_wait_until_returns_on_success() {


### PR DESCRIPTION
Instead of writing debug images to disk directly, `match`, `detect_motion` and `is_screen_black` register the debug images with an instance of `ImageLogger`. Helper functions like `_find_match` are injected the `ImageLogger` instance (this is the observer pattern).

This is better because previously `_log_image` (which wrote images to disk) and `_log_image_descriptions` (which wrote an html file) communicated with each other via the filesystem -- `_log_image_descriptions` would list the files on disk to determine how many levels of pyramid-matching had happened. This would create incorrect html output if a previous invocation of `stbt run` had created 3 levels of debug screenshots in `stbt-debug/detect_match/00001/` but the current invocation had only created 1 level (because no match was found).

It's also less magical -- previously we incremented the frame counter when someone logged an image called "source.png". Now we increment the frame counter when you create a new instance of `ImageLogger`.

My motivation in doing this work is that I want to add additional logging for https://github.com/stb-tester/stb-tester/pull/212 so I want to simplify the code first.
