### PR TITLE
stbt.match_text: Fix exception for single-channel images

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -447,9 +447,7 @@ class MatchResult(object):
                 self.match,
                 self.region,
                 self.first_pass_result,
-                "None" if self.frame is None else "%dx%dx%d" % (
-                    self.frame.shape[1], self.frame.shape[0],
-                    self.frame.shape[2]),
+                _str_frame_dimensions(self.frame),
                 "<Custom Image>" if isinstance(self.image, numpy.ndarray)
                 else repr(self.image)))
 
@@ -466,6 +464,15 @@ class MatchResult(object):
 
     def __nonzero__(self):
         return self.match
+
+
+def _str_frame_dimensions(frame):
+    if frame is None:
+        return "None"
+    if len(frame.shape) == 3:
+        return "%dx%dx%d" % (frame.shape[1], frame.shape[0], frame.shape[2])
+    else:
+        return "%dx%d" % (frame.shape[1], frame.shape[0])
 
 
 class _AnnotatedTemplate(namedtuple('_AnnotatedTemplate',
@@ -608,8 +615,7 @@ class TextMatchResult(object):
                 self.time,
                 self.match,
                 self.region,
-                "%dx%dx%d" % (self.frame.shape[1], self.frame.shape[0],
-                              self.frame.shape[2]),
+                _str_frame_dimensions(self.frame),
                 self.text))
 
     @property

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,24 @@ changes, along with upgrade instructions where necessary.
 For installation instructions see [Getting Started](
 https://github.com/stb-tester/stb-tester/wiki/Getting-started-with-stb-tester).
 
+#### v27
+
+_TODO: Summary._
+
+UNRELEASED
+
+##### Breaking changes since v26
+
+##### New features
+
+##### Minor fixes and packaging fixes
+
+* Python API: `stbt.match_text` can take single-channel images (black-and-white
+  or greyscale).
+
+##### Maintainer-visible changes
+
+
 #### 26
 
 New APIs to support frame-accurate performance measurements.

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -194,3 +194,8 @@ def test_that_match_text_gives_tesseract_a_hint():
     if "ITV Player" not in stbt.ocr(frame=frame, tesseract_user_words=["ITV"]):
         raise SkipTest("Giving tesseract a hint doesn't help")
     assert stbt.match_text("ITV Player", frame=frame)
+
+
+def test_match_text_on_single_channel_image():
+    frame = cv2.imread("tests/ocr/menu.png", cv2.IMREAD_GRAYSCALE)
+    assert stbt.match_text("Onion Bhaji", frame)


### PR DESCRIPTION
The `__repr__` of `TextMatchResult` was raising an `IndexError` if
`match_text` was given a single-channel (black-and-white or greyscale)
image. This means that you couldn't do custom thresholding before
running the image through `match_text`. This was the stack trace:

    Traceback (most recent call last):
     [...]
     _stbt/core.py line 1036 in match_text
       debug("match_text: Match found: %s" % str(result))
     _stbt/core.py line 612 in __repr__
       self.frame.shape[2]),
    IndexError: tuple index out of range

Note that I have also changed `MatchResult.__repr__` for consistency,
but `match` probably needs other changes too before it can support
single-channel images.