### PR TITLE
stbt control: Truncate keymap filename in interactive mode

### DIFF
--- a/stbt-control
+++ b/stbt-control
@@ -184,9 +184,8 @@ def clear_last_command(term):
 
 def keymap_fits_terminal(term, printed_keymap):
     term_y, term_x = term.getmaxyx()
-    keymap_y = printed_keymap.count("\n")
-    keymap_x = len(printed_keymap.split("\n")[0])
-    return term_y > keymap_y and term_x > keymap_x
+    lines = printed_keymap.split("\n")
+    return term_y > len(lines) and term_x > max(len(line) for line in lines)
 
 
 @contextlib.contextmanager

--- a/stbt-control
+++ b/stbt-control
@@ -143,13 +143,14 @@ def main_loop(control_uri, keymap_file):
     timer = None
 
     with terminal() as term:
+        _, term_width = term.getmaxyx()
         printed_keymap = dedent("""\
             Keymap: {keymap_file}
             Control: {control_uri}
 
             {mapping}
 
-            """).format(keymap_file=keymap_file,
+            """).format(keymap_file=keymap_file[:term_width - len("Keymap:  ")],
                         control_uri=control_uri,
                         mapping=keymap_string(keymap))
         if keymap_fits_terminal(term, printed_keymap):

--- a/stbt-control
+++ b/stbt-control
@@ -208,8 +208,8 @@ def keymap_string(keymap):
     middle = int(math.ceil(float(len(keylist)) / 2))
     rows = [
         "%s %s" % (
-            keylist[i], keylist[middle + i]
-            if middle + i < len(keylist) else "")
+            keylist[i],
+            keylist[middle + i] if middle + i < len(keylist) else "")
         for i in range(middle)]
     return "\n".join(rows)
 

--- a/stbt-control
+++ b/stbt-control
@@ -12,6 +12,7 @@ import os
 import sys
 import threading
 import time
+from textwrap import dedent
 
 import _stbt.control
 import stbt
@@ -142,8 +143,15 @@ def main_loop(control_uri, keymap_file):
     timer = None
 
     with terminal() as term:
-        printed_keymap = ("Keymap: %s\nControl: %s\n\n%s\n\n" %
-                          (keymap_file, control_uri, keymap_string(keymap)))
+        printed_keymap = dedent("""\
+            Keymap: {keymap_file}
+            Control: {control_uri}
+
+            {mapping}
+
+            """).format(keymap_file=keymap_file,
+                        control_uri=control_uri,
+                        mapping=keymap_string(keymap))
         if keymap_fits_terminal(term, printed_keymap):
             term.addstr(printed_keymap)
         else:

--- a/tests/test-stbt-control.sh
+++ b/tests/test-stbt-control.sh
@@ -41,7 +41,7 @@ validate_stbt_record_control_recorder() {
     diff -u expected test.py
 }
 
-test_stbt_control_as_stbt_record_control_recorder__explict_keymap() {
+test_stbt_control_as_stbt_record_control_recorder__explicit_keymap() {
     validate_stbt_record_control_recorder \
         stbt-control:$testdir/stbt-control.keymap
 }


### PR DESCRIPTION
test_stbt_control_as_stbt_record_control_recorder__explicit_keymap was
failing with "Unable to print keymap because the terminal is too small"
when run on my PC (but not on Travis) because the test gives
`stbt control` an absolute path ($testdir/stbt-control.keymap) which on
my PC was longer than the 80-column terminal we use during the test.

The fix is to truncate the keymap filename if it's longer than the terminal width.

I've also fixed a bug in the `keymap_fits_terminal` calculation.