### PR TITLE
Result object consistency

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -504,7 +504,7 @@ def _image_region(image):
     return Region(0, 0, s[1], s[0])
 
 
-class MotionResult(namedtuple('MotionResult', 'timestamp motion')):
+class MotionResult(object):
     """The result from `detect_motion`.
 
     * `timestamp`: Video stream timestamp.
@@ -512,8 +512,16 @@ class MotionResult(namedtuple('MotionResult', 'timestamp motion')):
       bool. That is, ``if result:`` will behave the same as
       ``if result.motion:``.
     """
+    def __init__(self, timestamp, motion):
+        self.timestamp = timestamp
+        self.motion = motion
+
     def __nonzero__(self):
         return self.motion
+
+    def __repr__(self):
+        return "MotionResult(timestamp=%r, motion=%r)" % (
+            self.timestamp, self.motion)
 
 
 class OcrMode(IntEnum):

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -508,9 +508,12 @@ class MotionResult(namedtuple('MotionResult', 'timestamp motion')):
     """The result from `detect_motion`.
 
     * `timestamp`: Video stream timestamp.
-    * `motion`: Boolean result.
+    * ``motion``: Boolean result, the same as evaluating `MotionResult` as a
+      bool. That is, ``if result:`` will behave the same as
+      ``if result.motion:``.
     """
-    pass
+    def __nonzero__(self):
+        return self.motion
 
 
 class OcrMode(IntEnum):

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -537,9 +537,7 @@ class OcrMode(IntEnum):
         return str(self)
 
 
-class TextMatchResult(namedtuple(
-        "TextMatchResult", "timestamp match region frame text")):
-
+class TextMatchResult(object):
     """The result from `match_text`.
 
     * ``timestamp``: Video stream timestamp.
@@ -552,6 +550,13 @@ class TextMatchResult(namedtuple(
     * ``text``: The text (unicode string) that was searched for, as given to
       `match_text`.
     """
+    def __init__(self, timestamp, match, region, frame, text):
+        self.timestamp = timestamp
+        self.match = match
+        self.region = region
+        self.frame = frame
+        self.text = text
+
     # pylint: disable=E1101
     def __nonzero__(self):
         return self.match

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -20,8 +20,9 @@ UNRELEASED
 
 ##### Breaking changes since 25
 
-* `TextMatchResult` (as returned from `match_text`) no longer derives from
-  `tuple`. We don't expect that this will break any real-life test scripts.
+* `TextMatchResult` (returned from `match_text`) and `MotionResult` (returned
+  from `wait_for_motion` no longer derive from `tuple`. We don't expect that
+  this will break any real-life test scripts.
 
 ##### New features
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -27,6 +27,11 @@ UNRELEASED
 
 ##### Minor fixes and packaging fixes
 
+* `MotionResult` now defines `__nonzero__()`. This means you can write
+  `if result:` rather than having to write `if result.motion`.  This is a minor
+  ergonomic improvement for consistency with `MatchResult` and
+  `TextMatchResult`.
+
 * The debug log output of `match`, `wait_for_match` and `match_text` shows the
   matching region as (x, y, right, bottom) instead of (x, y, width, height).
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -20,6 +20,9 @@ UNRELEASED
 
 ##### Breaking changes since 25
 
+* `TextMatchResult` (as returned from `match_text`) no longer derives from
+  `tuple`. We don't expect that this will break any real-life test scripts.
+
 ##### New features
 
 ##### Minor fixes and packaging fixes

--- a/tests/test-motion.sh
+++ b/tests/test-motion.sh
@@ -75,7 +75,8 @@ test_detect_motion_reports_motion() {
     cat > test.py <<-EOF
 	# Should report motion
 	for motion_result in detect_motion():
-	    if motion_result.motion:
+	    assert bool(motion_result) == motion_result.motion
+	    if motion_result:
 	        import sys
 	        sys.exit(0)
 	    else:
@@ -109,7 +110,8 @@ test_detect_motion_reports_no_motion() {
 	# Should not report motion
 	for motion_result in detect_motion(
 	        mask="$testdir/videotestsrc-mask-no-video.png"):
-	    if not motion_result.motion:
+	    assert bool(motion_result) == motion_result.motion
+	    if not motion_result:
 	        import sys
 	        sys.exit(0)
 	    else:
@@ -156,7 +158,7 @@ test_detect_motion_changing_mask() {
 	wait_for_motion(mask="$testdir/videotestsrc-mask-video.png")
 	for motion_result in detect_motion(
 	        mask="$testdir/videotestsrc-mask-no-video.png"):
-	    if not motion_result.motion:
+	    if not motion_result:
 	        import sys
 	        sys.exit(0)
 	raise Exception("Timeout occured without any result reported.")
@@ -168,7 +170,7 @@ test_detect_motion_changing_mask_is_not_racy() {
     cat > test.py <<-EOF
 	for motion_result in detect_motion(
 	        mask="$testdir/videotestsrc-mask-video.png"):
-	    if not motion_result.motion:
+	    if not motion_result:
 	        raise Exception("Motion not reported.")
 	    # Leave time for another frame to be processed with this mask
 	    import time
@@ -177,7 +179,7 @@ test_detect_motion_changing_mask_is_not_racy() {
 	for motion_result in detect_motion(
 	        mask="$testdir/videotestsrc-mask-no-video.png"):
 	    # Not supposed to detect motion
-	    if not motion_result.motion:
+	    if not motion_result:
 	        import sys
 	        sys.exit(0)
 	    else:
@@ -192,12 +194,12 @@ test_detect_motion_example_press_and_wait_for_no_motion() {
 	key_sent = False
 	for motion_result in detect_motion():
 	    if not key_sent:
-	        if not motion_result.motion:
+	        if not motion_result:
 	            raise Exception("Motion not reported.")
 	        press("checkers-8")
 	        key_sent = True
 	    else:
-	        if not motion_result.motion:
+	        if not motion_result:
 	            import sys
 	            sys.exit(0)
 	raise Exception("Timeout occured without any result reported.")


### PR DESCRIPTION
Broken out of #364.

They now all derive from object and all implement `__nonzero__`.  This will make it easier to extend them in the future in a backwards-compatible way (although this is a weakly backwards-incompatible change).