### PR TITLE
make check: Use pytest instead of nose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,12 @@
 *.srpm
 *_orc.c
 *_orc.h
+.cache
 .DS_Store
 .stbt-cflags
 .stbt-ldflags
 .stbt-prefix
+__pycache__
 _stbt/libxxhash.so
 _stbt/lmdb/
 debian-packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install:
         astroid==1.2.1
         isort==3.9.0
         pylint==1.3.1
-        rednose
+        pytest==3.0.3
         responses==0.5.1
  - |
      {

--- a/Makefile
+++ b/Makefile
@@ -163,19 +163,20 @@ PYTHON_FILES := \
              | grep -v '^vendor/' \
              | sort | uniq | grep -v tests/webminspector)
 
-check: check-pylint check-nosetests check-integrationtests check-bashcompletion
-check-nosetests: all tests/buttons.png tests/ocr/menu.png
+check: check-pylint check-pytest check-integrationtests check-bashcompletion
+check-pytest: all tests/buttons.png tests/ocr/menu.png
 	# Workaround for https://github.com/nose-devs/nose/issues/49:
 	cp stbt-control nosetest-issue-49-workaround-stbt-control.py && \
-	PYTHONPATH=$$PWD NOSE_REDNOSE=1 \
-	nosetests --with-doctest -v --match "^test_" \
-	    --doctest-options=+ELLIPSIS \
+	PYTHONPATH=$$PWD \
+	py.test -v --doctest-modules \
 	    $(shell git ls-files '*.py' |\
 	      grep -v -e tests/auto_selftest_bare.py \
 		      -e tests/test.py \
 	              -e tests/test2.py \
 	              -e tests/test_functions.py \
 	              -e tests/auto-selftest-example-test-pack/tests/syntax_error.py \
+	              -e tests/auto-selftest-example-test-pack/tests/example_with_no_tests.py \
+	              -e tests/auto-selftest-example-test-pack/tests/empty_dir/subdir/example_with_no_tests.py \
 	              -e tests/vstb-example-html5/ \
 	              -e tests/webminspector/ \
 	              -e vendor/) \
@@ -453,7 +454,7 @@ install-stbt-camera: $(stbt_camera_files) stbt-camera.d/gst/stbt-gst-plugins.so
 
 .PHONY: all clean deb dist doc install install-core uninstall
 .PHONY: check check-bashcompletion check-hardware check-integrationtests
-.PHONY: check-nosetests check-pylint install-for-test
+.PHONY: check-pytest check-pylint install-for-test
 .PHONY: ppa-publish rpm srpm
 .PHONY: check-cameratests install-stbt-camera
 .PHONY: FORCE TAGS

--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -699,7 +699,7 @@ def test_samsung_tcp_remote():
 
 
 def test_x11_remote():
-    from nose.plugins.skip import SkipTest
+    from unittest import SkipTest
     from .x11 import x_server
     if not find_executable('Xorg') or not find_executable('xterm'):
         raise SkipTest("Testing X11Remote requires X11 and xterm")

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -2737,12 +2737,12 @@ def test_ocr_on_static_images():
 
 
 def test_region_replace():
-    from nose.tools import eq_, raises
+    from nose.tools import raises
 
     r = Region(x=10, y=20, width=20, height=30)
 
     def t(kwargs, expected):
-        eq_(r.replace(**kwargs), expected)
+        assert r.replace(**kwargs) == expected
 
     @raises(ValueError)
     def e(kwargs):

--- a/_stbt/imgproc_cache.py
+++ b/_stbt/imgproc_cache.py
@@ -324,7 +324,7 @@ def test_memoize_iterator_on_empty_iterator():
 
 def test_that_cache_speeds_up_match():
     import stbt
-    black = numpy.zeros((720, 1280, 3), dtype=numpy.uint8)
+    black = numpy.zeros((1440, 2560, 3), dtype=numpy.uint8)
 
     def match():
         return stbt.match('tests/red-black.png', frame=black)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+python_functions = test_
+addopts = --doctest-modules
+doctest_optionflags = ELLIPSIS

--- a/stbt_auto_selftest.py
+++ b/stbt_auto_selftest.py
@@ -465,7 +465,7 @@ def update_doctests(infilename, outfile):
 
 
 def test_update_doctests():
-    # We test that what we generate is what we expect.  make check-nosetests
+    # We test that what we generate is what we expect.  make check-pytest
     # will check that the generated doctest passes as a doctest itself.
     import subprocess
     from tempfile import NamedTemporaryFile

--- a/tests/test-stbt-auto-selftest.sh
+++ b/tests/test-stbt-auto-selftest.sh
@@ -7,7 +7,7 @@ test_auto_selftest_generate()
     stbt --with-experimental auto-selftest generate &&
     cd .. &&
 
-    find . -name '*.pyc' -delete &&
+    find . -name '*.pyc' -delete -o -name __pycache__ -delete &&
     diff -ur "pristine" "regenerated"
 }
 

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -6,7 +6,7 @@ from textwrap import dedent
 from unittest import SkipTest
 
 import cv2
-from nose.tools import eq_, raises
+from nose.tools import raises
 
 import _stbt.core
 import stbt
@@ -19,12 +19,13 @@ def test_that_ocr_returns_unicode():
 
 def test_that_ocr_reads_unicode():
     text = stbt.ocr(frame=cv2.imread('tests/ocr/unicode.png'), lang='eng+deu')
-    eq_(u'£500\nRöthlisberger', text)
+    assert u'£500\nRöthlisberger' == text
 
 
 def test_that_ocr_can_read_small_text():
     text = stbt.ocr(frame=cv2.imread('tests/ocr/small.png'))
-    eq_(u'Small anti-aliased text is hard to read\nunless you magnify', text)
+    assert u'Small anti-aliased text is hard to read\nunless you magnify' == \
+        text
 
 
 ligature_text = dedent(u"""\
@@ -43,7 +44,7 @@ ligature_text = dedent(u"""\
 def test_that_ligatures_and_ambiguous_punctuation_are_normalised():
     text = stbt.ocr(frame=cv2.imread('tests/ocr/ambig.png'))
     text = text.replace("horizonta|", "horizontal")  # for tesseract < 3.03
-    eq_(ligature_text, text)
+    assert ligature_text == text
 
 
 def test_that_setting_config_options_has_an_effect():
@@ -80,10 +81,10 @@ def test_that_passing_patterns_helps_reading_serial_codes():
         raise SkipTest('tesseract is too old')
 
     # Now the real test:
-    eq_(u'UJJM2LGE', stbt.ocr(
+    assert u'UJJM2LGE' == stbt.ocr(
         frame=cv2.imread('tests/ocr/UJJM2LGE.png'),
         mode=stbt.OcrMode.SINGLE_WORD,
-        tesseract_user_patterns=[r'\n\n\n\n\n\n\n\n']))
+        tesseract_user_patterns=[r'\n\n\n\n\n\n\n\n'])
 
 
 @raises(RuntimeError)
@@ -100,11 +101,11 @@ def test_that_with_old_tesseract_ocr_raises_an_exception_with_patterns():
 
 
 def test_user_dictionary_with_non_english_language():
-    eq_(u'UJJM2LGE', stbt.ocr(
+    assert u'UJJM2LGE' == stbt.ocr(
         frame=cv2.imread('tests/ocr/UJJM2LGE.png'),
         mode=stbt.OcrMode.SINGLE_WORD,
         lang="deu",
-        tesseract_user_words=[u'UJJM2LGE']))
+        tesseract_user_words=[u'UJJM2LGE'])
 
 # Menu as listed in menu.svg:
 menu = [

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -3,9 +3,9 @@
 import distutils
 import re
 from textwrap import dedent
+from unittest import SkipTest
 
 import cv2
-from nose.plugins.skip import SkipTest
 from nose.tools import eq_, raises
 
 import _stbt.core

--- a/tests/test_set_config.py
+++ b/tests/test_set_config.py
@@ -75,7 +75,7 @@ def test_that_set_config_preserves_file_comments_and_formatting():
     # comments and whitespace are not currently stored in Python's internal
     # ConfigParser representation and multiline values makes just using regex
     # tricky.
-    from nose import SkipTest
+    from unittest import SkipTest
     raise SkipTest("set_config doesn't currently preserve formatting")
     with set_config_test():
         set_config('global', 'test', 'goodbye')


### PR DESCRIPTION
...to run our Python unit tests & doctests.

Pytest is a drop-in replacement for nose, and it has some advanced
features that I want to take advantage of in future commits, such as
test parametrization[1] and fixtures[2]. We will also benefit
immediately from pytest's cleaner output (it captures stderr as well as
stdout, so we don't have stderr output from stbt intermingled with the
py.test output) and pytest's advanced assert introspection[3].

[1]: http://doc.pytest.org/en/latest/parametrize.html
[2]: http://doc.pytest.org/en/latest/fixture.html
[3]: http://doc.pytest.org/en/latest/assert.html