### PR TITLE
WIP: stbt.wait_for_motion, stbt.detect_motion: Add region parameter

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -675,7 +675,12 @@ class DeviceUnderTest(object):
             self._display.draw(result, None)
             yield result
 
-    def detect_motion(self, timeout_secs=10, noise_threshold=None, mask=None):
+    def detect_motion(self, timeout_secs=10, noise_threshold=None, mask=None,
+                      region=Region.ALL):
+
+        if mask is not None and region != Region.ALL:
+            raise ValueError("You can't specify both 'mask' and 'region'")
+
         if noise_threshold is None:
             noise_threshold = get_config(
                 'motion', 'noise_threshold', type_=float)
@@ -803,7 +808,10 @@ class DeviceUnderTest(object):
 
     def wait_for_motion(
             self, timeout_secs=10, consecutive_frames=None,
-            noise_threshold=None, mask=None):
+            noise_threshold=None, mask=None, region=Region.ALL):
+
+        if mask is not None and region != Region.ALL:
+            raise ValueError("You can't specify both 'mask' and 'region'")
 
         if consecutive_frames is None:
             consecutive_frames = get_config('motion', 'consecutive_frames')
@@ -824,7 +832,8 @@ class DeviceUnderTest(object):
             motion_frames, considered_frames))
 
         matches = deque(maxlen=considered_frames)
-        for res in self.detect_motion(timeout_secs, noise_threshold, mask):
+        for res in self.detect_motion(timeout_secs, noise_threshold, mask,
+                                      region):
             matches.append(res.motion)
             if matches.count(True) >= motion_frames:
                 debug("Motion detected.")


### PR DESCRIPTION
Passing a Region is more convenient than making a mask image for the simple cases where a single rectangular region is sufficient.

TODO:
- [x] Merge #352 as I don't want conflicts with the logging (and I might want to draw the region on the debug images?)
- [ ] Implement it
- [ ] API documentation in `stbt/__init__.py`
- [ ] Tests
- [ ] Also for `is_screen_black`?
