### PR TITLE
Refactor: Hide `Gst.Sample` in `_Display` for simplicity

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -36,9 +36,9 @@ from kitchen.text.converters import to_bytes
 
 from _stbt import imgproc_cache, logging, utils
 from _stbt.config import ConfigurationError, get_config
-from _stbt.gst_hacks import gst_iterate
-from _stbt.gst_utils import (get_frame_timestamp, gst_sample_make_writable,
-                             numpy_from_sample, sample_shape)
+from _stbt.gst_utils import (get_frame_timestamp, gst_iterate,
+                             gst_sample_make_writable, numpy_from_sample,
+                             sample_shape)
 from _stbt.logging import ddebug, debug, warn
 
 gi.require_version("Gst", "1.0")

--- a/_stbt/gst_hacks.py
+++ b/_stbt/gst_hacks.py
@@ -130,19 +130,3 @@ def test_map_sample_without_buffer():
             assert False
     except ValueError:
         pass
-
-
-def gst_iterate(gst_iterator):
-    """Wrap a Gst.Iterator to expose the Python iteration protocol.  The
-    gst-python package exposes similar functionality on Gst.Iterator itself so
-    this code should be retired in the future once gst-python is broadly enough
-    available."""
-    result = Gst.IteratorResult.OK
-    while result == Gst.IteratorResult.OK:
-        result, value = gst_iterator.next()
-        if result == Gst.IteratorResult.OK:
-            yield value
-        elif result == Gst.IteratorResult.ERROR:
-            raise RuntimeError("Iteration Error")
-        elif result == Gst.IteratorResult.RESYNC:
-            raise RuntimeError("Iteration Resync")

--- a/_stbt/gst_utils.py
+++ b/_stbt/gst_utils.py
@@ -127,6 +127,22 @@ def sample_shape(sample):
                         "numpy.ndarray.  Received a %s" % str(type(sample)))
 
 
+def gst_iterate(gst_iterator):
+    """Wrap a Gst.Iterator to expose the Python iteration protocol.  The
+    gst-python package exposes similar functionality on Gst.Iterator itself so
+    this code should be retired in the future once gst-python is broadly enough
+    available."""
+    result = Gst.IteratorResult.OK
+    while result == Gst.IteratorResult.OK:
+        result, value = gst_iterator.next()
+        if result == Gst.IteratorResult.OK:
+            yield value
+        elif result == Gst.IteratorResult.ERROR:
+            raise RuntimeError("Iteration Error")
+        elif result == Gst.IteratorResult.RESYNC:
+            raise RuntimeError("Iteration Resync")
+
+
 def frames_to_video(outfilename, frames, caps="image/svg",
                     container="ts"):
     """Given a list (or generator) of video frames generates a video and writes

--- a/_stbt/imgproc_cache.py
+++ b/_stbt/imgproc_cache.py
@@ -19,7 +19,6 @@ from contextlib import contextmanager
 
 import numpy
 
-from _stbt.gst_utils import Gst, numpy_from_sample
 from _stbt.logging import ImageLogger
 from _stbt.utils import mkdir_p, named_temporary_directory, scoped_curdir
 
@@ -204,12 +203,11 @@ class _ArgsEncoder(json.JSONEncoder):
                 "confirm_method": value.confirm_method,
                 "confirm_threshold": value.confirm_threshold,
                 "erode_passes": value.erode_passes}
-        elif isinstance(value, (Gst.Sample, numpy.ndarray)):
+        elif isinstance(value, numpy.ndarray):
             from _stbt.xxhash import Xxhash64
-            with numpy_from_sample(value, readonly=True) as s:
-                h = Xxhash64()
-                h.update(numpy.ascontiguousarray(s).data)
-                return (s.shape, h.hexdigest())
+            h = Xxhash64()
+            h.update(numpy.ascontiguousarray(value).data)
+            return (value.shape, h.hexdigest())
         else:
             json.JSONEncoder.default(self, value)
 

--- a/_stbt/logging.py
+++ b/_stbt/logging.py
@@ -11,7 +11,6 @@ import cv2
 import numpy
 
 from .config import get_config
-from .gst_utils import numpy_from_sample
 from .utils import mkdir_p
 
 _debug_level = None
@@ -127,20 +126,19 @@ class ImageLogger(object):
             return
         if name in self.images:
             raise ValueError("Image for name '%s' already logged" % name)
-        with numpy_from_sample(image, readonly=True) as img:
-            if img.dtype == numpy.float32:
-                # Scale `cv2.matchTemplate` heatmap output in range
-                # [0.0, 1.0] to visible grayscale range [0, 255].
-                img = cv2.convertScaleAbs(image, alpha=255)
-            else:
-                img = img.copy()
-            self.images[name] = img
-            if region:
-                cv2.rectangle(
-                    img, (region.x, region.y), (region.right, region.bottom),
-                    colour, thickness=1)
+        if image.dtype == numpy.float32:
+            # Scale `cv2.matchTemplate` heatmap output in range
+            # [0.0, 1.0] to visible grayscale range [0, 255].
+            image = cv2.convertScaleAbs(image, alpha=255)
+        else:
+            image = image.copy()
+        self.images[name] = image
+        if region:
+            cv2.rectangle(
+                image, (region.x, region.y), (region.right, region.bottom),
+                colour, thickness=1)
 
-            cv2.imwrite(os.path.join(self.outdir, name + ".png"), img)
+        cv2.imwrite(os.path.join(self.outdir, name + ".png"), image)
 
 
 def test_that_debug_can_write_unicode_strings():

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -46,6 +46,10 @@ UNRELEASED
 
 ##### Developer-visible changes
 
+* We no-longer use `with numpy_from_sample` when dealing with frames internally.
+  The new `array_from_sample` and the `CapturedFrame` `ndarray` subclass fulfill
+  a similar job but without needing a `with` block.
+
 #### 25
 
 New features `stbt.FrameObject` and `stbt auto-selftest` that work in tandem to

--- a/extra/pylint.conf
+++ b/extra/pylint.conf
@@ -9,7 +9,7 @@ reports=no
 disable=C0102,C0103,C0111,C0112,C0121,C0202,C0203,C0302,C0321,C0322,C0323,C0324,C0330,E0012,E1103,I0011,I0012,R0201,R0401,R0801,R0901,R0902,R0903,R0904,R0911,R0912,R0913,R0914,R0915,R0921,R0922,R0923,W0142,W0232,W0603
 
 [TYPECHECK]
-ignored-classes=Buffer,Caps,Client,Event,gi.repository.Gst,MainLoop,numpy,numpy.linalg,Sample,scipy.interpolate,scipy.optimize,_socketobject
+ignored-classes=Buffer,Caps,CapturedFrame,Client,Event,gi.repository.Gst,MainLoop,numpy,numpy.linalg,Sample,scipy.interpolate,scipy.optimize,_socketobject
 
 [VARIABLES]
 dummy-variables-rgx=_

--- a/stbt-camera.d/stbt_camera_calibrate.py
+++ b/stbt-camera.d/stbt_camera_calibrate.py
@@ -164,23 +164,21 @@ class NoChessboardError(Exception):
 
 
 def _find_chessboard(appsink, timeout=10):
-    from _stbt.gst_utils import numpy_from_sample
+    from _stbt.gst_utils import array_from_sample
 
     sys.stderr.write("Searching for chessboard\n")
     success = False
     endtime = time.time() + timeout
     while not success and time.time() < endtime:
         sample = appsink.emit("pull-sample")
-        with numpy_from_sample(sample, readonly=True) as input_image:
-            success, corners = cv2.findChessboardCorners(
-                input_image, (29, 15), flags=cv2.cv.CV_CALIB_CB_ADAPTIVE_THRESH)
+        input_image = array_from_sample(sample)
+        success, corners = cv2.findChessboardCorners(
+            input_image, (29, 15), flags=cv2.cv.CV_CALIB_CB_ADAPTIVE_THRESH)
 
     if success:
         # Refine the corner measurements (not sure why this isn't built into
         # findChessboardCorners?
-        with numpy_from_sample(sample, readonly=True) as input_image:
-            grey_image = cv2.cvtColor(input_image, cv2.COLOR_BGR2GRAY)
-
+        grey_image = cv2.cvtColor(input_image, cv2.COLOR_BGR2GRAY)
         cv2.cornerSubPix(grey_image, corners, (5, 5), (-1, -1),
                          (cv2.TERM_CRITERIA_COUNT, 100, 0.1))
 

--- a/stbt-camera.d/stbt_camera_validate.py
+++ b/stbt-camera.d/stbt_camera_validate.py
@@ -88,7 +88,7 @@ def length(vec):
 
 
 def svg_to_array(svg):
-    from _stbt.gst_utils import numpy_from_sample
+    from _stbt.gst_utils import array_from_sample
     pipeline = Gst.parse_launch(
         'appsrc name="src" caps="image/svg" ! rsvgdec ! '
         'videoconvert ! appsink caps="video/x-raw,format=BGR" name="sink"')
@@ -101,8 +101,7 @@ def svg_to_array(svg):
     src.emit("end-of-stream")
     pipeline.set_state(Gst.State.NULL)
     pipeline.get_state(0)
-    with numpy_from_sample(sample, readonly=True) as frame:
-        return frame.copy()
+    return array_from_sample(sample)
 
 
 def generate_letters_svg(fgcolour, bgcolour):

--- a/tests/test-match.sh
+++ b/tests/test-match.sh
@@ -240,7 +240,7 @@ test_press_until_match_max_presses() {
 test_press_until_match_reads_interval_secs_from_config_file() {
     cat > test-3s.py <<-EOF &&
 	import stbt
-	start = stbt._dut._display.gst_samples().next().get_buffer().pts
+	_, start = stbt.frames().next()
 	match = press_until_match(
 	    "checkers-8", "$testdir/videotestsrc-checkers-8.png")
 	assert (match.timestamp - start) >= 3e9, (
@@ -250,7 +250,7 @@ test_press_until_match_reads_interval_secs_from_config_file() {
 
     cat > test-1s.py <<-EOF &&
 	import stbt
-	start = stbt._dut._display.gst_samples().next().get_buffer().pts
+	_, start = stbt.frames().next()
 	match = press_until_match(
 	    "checkers-8", "$testdir/videotestsrc-checkers-8.png")
 	assert (match.timestamp - start) < 3e9, (


### PR DESCRIPTION
We were previously passing around `Gst.Sample`s because:

* There are timestamp metadata attached to them
* It was easier to handle lifetime management of the buffers, specifically WRT calling `gst_buffer_unmap`

These commits create a new numpy array type and a new backing store to solve each of those problems respectively.

Now this is done:

* We now no longer need to put `numpy_from_sample` everywhere.
* It opens the door to reducing copying, in the future we will be able to give clients these frames directly
* We have a place to attach arbitrary extra metadata to frames

I've implemented this for the last point.  I'll be needing that for #364.

TODO:

- [x] Release note: internal change