### PR TITLE
Rename "stbt templatematch" command to "stbt match"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,11 +95,11 @@ INSTALL_CORE_FILES = \
     stbt-config \
     stbt-control \
     stbt-lint \
+    stbt-match \
     stbt-power \
     stbt-record \
     stbt-run \
     stbt-screenshot \
-    stbt-templatematch \
     stbt-tv
 
 INSTALL_VSTB_FILES = \

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -45,6 +45,10 @@ UNRELEASED
       real hardware.  This approach can be particularly useful to reduce the
       cost of test maintainance.
 
+* The `stbt templatematch` command-line tool has been renamed to `stbt match`
+  (for consistency with the Python API terminology). The old name remains as an
+  alias, for backwards compatibility.
+
 * New `roku` remote control that uses the [Roku HTTP control protocol].
   Stb-tester's [standard key names] (like "KEY_HOME") will be converted to the
   corresponding Roku key name, or you can use the [Roku key names] directly.

--- a/stbt-match
+++ b/stbt-match
@@ -18,13 +18,13 @@ import stbt
 
 
 def error(s):
-    sys.stderr.write("stbt templatematch: error: %s\n" % s)
+    sys.stderr.write("stbt match: error: %s\n" % s)
     sys.exit(1)
 
 
 parser = argparse.ArgumentParser()
-parser.prog = "stbt templatematch"
-parser.description = """Run stbt's templatematch algorithm against a single
+parser.prog = "stbt match"
+parser.description = """Run stbt's image-matching algorithm against a single
     frame (which you can capture using `stbt screenshot`)."""
 parser.add_argument(
     "-v", "--verbose", action="store_true",

--- a/stbt.sh.in
+++ b/stbt.sh.in
@@ -57,18 +57,7 @@ case "$cmd" in
         usage; exit 0;;
     -v|--version)
         echo "stb-tester $STBT_VERSION"; exit 0;;
-    auto-selftest)
-        check_experimental
-        exec @LIBEXECDIR@/stbt/stbt_auto_selftest.py "$@";;
     run|record|batch|config|control|lint|power|screenshot|templatematch|tv)
-        exec @LIBEXECDIR@/stbt/stbt-"$cmd" "$@";;
-    # Experimental sub-commands:
-    camera)
-        if [ ! -e @LIBEXECDIR@/stbt/stbt-"$cmd" ]; then
-            echo "stb-tester camera support is not installed." 1>&2
-            exit 1
-        fi
-        check_experimental
         exec @LIBEXECDIR@/stbt/stbt-"$cmd" "$@";;
     virtual-stb)
         export PYTHONPATH=$PYTHONPATH:@LIBEXECDIR@/stbt/
@@ -77,6 +66,17 @@ case "$cmd" in
             exit 1
         fi
         exec @LIBEXECDIR@/stbt/stbt_virtual_stb.py "$@";;
+    # Experimental sub-commands:
+    auto-selftest)
+        check_experimental
+        exec @LIBEXECDIR@/stbt/stbt_auto_selftest.py "$@";;
+    camera)
+        if [ ! -e @LIBEXECDIR@/stbt/stbt-"$cmd" ]; then
+            echo "stb-tester camera support is not installed." 1>&2
+            exit 1
+        fi
+        check_experimental
+        exec @LIBEXECDIR@/stbt/stbt-"$cmd" "$@";;
     *)
         usage >&2; exit 1;;
 esac

--- a/stbt.sh.in
+++ b/stbt.sh.in
@@ -12,10 +12,10 @@
 #/     config         Print configuration value
 #/     control        Send remote control signals
 #/     lint           Static analysis of testcases
+#/     match          Compare two images
 #/     power          Control networked power switch
 #/     record         Record a testcase
 #/     screenshot     Capture a single screenshot
-#/     templatematch  Compare two images
 #/     tv             View live video on screen
 #/     virtual-stb    Configure stbt to use an STB emulator
 #/
@@ -57,8 +57,10 @@ case "$cmd" in
         usage; exit 0;;
     -v|--version)
         echo "stb-tester $STBT_VERSION"; exit 0;;
-    run|record|batch|config|control|lint|power|screenshot|templatematch|tv)
+    run|record|batch|config|control|lint|power|screenshot|match|tv)
         exec @LIBEXECDIR@/stbt/stbt-"$cmd" "$@";;
+    templatematch)  # for backwards compatibility
+        exec @LIBEXECDIR@/stbt/stbt-match "$@";;
     virtual-stb)
         export PYTHONPATH=$PYTHONPATH:@LIBEXECDIR@/stbt/
         if ! [ -e @LIBEXECDIR@/stbt/stbt_virtual_stb.py ]; then

--- a/tests/test-match.sh
+++ b/tests/test-match.sh
@@ -516,6 +516,6 @@ test_that_matchtimeout_screenshot_doesnt_include_visualisation() {
         test.py &&
 
     # sqdiff-normed & ccorr-normed give incorrect result on all-black images
-    stbt templatematch screenshot.png "$testdir"/black-full-frame.png \
+    stbt match screenshot.png "$testdir"/black-full-frame.png \
         match_method=ccoeff-normed
 }

--- a/tests/test-stbt-match.sh
+++ b/tests/test-stbt-match.sh
@@ -1,44 +1,53 @@
 # Run with ./run-tests.sh
 
-test_that_stbt_templatematch_finds_match() {
-    stbt templatematch \
+test_that_stbt_match_finds_match() {
+    stbt match \
         "$testdir"/videotestsrc-full-frame.png \
         "$testdir"/videotestsrc-redblue.png
 }
 
-test_that_stbt_templatematch_doesnt_find_match() {
-    ! stbt templatematch \
+test_that_stbt_match_doesnt_find_match() {
+    ! stbt match \
         "$testdir"/videotestsrc-full-frame.png \
         "$testdir"/videotestsrc-gamut.png
 }
 
-test_that_stbt_templatematch_applies_confirm_threshold_parameter() {
-    ! stbt templatematch \
+test_that_stbt_match_applies_confirm_threshold_parameter() {
+    ! stbt match \
         "$testdir"/videotestsrc-full-frame.png \
         "$testdir"/videotestsrc-redblue-with-dots.png &&
-    stbt templatematch \
+    stbt match \
         "$testdir"/videotestsrc-full-frame.png \
         "$testdir"/videotestsrc-redblue-with-dots.png confirm_threshold=0.9
 }
 
-test_that_stbt_templatematch_rejects_invalid_parameters() {
-    ! stbt templatematch \
+test_that_stbt_match_rejects_invalid_parameters() {
+    ! stbt match \
         idontexist.png \
         "$testdir"/videotestsrc-redblue-with-dots.png &&
     cat log | grep -q "Invalid image 'idontexist.png'" &&
-    ! stbt templatematch \
+    ! stbt match \
         "$testdir"/videotestsrc-full-frame.png \
         idontexisteither.png &&
     cat log | grep -q "No such template file: .*/idontexisteither.png" &&
-    ! stbt templatematch \
+    ! stbt match \
         "$testdir"/videotestsrc-full-frame.png \
         "$testdir"/videotestsrc-redblue-with-dots.png \
         confirm_threshold=0.9 \
         lahdee=dah &&
     cat log | grep -q "Invalid argument 'lahdee=dah'" &&
-    ! stbt templatematch \
+    ! stbt match \
         "$testdir"/videotestsrc-full-frame.png \
         "$testdir"/videotestsrc-redblue-with-dots.png \
         confirm_threshold=five &&
     cat log | grep -q "Invalid argument 'confirm_threshold=five'"
+}
+
+test_that_stbt_match_is_an_alias_for_stbt_templatematch() {
+    stbt templatematch \
+        "$testdir"/videotestsrc-full-frame.png \
+        "$testdir"/videotestsrc-redblue.png &&
+    ! stbt templatematch \
+        "$testdir"/videotestsrc-full-frame.png \
+        "$testdir"/videotestsrc-gamut.png
 }


### PR DESCRIPTION
For consistency with the Python API "stbt.match". I've been trying to
remove the wording "templatematch" from our public APIs as it is the
name of the OpenCV function we use in the first pass of our matching
algorithm; as such it is an implementation detail. The argument names to
`stbt.match`, `stbt.wait_for_match` etc are "image" (not "template") and
in prose we call this a "reference image" rather than a "template".

For backwards compatibility we keep "stbt templatematch" as an alias.
