### PR TITLE
FrameObject: Anticipate stbt.get_frame returning a read-only image

### DIFF
--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -715,6 +715,9 @@ class FrameObject(_stbt.core.FrameObject):
     def __init__(self, frame=None):
         if frame is None:
             frame = _dut.get_frame()
+            # This anticipates a time where stbt.get_frame returns a read-only
+            # buffer:
+            frame.flags.writeable = False
         super(FrameObject, self).__init__(frame)
 
 

--- a/stbt_auto_selftest.py
+++ b/stbt_auto_selftest.py
@@ -304,6 +304,7 @@ def write_bare_doctest(module, output_filename):
                                         {screenshots_rel}, name)
                 img = cv2.imread(filename)
                 assert img is not None, "Failed to load %s" % filename
+                img.flags.writeable = False
                 _FRAME_CACHE[name] = img
             return img
         '''.format(name=os.path.basename(module.filename[:-3]),

--- a/tests/auto-selftest-example-test-pack/selftest/auto_selftest/tests/example_selftest.py
+++ b/tests/auto-selftest-example-test-pack/selftest/auto_selftest/tests/example_selftest.py
@@ -33,6 +33,7 @@ def f(name):
                                 '../../screenshots', name)
         img = cv2.imread(filename)
         assert img is not None, "Failed to load %s" % filename
+        img.flags.writeable = False
         _FRAME_CACHE[name] = img
     return img
 

--- a/tests/auto-selftest-example-test-pack/selftest/auto_selftest/tests/subdir/subsubdir/subdir_example_selftest.py
+++ b/tests/auto-selftest-example-test-pack/selftest/auto_selftest/tests/subdir/subsubdir/subdir_example_selftest.py
@@ -33,6 +33,7 @@ def f(name):
                                 '../../../../screenshots', name)
         img = cv2.imread(filename)
         assert img is not None, "Failed to load %s" % filename
+        img.flags.writeable = False
         _FRAME_CACHE[name] = img
     return img
 

--- a/tests/auto-selftest-example-test-pack/selftest/auto_selftest/tests/unicode_example_selftest.py
+++ b/tests/auto-selftest-example-test-pack/selftest/auto_selftest/tests/unicode_example_selftest.py
@@ -33,6 +33,7 @@ def f(name):
                                 '../../screenshots', name)
         img = cv2.imread(filename)
         assert img is not None, "Failed to load %s" % filename
+        img.flags.writeable = False
         _FRAME_CACHE[name] = img
     return img
 


### PR DESCRIPTION
In the future I want to make `stbt.get_frame()` return an immutable image.
This way we will be able to reduce copying of data by providing numpy
arrays backed by the original `Gst.Sample`s.  This will be particularly
important for better and more efficient handling of 4K video.

This commit anticipates that change by exercising user's `FrameObject`s
with read-only buffers.  This is good because it makes a future change to
the behaviour of `get_frame()` less likely to break user-scripts.  This is
a non-breaking change itself as `FrameObject` has yet to be released.