### PR TITLE
Python API: Add __repr__ for stbt.MatchResult etc

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -24,6 +24,9 @@ UNRELEASED
 
 ##### Minor fixes and packaging fixes
 
+* The debug log output of `match`, `wait_for_match` and `match_text` shows the
+  matching region as (x, y, right, bottom) instead of (x, y, width, height).
+
 ##### Developer-visible changes
 
 #### 25

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -154,7 +154,7 @@ def test_match_text_stringify_result():
 
     assert re.match(
         r"TextMatchResult\(timestamp=None, match=True, region=Region\(.*\), "
-        r"frame=1280x720x3, text=u'Onion Bhaji'\)", str(result))
+        r"frame=<1280x720x3>, text=u'Onion Bhaji'\)", str(result))
 
 
 def test_that_text_region_is_correct_even_with_regions_larger_than_frame():


### PR DESCRIPTION
This makes MatchResult values more convenient to use in auto-selftests.

I've added a `__repr__` to MatchParameters for consistency. All other classes either have a `__repr__` already, or they derive from namedtuple which provides an appropriate `__repr__` implementation.

I made a few other changes for consistency:

* Use %r instead of %s where appropriate (because this is `__repr__` after all) although in most cases the output is the same.

* `stbt.Region` had different output for `str(region)` vs. `repr(region)`: The former printed width & height whereas the latter printed right & bottom. Now both print ~~width & height~~ right & bottom (the repr can't use width & height because those are ambiguous if x or y are -inf).

TODO:

- [x] MatchResult repr.
- [x] Make Region repr & str consistent.
- [x] Make Region repr use bottom & right again.
- [x] Make "frame" output in MatchResult/TextMatchResult reprs have &lt;angle brackets&gt;
- [x] Release notes about change to Region description in `match` & `match_text` debug log.
