### PR TITLE
Fix virtual-stb intermittant test-failure on Travis

### DIFF
--- a/tests/vstb-example-html5/tests/rotate.py
+++ b/tests/vstb-example-html5/tests/rotate.py
@@ -3,7 +3,7 @@ from stbt import press, wait_for_match
 
 
 def wait_for_vstb_startup():
-    wait_for_match('stb-tester-350px.png')
+    wait_for_match('stb-tester-350px.png', timeout_secs=20)
 
 
 def test_that_image_is_rotated_by_arrows():


### PR DESCRIPTION
test_that_virtual_stb_configures_stb_tester_for_testing_virtual_stbs fails
intermittently on Travis because sometimes chrome takes longer than 10s to
start-up.  This causes the test to fail with:

> MatchTimeout: Didn't find match for '.../stb-tester-350px.png' within 10
> seconds

This commit should fix that issue.

TODO:

- [ ] Re-run the test a few times to see if it is actually fixed.