### PR TITLE
_stbt.imgproc_cache unit tests: Take the minimum time of 10 executions

### DIFF
--- a/_stbt/imgproc_cache.py
+++ b/_stbt/imgproc_cache.py
@@ -256,12 +256,12 @@ def _check_cache_behaviour(func):
 
     timer = Timer(func)
     uncached_result = func()
-    uncached_time = timer.timeit(number=5) / 5.
+    uncached_time = min(timer.repeat(10, number=1))
 
     with named_temporary_directory() as tmpdir, cache(tmpdir):
         # Prime the cache
         func()
-        cached_time = timer.timeit(number=5) / 5.
+        cached_time = min(timer.repeat(10, number=1))
         cached_result = func()
 
     print "%s with cache: %s" % (func.__name__, cached_time)


### PR DESCRIPTION
...instead of the average. This is to fix false positives on Travis.

The minimum gives a lower bound for how fast the operation is. Higher
values will be caused by other processes competing for CPU time, which
happens especially on Travis.

TODO:

- [x] Test 20 times on Travis with the patch below. *(passed [here](https://travis-ci.org/stb-tester/stb-tester/builds/137279145) and [here](https://travis-ci.org/stb-tester/stb-tester/builds/137279135))*

```
diff --git a/Makefile b/Makefile
index 5f0156f..033fdab 100644
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,13 @@ PYTHON_FILES = $(shell (git ls-files '*.py' && \
            | grep -v '^vendor/' \
            | sort | uniq | grep -v tests/webminspector)
 
-check: check-pylint check-nosetests check-integrationtests check-bashcompletion
+check:  # Don't merge this
+       for i in `seq 20`; do \
+         PYTHONPATH=$$PWD NOSE_REDNOSE=1 \
+         nosetests --with-doctest -v --match "^test_" \
+           --doctest-options=+ELLIPSIS \
+           _stbt/imgproc_cache.py; \
+       done
 check-nosetests: $(INSTALL_CORE_FILES) tests/buttons.png tests/ocr/menu.png
        # Workaround for https://github.com/nose-devs/nose/issues/49:
        cp stbt-control nosetest-issue-49-workaround-stbt-control.py && \
```