### PR TITLE
Realtime timestamps

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1484,7 +1484,7 @@ class Display(object):
         self.novideo = False
         self.lock = threading.RLock()  # Held by whoever is consuming frames
         self.last_sample = Queue.Queue(maxsize=1)
-        self.last_used_sample = None
+        self.last_used_frame = None
         self.source_pipeline = None
         self.start_timestamp = None
         self.underrun_timeout = None
@@ -1610,7 +1610,7 @@ class Display(object):
             raise UITestError(str(gst_sample))
 
         if isinstance(gst_sample, Gst.Sample):
-            self.last_used_sample = array_from_sample(gst_sample)
+            self.last_used_frame = array_from_sample(gst_sample)
 
         return gst_sample
 

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -36,9 +36,9 @@ from kitchen.text.converters import to_bytes
 
 from _stbt import imgproc_cache, logging, utils
 from _stbt.config import ConfigurationError, get_config
-from _stbt.gst_utils import (array_from_sample, get_frame_timestamp,
-                             gst_iterate, gst_sample_make_writable,
-                             sample_shape)
+from _stbt.gst_utils import (array_from_sample, CapturedFrame,
+                             get_frame_timestamp, gst_iterate,
+                             gst_sample_make_writable, sample_shape)
 from _stbt.logging import ddebug, debug, warn
 
 gi.require_version("Gst", "1.0")
@@ -2615,7 +2615,6 @@ def test_wait_for_motion_half_motion_int():
 def _fake_frames_at_half_motion():
     class FakeDisplay(object):
         def frames(self, _timeout_secs=10):
-            from _stbt.gst_utils import CapturedFrame
             data = [
                 numpy.zeros((2, 2, 3), dtype=numpy.uint8),
                 numpy.ones((2, 2, 3), dtype=numpy.uint8) * 255,

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -430,26 +430,13 @@ class MatchResult(object):
     """
     # pylint: disable=W0621
     def __init__(
-            self, time, match, region, first_pass_result, frame=None,
-            image=None, timestamp=None, _first_pass_matched=None):
+            self, time, match, region, first_pass_result, frame, image,
+            timestamp=None, _first_pass_matched=None):
         self.timestamp = timestamp
         self.match = match
         self.region = region
         self.first_pass_result = first_pass_result
-        if frame is None:
-            warnings.warn(
-                "Creating a 'MatchResult' without specifying 'frame' is "
-                "deprecated. In a future release of stb-tester the 'frame' "
-                "parameter will be mandatory.",
-                DeprecationWarning, stacklevel=2)
         self.frame = frame
-        if image is None:
-            warnings.warn(
-                "Creating a 'MatchResult' without specifying 'image' is "
-                "deprecated. In a future release of stb-tester the 'image' "
-                "parameter will be mandatory.",
-                DeprecationWarning, stacklevel=2)
-            image = ""
         self.image = image
         self.time = time
         self._first_pass_matched = _first_pass_matched

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -412,7 +412,7 @@ class MatchResult(object):
 
     * ``time`` (float): The time at which the video-frame was captured in
       seconds since 1970-01-01T00:00Z.  This timestamp can be compared with
-      system time (`time.time()`).  Introduced in v26.
+      system time (`time.time()`).
     * ``match``: Boolean result, the same as evaluating `MatchResult` as a bool.
       That is, ``if match_result:`` will behave the same as
       ``if match_result.match:``.
@@ -420,12 +420,13 @@ class MatchResult(object):
     * ``first_pass_result``: Value between 0 (poor) and 1.0 (excellent match)
       from the first pass of stb-tester's two-pass image matching algorithm
       (see `MatchParameters` for details).
-    * ``frame``: The video frame that was searched, in OpenCV format.
+    * ``frame`` (`Frame` or `numpy.ndarray`): The video frame that was
+      searched, as given to `match`.
     * ``image``: The template image that was searched for, as given to `match`.
-    * ``timestamp`` (int): Video stream timestamp in nanoseconds.  The absolute
-      value isn’t related to the system time; what’s useful is the relative
-      difference between frames.  This is here for compatibility reasons only.
-      Use ``time`` instead.
+    * ``timestamp`` (int): DEPRECATED. Timestamp in nanoseconds. Use ``time``
+      instead.
+
+    The ``time`` attribute was added in stb-tester v26.
     """
     def __init__(
             self, time, match, region, first_pass_result, frame, image,
@@ -502,20 +503,20 @@ def _image_region(image):
 
 
 class MotionResult(object):
-    """The result from `detect_motion`.
+    """The result from `detect_motion` and `wait_for_motion`.
 
     * ``time`` (float): The time at which the video-frame was captured in
       seconds since 1970-01-01T00:00Z.  This timestamp can be compared with
-      system time (`time.time()`).  Introduced in v26.
+      system time (`time.time()`).
     * ``motion``: Boolean result, the same as evaluating `MotionResult` as a
       bool. That is, ``if result:`` will behave the same as
       ``if result.motion:``.
-    * ``region``: The region of the video frame that contained the motion.
-      `None` if no motion detected.
-    * ``timestamp`` (int): Video stream timestamp in nanoseconds.  The absolute
-      value isn’t related to the system time; what’s useful is the relative
-      difference between frames.  This is here for compatibility reasons only.
-      Use ``time`` instead.
+    * ``region``: The `Region` of the video frame that contained the motion.
+      ``None`` if no motion detected.
+    * ``timestamp`` (int): DEPRECATED. Timestamp in nanoseconds. Use ``time``
+      instead.
+
+    The ``time`` attribute was added in stb-tester v26.
     """
     def __init__(self, time, motion, region):
         self.time = time
@@ -574,19 +575,20 @@ class TextMatchResult(object):
 
     * ``time`` (float): The time at which the video-frame was captured in
       seconds since 1970-01-01T00:00Z.  This timestamp can be compared with
-      system time (`time.time()`).  Introduced in v26.
+      system time (`time.time()`).
     * ``match``: Boolean result, the same as evaluating `TextMatchResult` as a
       bool. That is, ``if result:`` will behave the same as
       ``if result.match:``.
     * ``region``: The `Region` (bounding box) of the text found, or ``None`` if
       no text was found.
-    * ``frame``: The video frame that was searched, in OpenCV format.
+    * ``frame`` (`Frame` or `numpy.ndarray`): The video frame that was
+      searched, as given to `match_text`.
     * ``text``: The text (unicode string) that was searched for, as given to
       `match_text`.
-    * ``timestamp`` (int): Video stream timestamp in nanoseconds.  The absolute
-      value isn’t related to the system time; what’s useful is the relative
-      difference between frames.  This is here for compatibility reasons only.
-      Use ``time`` instead.
+    * ``timestamp`` (int): DEPRECATED. Timestamp in nanoseconds. Use ``time``
+      instead.
+
+    The ``time`` attribute was added in stb-tester v26.
     """
     def __init__(self, time, match, region, frame, text):
         self.time = time

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -35,7 +35,7 @@ from kitchen.text.converters import to_bytes
 
 from _stbt import imgproc_cache, logging, utils
 from _stbt.config import ConfigurationError, get_config
-from _stbt.gst_utils import (array_from_sample, CapturedFrame,
+from _stbt.gst_utils import (array_from_sample, Frame,
                              get_frame_stream_timestamp_ns, gst_iterate,
                              gst_sample_make_writable, sample_shape)
 from _stbt.logging import ddebug, debug, warn
@@ -2693,12 +2693,12 @@ def _fake_frames_at_half_motion():
             ]
             # Start with no motion
             for i in range(6):
-                yield CapturedFrame(data[0], _gst_pts=int(i * 1e9),
-                                    time=1466084606. + i)
+                yield Frame(data[0], _gst_pts=int(i * 1e9),
+                            time=1466084606. + i)
             # Motion starts on 6th frame at time 1466084612.
             for i in range(6, 20):
-                yield CapturedFrame(data[i % len(data)], _gst_pts=int(i * 1e9),
-                                    time=1466084606. + i)
+                yield Frame(data[i % len(data)], _gst_pts=int(i * 1e9),
+                            time=1466084606. + i)
 
         def draw(self, *_args, **_kwargs):
             pass

--- a/_stbt/gst_utils.py
+++ b/_stbt/gst_utils.py
@@ -87,14 +87,13 @@ class _MappedSample(object):
             self._ctx.__exit__(None, None, None)
 
 
-class CapturedFrame(numpy.ndarray):
+class Frame(numpy.ndarray):
     """
-    `CapturedFrame`s are returned from `stbt.get_frame()` and `stbt.frames()`.
+    `Frame`s are returned from `stbt.get_frame()` and `stbt.frames()`.
     They are a subclass of `numpy.ndarray` - the type that OpenCV uses to
     represent images.  Data is stored in 8-bit, 3 channel BGR format.
 
-    In addition to the members inherited from `numpy.ndarray` `CapturedFrame`
-    defines:
+    In addition to the members inherited from `numpy.ndarray` `Frame` defines:
 
     * `time` (float) - the wall-clock time that this video-frame was captured
       as number of seconds since the unix epoch (1970-01-01T00:00:00Z).  This
@@ -117,7 +116,7 @@ class CapturedFrame(numpy.ndarray):
 
 
 def array_from_sample(sample, readwrite=False):
-    return CapturedFrame(
+    return Frame(
         _MappedSample(sample, readwrite),
         _gst_pts=sample.get_buffer().pts,
         time=getattr(sample, 'time', None))

--- a/_stbt/gst_utils.py
+++ b/_stbt/gst_utils.py
@@ -81,19 +81,21 @@ class _MappedSample(object):
 
 
 class Frame(numpy.ndarray):
-    """
-    `Frame`s are returned from `stbt.get_frame()` and `stbt.frames()`.
-    They are a subclass of `numpy.ndarray` - the type that OpenCV uses to
-    represent images.  Data is stored in 8-bit, 3 channel BGR format.
+    """A frame of video.
 
-    In addition to the members inherited from `numpy.ndarray` `Frame` defines:
+    A ``Frame`` is what you get from `stbt.get_frame` and `stbt.frames`. It is
+    a subclass of `numpy.ndarray`, which is the type that OpenCV uses to
+    represent images. Data is stored in 8-bit, 3 channel BGR format.
 
-    * `time` (float) - the wall-clock time that this video-frame was captured
-      as number of seconds since the unix epoch (1970-01-01T00:00:00Z).  This
-      is the same format as returned from the Python standard library function
-      `time.time()`.
+    In addition to the members inherited from `numpy.ndarray`, `Frame` defines
+    the following attributes:
 
-    Added in stb-tester v26.
+    * ``time`` (float) - the wall-clock time that this video-frame was captured
+      as number of seconds since the unix epoch (1970-01-01T00:00:00Z). This is
+      the same format used by the Python standard library function `time.time`.
+
+    ``Frame`` was added in stb-tester v26.
+
     """
     def __new__(cls, array, dtype=None, order=None, time=None):
         obj = numpy.asarray(array, dtype=dtype, order=order).view(cls)

--- a/_stbt/gst_utils.py
+++ b/_stbt/gst_utils.py
@@ -26,7 +26,7 @@ def gst_sample_make_writable(sample):
             sample.get_info())
 
 
-def get_frame_timestamp(frame):
+def get_frame_stream_timestamp_ns(frame):
     if isinstance(frame, Gst.Sample):
         return frame.get_buffer().pts
     else:

--- a/_stbt/gst_utils.py
+++ b/_stbt/gst_utils.py
@@ -89,8 +89,11 @@ class _MappedSample(object):
 
 class CapturedFrame(numpy.ndarray):
     """
-    A subclass of ndarray that we use so we can attach additional metadata to it
-    such as timestamps.
+    `CapturedFrame`s are returned from `stbt.get_frame()` and `stbt.frames()`.
+    They are a subclass of `numpy.ndarray` - the type that OpenCV uses to
+    represent images.  Data is stored in 8-bit, 3 channel BGR format.
+
+    Added in stb-tester v26.
     """
     def __new__(cls, array, dtype=None, order=None, _gst_pts=None):
         obj = numpy.asarray(array, dtype=dtype, order=order).view(cls)

--- a/_stbt/gst_utils.py
+++ b/_stbt/gst_utils.py
@@ -26,13 +26,6 @@ def gst_sample_make_writable(sample):
             sample.get_info())
 
 
-def get_frame_stream_timestamp_ns(frame):
-    if isinstance(frame, Gst.Sample):
-        return frame.get_buffer().pts
-    else:
-        return getattr(frame, "_gst_pts", None)
-
-
 def sample_shape(sample):
     if isinstance(sample, numpy.ndarray):
         return sample.shape
@@ -102,23 +95,20 @@ class Frame(numpy.ndarray):
 
     Added in stb-tester v26.
     """
-    def __new__(cls, array, dtype=None, order=None, _gst_pts=None, time=None):
+    def __new__(cls, array, dtype=None, order=None, time=None):
         obj = numpy.asarray(array, dtype=dtype, order=order).view(cls)
-        obj._gst_pts = _gst_pts  # pylint: disable=protected-access
         obj.time = time
         return obj
 
     def __array_finalize__(self, obj):
         if obj is None:
             return
-        self._gst_pts = getattr(obj, '_gst_pts', None)  # pylint: disable=protected-access,attribute-defined-outside-init
         self.time = getattr(obj, 'time', None)  # pylint: disable=attribute-defined-outside-init
 
 
 def array_from_sample(sample, readwrite=False):
     return Frame(
         _MappedSample(sample, readwrite),
-        _gst_pts=sample.get_buffer().pts,
         time=getattr(sample, 'time', None))
 
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -30,7 +30,7 @@ UNRELEASED
   `wait_for_motion()`) now has a member `region` which indicates where in the
   video the motion was detected.
 
-* Python API: `get_frame()` and `frames()` now return a `CapturedFrame` object.
+* Python API: `get_frame()` and `frames()` now return a `Frame` object.
   This is a subclass of `numpy.ndarray`.
 
 ##### Minor fixes and packaging fixes
@@ -50,8 +50,8 @@ UNRELEASED
 ##### Developer-visible changes
 
 * We no-longer use `with numpy_from_sample` when dealing with frames internally.
-  The new `array_from_sample` and the `CapturedFrame` `ndarray` subclass fulfill
-  a similar job but without needing a `with` block.
+  The new `array_from_sample` and the `Frame` `ndarray` subclass fulfill a
+  similar job but without needing a `with` block.
 
 #### 25
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -30,6 +30,9 @@ UNRELEASED
   `wait_for_motion()`) now has a member `region` which indicates where in the
   video the motion was detected.
 
+* Python API: `get_frame()` and `frames()` now return a `CapturedFrame` object.
+  This is a subclass of `numpy.ndarray`.
+
 ##### Minor fixes and packaging fixes
 
 * `MotionResult` now defines `__nonzero__()`. This means you can write

--- a/extra/pylint.conf
+++ b/extra/pylint.conf
@@ -9,7 +9,7 @@ reports=no
 disable=C0102,C0103,C0111,C0112,C0121,C0202,C0203,C0302,C0321,C0322,C0323,C0324,C0330,E0012,E1103,I0011,I0012,R0201,R0401,R0801,R0901,R0902,R0903,R0904,R0911,R0912,R0913,R0914,R0915,R0921,R0922,R0923,W0142,W0232,W0603
 
 [TYPECHECK]
-ignored-classes=Buffer,Caps,CapturedFrame,Client,Event,gi.repository.Gst,MainLoop,numpy,numpy.linalg,Sample,scipy.interpolate,scipy.optimize,_socketobject
+ignored-classes=Buffer,Caps,Frame,Client,Event,gi.repository.Gst,MainLoop,numpy,numpy.linalg,Sample,scipy.interpolate,scipy.optimize,_socketobject
 
 [VARIABLES]
 dummy-variables-rgx=_

--- a/stbt-run
+++ b/stbt-run
@@ -134,7 +134,7 @@ except Exception as e:  # pylint: disable=W0703
     if hasattr(e, "screenshot") and e.screenshot is not None:
         screenshot = e.screenshot
     elif stbt._dut._display:  # pylint: disable=W0212
-        screenshot = stbt._dut._display.last_used_sample  # pylint: disable=W0212
+        screenshot = stbt._dut._display.last_used_frame  # pylint: disable=W0212
     else:
         screenshot = None
 

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -429,9 +429,14 @@ def frames(timeout_secs=None):
       An ``(image, timestamp)`` tuple for each video frame:
 
       * ``image`` is a `CapturedFrame` object (that is, an OpenCV image).
-      * ``timestamp`` is a time in nanoseconds. The absolute value isn't
-        related to the system time; what's useful is the relative difference
-        between frames.
+      * ``timestamp`` (deprecated since v26) is a time in nanoseconds. The
+        absolute value isn't related to the system time; what's useful is the
+        relative difference between frames.
+
+        This is here for backwards compatibility reasons.  In new tests
+        `image.time` instead.  `time` is better as it is in seconds (rather
+        than nanoseconds) and measures system time so can be compared to
+        `time.time()`.
     """
     return _dut.frames(timeout_secs)
 

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -312,7 +312,8 @@ def wait_for_motion(
 
     :param str mask: See `detect_motion`.
 
-    :returns: `MotionResult` when motion is detected.
+    :returns: `MotionResult` when motion is detected.  `result.time` is the time
+              of the first frame in which motion was detected.
     :raises: `MotionTimeout` if no motion is detected after ``timeout_secs``
         seconds.
     """

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -16,7 +16,7 @@ from _stbt.core import \
     as_precondition, \
     debug, \
     get_config, \
-    CapturedFrame, \
+    Frame, \
     ConfigurationError, \
     MatchParameters, \
     MatchResult, \
@@ -36,7 +36,7 @@ from _stbt.core import \
 
 __all__ = [
     "as_precondition",
-    "CapturedFrame",
+    "Frame",
     "ConfigurationError",
     "debug",
     "detect_match",
@@ -429,7 +429,7 @@ def frames(timeout_secs=None):
     :returns:
       An ``(image, timestamp)`` tuple for each video frame:
 
-      * ``image`` is a `CapturedFrame` object (that is, an OpenCV image).
+      * ``image`` is a `Frame` (that is, an OpenCV image).
       * ``timestamp`` (deprecated since v26) is a time in nanoseconds. The
         absolute value isn't related to the system time; what's useful is the
         relative difference between frames.
@@ -443,7 +443,7 @@ def frames(timeout_secs=None):
 
 
 def get_frame():
-    """:returns: The latest video frame in OpenCV format (a `CapturedFrame`)."""
+    """:returns: The latest video frame in OpenCV format (a `Frame`)."""
     return _dut.get_frame()
 
 

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -312,8 +312,9 @@ def wait_for_motion(
 
     :param str mask: See `detect_motion`.
 
-    :returns: `MotionResult` when motion is detected.  `result.time` is the time
-              of the first frame in which motion was detected.
+    :returns: `MotionResult` when motion is detected. The MotionResult's
+        ``time`` attribute is the time of the first frame in which motion was
+        detected.
     :raises: `MotionTimeout` if no motion is detected after ``timeout_secs``
         seconds.
     """
@@ -427,23 +428,26 @@ def frames(timeout_secs=None):
       iterating (for example with ``break``) at any time.
 
     :returns:
-      An ``(image, timestamp)`` tuple for each video frame:
+      A ``(frame, timestamp)`` tuple for each video frame:
 
-      * ``image`` is a `Frame` (that is, an OpenCV image).
-      * ``timestamp`` (deprecated since v26) is a time in nanoseconds. The
-        absolute value isn't related to the system time; what's useful is the
-        relative difference between frames.
+      * ``frame`` is a `stbt.Frame` (that is, an OpenCV image).
+      * ``timestamp`` (int): DEPRECATED. Timestamp in nanoseconds. Use
+        ``frame.time`` instead.
 
-        This is here for backwards compatibility reasons.  In new tests
-        `image.time` instead.  `time` is better as it is in seconds (rather
-        than nanoseconds) and measures system time so can be compared to
-        `time.time()`.
+    Changed in stb-tester v26: The first item of the tuple is a `stbt.Frame`
+    instead of a `numpy.ndarray`.
     """
     return _dut.frames(timeout_secs)
 
 
 def get_frame():
-    """:returns: The latest video frame in OpenCV format (a `Frame`)."""
+    """Grabs a video frame captured from the system-under-test.
+
+    :returns: The latest video frame in OpenCV format (a `stbt.Frame`).
+
+    Changed in stb-tester v26: Returns a `stbt.Frame` instead of a
+    `numpy.ndarray`.
+    """
     return _dut.get_frame()
 
 

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -16,6 +16,7 @@ from _stbt.core import \
     as_precondition, \
     debug, \
     get_config, \
+    CapturedFrame, \
     ConfigurationError, \
     MatchParameters, \
     MatchResult, \
@@ -35,6 +36,7 @@ from _stbt.core import \
 
 __all__ = [
     "as_precondition",
+    "CapturedFrame",
     "ConfigurationError",
     "debug",
     "detect_match",
@@ -426,7 +428,7 @@ def frames(timeout_secs=None):
     :returns:
       An ``(image, timestamp)`` tuple for each video frame:
 
-      * ``image`` is a `numpy.ndarray` object (that is, an OpenCV image).
+      * ``image`` is a `CapturedFrame` object (that is, an OpenCV image).
       * ``timestamp`` is a time in nanoseconds. The absolute value isn't
         related to the system time; what's useful is the relative difference
         between frames.
@@ -435,7 +437,7 @@ def frames(timeout_secs=None):
 
 
 def get_frame():
-    """:returns: The latest video frame in OpenCV format (a `numpy.ndarray`)."""
+    """:returns: The latest video frame in OpenCV format (a `CapturedFrame`)."""
     return _dut.get_frame()
 
 

--- a/tests/run-performance-test.sh
+++ b/tests/run-performance-test.sh
@@ -12,7 +12,7 @@ cat > script.$$ <<-EOF
 	frames = 0
 	stbt.frames().next()  # Don't count pipeline startup time
 	start = datetime.datetime.now()
-	for m in stbt.detect_match("template.png", timeout_secs=10):
+	for m in stbt.detect_match("videotestsrc-redblue.png", timeout_secs=10):
 	    frames += 1
 	    print "%s %s %s" % (m.timestamp, bool(m), m.position)
 	    # if not m:
@@ -24,7 +24,6 @@ cat > script.$$ <<-EOF
 trap "rm -f script.$$" EXIT
 
 ../stbt-run \
-    --source-pipeline \
-      "filesrc location=video.mpeg ! tsdemux ! h264parse" \
+    --source-pipeline "filesrc location=video.mpeg" \
     --control none \
     script.$$

--- a/tests/test-motion.sh
+++ b/tests/test-motion.sh
@@ -91,18 +91,24 @@ test_detect_motion_reports_motion() {
 
 test_detect_motion_reports_valid_timestamp() {
     cat > test.py <<-EOF
-	last_timestamp=None
+	import time
+	
+	start_time = time.time()
+	last_timestamp = None
 	for motion_result in detect_motion():
+	    assert motion_result.time >= start_time
 	    if last_timestamp != None:
-	        if motion_result.timestamp - last_timestamp >= 0:
+	        if motion_result.time - last_timestamp >= 0:
 	            import sys
+	            assert motion_result.time <= time.time()
 	            sys.exit(0)
 	        else:
-	            raise Exception("Invalid timestamps reported: %d - %d." % (
-	                            last_timestamp, motion_result.timestamp))
-	    if motion_result.timestamp == None:
+	            raise Exception("Invalid timestamps reported: %f - %f." % (
+	                            last_timestamp,
+	                            motion_result.time))
+	    if motion_result.time == None:
 	        raise Exception("Empty timestamp reported.")
-	    last_timestamp = motion_result.timestamp
+	    last_timestamp = motion_result.time
 	raise Exception("Timeout occured without any result reported.")
 	EOF
     stbt run -v test.py

--- a/tests/test-motion.sh
+++ b/tests/test-motion.sh
@@ -224,7 +224,8 @@ test_detect_motion_visualisation() {
     mkfifo fifo || fail "Initial test setup failed"
 
     stbt run -v \
-        --source-pipeline "multifilesrc location=$testdir/box-%05d.png loop=true" \
+        --source-pipeline "multifilesrc location=$testdir/box-%05d.png loop=true \
+                           ! image/png,framerate=25/1" \
         --sink-pipeline 'gdppay ! filesink location=fifo' \
         detect_motion.py &
     source_pid=$!

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -447,6 +447,25 @@ test_clock_visualisation() {
         verify.py
 }
 
+test_that_get_frame_time_is_wall_time() {
+    cat > test.py <<-EOF &&
+	import stbt, time
+
+	f = stbt.get_frame()
+	t = time.time()
+
+	print "stbt.get_frame().time:", f.time
+	print "time.time():", t
+	print "latency:", t - f.time
+
+	# get_frame() gives us the last frame that arrived.  This may arrived a
+	# little time ago and have been waiting in a buffer.
+	assert t - 0.1 < f.time < t
+	EOF
+
+    stbt run -vv test.py
+}
+
 test_template_annotation_labels() {
     cat > test.py <<-EOF &&
 	import stbt

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -153,8 +153,9 @@ def test_match_text_stringify_result():
     result = stbt.match_text(u"Onion Bhaji", frame=frame)
 
     assert re.match(
-        r"TextMatchResult\(timestamp=None, match=True, region=Region\(.*\), "
-        r"frame=<1280x720x3>, text=u'Onion Bhaji'\)", str(result))
+        r"TextMatchResult\(time=None, match=True, region=Region\(.*\), "
+        r"frame=<1280x720x3>, text=u'Onion Bhaji', timestamp=None\)",
+        str(result))
 
 
 def test_that_text_region_is_correct_even_with_regions_larger_than_frame():

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -154,7 +154,7 @@ def test_match_text_stringify_result():
 
     assert re.match(
         r"TextMatchResult\(time=None, match=True, region=Region\(.*\), "
-        r"frame=<1280x720x3>, text=u'Onion Bhaji', timestamp=None\)",
+        r"frame=<1280x720x3>, text=u'Onion Bhaji'\)",
         str(result))
 
 


### PR DESCRIPTION
The timestamps we currently provide are the PTS data attached to the
`Gst.Sample`s pulled from the source pipeline.  In practice with v4l2src
this will have tended to roughly be the time from the start of the test or
the last pipeline restart.  It could be some other number depending on the
source pipeline used.   It is only useful for comparing the time
difference between two frames.

This commit introduces `sample.realtime_timestamp` for each pulled frame.
This is the time since the unix epoch in seconds as a float.  This can be
used to compare the time of a frame against:

* The current time (for debugging)
* Other events that happen on the system such as IR presses for more-precise latency measurements
* Other events that occur in the world such as remote server timestamps or for measuring synchronisation between different devices-under-test (assuming a correctly set system-clock).

This could help solve #247 too.

TODO:

- [x] Work out an API - perhaps attaching the data as an additional member to `ndarray` would be best.  See http://stackoverflow.com/a/34967782/65031 for how
- [x] Merge #379 
- [x] Add test for `MotionResult` repr
- [x] Add test that provided timestamps are in wall-clock time
- [x] Add release note for new timestamps
- [x] Document `*.time`
- [x] Clarify what `MotionResult.time` refers to
- [x] Clarify documentation.  `{Match,TextMatch}Result.frame` isn't necessarily a `Frame`