### PR TITLE
Add stbt control-relay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ INSTALL_CORE_FILES = \
     _stbt/xorg.conf.in \
     _stbt/xxhash.py \
     stbt_auto_selftest.py \
+    stbt_control_relay.py \
     stbt-batch \
     stbt-batch.d/instaweb \
     stbt-batch.d/report \

--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -51,6 +51,7 @@ def uri_to_remote_recorder(uri):
          lirc_remote_listen_tcp),
         (r'lirc:(?P<lircd_socket>[^:]+)?:(?P<control_name>.+)',
          lirc_remote_listen),
+        (r'lircd(:(?P<lircd_socket>[^:]+))?', fake_lircd_listen),
         (r'stbt-control(:(?P<keymap_file>.+))?', stbt_control_listen),
         (r'vr:(?P<address>[^:/]*)(:(?P<port>\d+))?', virtual_remote_listen),
     ]
@@ -498,7 +499,8 @@ def virtual_remote_listen(address, port=None):
 
 def lirc_remote_listen(lircd_socket, control_name):
     """Returns an iterator yielding keypresses received from a lircd file
-    socket.
+    socket -- that is, the keypresses that lircd received from a hardware
+    infrared receiver and is now sending on to us.
 
     See http://www.lirc.org/html/technical.html#applications
     """
@@ -554,6 +556,25 @@ def lirc_key_reader(cmd_iter, control_name):
             s)
         if m and int(m.group('repeat_count')) == 0:
             yield m.group('key')
+
+
+def fake_lircd_listen(lircd_socket=None):
+    """Pretend to be lircd, yielding keys that are sent to us by a lirc client
+    such as ``irsend``.
+    """
+    if lircd_socket is None:
+        lircd_socket = DEFAULT_LIRCD_SOCKET
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.bind(lircd_socket)
+    s.listen(5)
+
+    while True:
+        control, _ = s.accept()
+        for cmd in control.makefile():
+            m = re.match(r'SEND_ONCE (?P<ctrl>\w+) (?P<key>\w+)', cmd)
+            control.sendall('BEGIN\n%sSUCCESS\nEND\n' % cmd)
+            yield m.groupdict()["key"]
+        control.close()
 
 
 def _connect_tcp_socket(address, port, timeout=3):

--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -35,6 +35,7 @@ def uri_to_remote(uri, display=None):
         (r'test', lambda: VideoTestSrcControl(display)),
         (r'vr:(?P<hostname>[^:/]+)(:(?P<port>\d+))?', VirtualRemote),
         (r'x11:(?P<display>[^,]+)?(,(?P<mapping>.+)?)?', _X11Remote),
+        (r'file(:(?P<filename>[^,]+))?', FileControl),
     ]
     for regex, factory in remotes:
         m = re.match(regex, uri, re.VERBOSE | re.IGNORECASE)
@@ -65,6 +66,21 @@ class NullRemote(object):
     @staticmethod
     def press(key):
         debug('NullRemote: Ignoring request to press "%s"' % key)
+
+
+class FileControl(object):
+    """Writes keypress events to file.  Mostly useful for testing.  Defaults to
+    writing to stdout.
+    """
+    def __init__(self, filename):
+        if filename is None:
+            self.outfile = sys.stdout
+        else:
+            self.outfile = open(filename, 'w+')
+
+    def press(self, key):
+        self.outfile.write(key + '\n')
+        self.outfile.flush()
 
 
 class VideoTestSrcControl(object):

--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -69,6 +69,18 @@ class NullRemote(object):
         debug('NullRemote: Ignoring request to press "%s"' % key)
 
 
+class MultiRemote(object):
+    """Allows sending press events on multiple remotes at a time.
+    """
+    def __init__(self, controls):
+        from multiprocessing.pool import ThreadPool
+        self.pool = ThreadPool()
+        self._controls = list(controls)
+
+    def press(self, key):
+        self.pool.map(lambda r: r.press(key), self._controls)
+
+
 class FileControl(object):
     """Writes keypress events to file.  Mostly useful for testing.  Defaults to
     writing to stdout.

--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -503,7 +503,7 @@ def lirc_remote_listen(lircd_socket, control_name):
     See http://www.lirc.org/html/technical.html#applications
     """
     if lircd_socket is None:
-        lircd_socket = '/var/run/lirc/lircd'
+        lircd_socket = DEFAULT_LIRCD_SOCKET
     lircd = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     debug("control-recorder connecting to lirc file socket '%s'..." %
           lircd_socket)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -39,6 +39,11 @@ UNRELEASED
 * Remote controls: Added `file:` remote control which writes keys pressed to a
   file.  Mostly intended for debugging.
 
+* Remote controls: Added a `lircd` remote control listener which pretends to
+  be lircd. This is distinct from the existing `lirc` remote control listener
+  which connects to a running `lircd` instance and reads which keys have been
+  pressed.
+
 ##### Maintainer-visible changes
 
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -28,6 +28,10 @@ UNRELEASED
   `right_of` and `left_of`. They return a new Region relative to the current
   region.
 
+* Added helper utility `stbt control-relay` which allows you to use any stbt
+  remote control using the lirc socket protocol. This for example allows you to
+  control a roku via its HTTP REST API using `irsend`.
+
 ##### Minor fixes and packaging fixes
 
 * Python API: `stbt.match_text` can take single-channel images (black-and-white

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -36,6 +36,9 @@ UNRELEASED
 * Python API: `stbt.match_text` normalises punctuation such as em-dash and
   en-dash, just like `stbt.ocr` already does.
 
+* Remote controls: Added `file:` remote control which writes keys pressed to a
+  file.  Mostly intended for debugging.
+
 ##### Maintainer-visible changes
 
 

--- a/docs/stbt.1.rst
+++ b/docs/stbt.1.rst
@@ -163,8 +163,14 @@ Additional options to stbt record
   The source of remote control presses.  `uri` can be:
 
   lirc:([<lircd_socket>]|[<hostname>:]<port>):<remote_control_name>
-    A hardware infrared receiver controlled by the lirc (Linux Infrared Remote
-    Control) daemon. Parameters are as for `--control`.
+    This reports the keypresses that lircd (Linux Infrared Remote Control
+    daemon) receives from a hardware infrared receiver. Parameters are as for
+    `--control`.
+
+  lircd[:<lircd_socket>]
+    This pretends to be lircd, and reports the keypresses that it receives from
+    a lirc client such as the ``irsend`` command-line tool or another
+    ``stbt run`` process.
 
   file://<filename>
     Reads remote control keypresses from a newline-separated list of key names.

--- a/docs/stbt.1.rst
+++ b/docs/stbt.1.rst
@@ -123,6 +123,11 @@ Global options
 
     The x11 control requires that `xdotool` is installed.
 
+  file[:<filename>]
+    Append a newline seperated key name to the given file for each press.
+    Mostly useful for testing.  If a filename is not specified it defaults to
+    stdout.
+
 --source-pipeline=<pipeline>
   A GStreamer pipeline providing a video stream to use as video output from the
   set-top box under test.  For the Hauppauge HD PVR use::

--- a/stbt.sh.in
+++ b/stbt.sh.in
@@ -12,6 +12,7 @@
 #/     auto-selftest  Test your test-cases against saved screenshots
 #/     config         Print configuration value
 #/     control        Send remote control signals
+#/     control-relay  Relay remote control keypresses
 #/     lint           Static analysis of testcases
 #/     match          Compare two images
 #/     power          Control networked power switch
@@ -59,6 +60,8 @@ case "$cmd" in
         echo "stb-tester $STBT_VERSION"; exit 0;;
     auto-selftest)
         exec @LIBEXECDIR@/stbt/stbt_auto_selftest.py "$@";;
+    control-relay)
+        exec @LIBEXECDIR@/stbt/stbt_control_relay.py "$@";;
     run|record|batch|config|control|lint|power|screenshot|match|tv)
         exec @LIBEXECDIR@/stbt/stbt-"$cmd" "$@";;
     templatematch)  # for backwards compatibility

--- a/stbt_control_relay.py
+++ b/stbt_control_relay.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python
+"""
+Allows using any of the stbt remote control backends remotely using the lirc
+protocol.
+
+Presents the same socket protocol as lircd but sending keypresses using any of
+stbt's controls.  This allows for example controlling a roku over its HTTP
+interface from some software that only speaks lirc.
+
+Example usage:
+
+    $ stbt control-relay file:example
+
+Listens on `/var/run/lirc/lircd` for lirc clients.  Keypress sent will be
+written to the file example.  So
+
+    $ irsend SEND_ONCE stbt KEY_UP
+
+Will write the text "KEY_UP" to the file `example`.
+
+    $ stbt control-relay --input=lircd:lircd.sock \\
+          roku:192.168.1.13 samsung:192.168.1.14
+
+Listens on lircd.sock and will forward keypresses to the roku at 192.168.1.13
+using its HTTP protocol and to the Samsung TV at 192.168.1.14 using its TCP
+protocol.  So
+
+    $ irsend -d lircd.sock SEND_ONCE stbt KEY_OK
+
+Will press KEY_OK on both the Samsung and the roku devices simultaneously.
+"""
+import argparse
+import signal
+import sys
+
+from _stbt.control import MultiRemote, uri_to_remote, uri_to_remote_recorder
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(
+        epilog=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--input", default="lircd")
+    parser.add_argument("output", nargs="*")
+    args = parser.parse_args(argv[1:])
+
+    signal.signal(signal.SIGTERM, lambda _signo, _stack_frame: sys.exit(0))
+
+    r = MultiRemote(uri_to_remote(x) for x in args.output)
+    listener = uri_to_remote_recorder(args.input)
+    for key in listener:
+        sys.stderr.write("Received %s\n" % key)
+        r.press(key)
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/test_stbt_control_relay.py
+++ b/tests/test_stbt_control_relay.py
@@ -1,0 +1,52 @@
+import os
+import subprocess
+from contextlib import contextmanager
+
+from _stbt.control import uri_to_remote
+from _stbt.core import wait_until
+from _stbt.utils import named_temporary_directory
+
+
+@contextmanager
+def scoped_process(process):
+    try:
+        yield process
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+
+
+def srcdir(filename="", here=os.path.abspath(__file__)):
+    return os.path.join(os.path.dirname(here), "..", filename)
+
+
+def test_stbt_control_relay():
+    with named_temporary_directory("stbt-control-relay-test.XXXXXX") as tmpdir:
+        def t(filename):
+            return os.path.join(tmpdir, filename)
+        proc = subprocess.Popen(
+            [srcdir("stbt_control_relay.py"),
+             "--input=lircd:" + t("lircd.sock"),
+             "file:" + t("one-file"), "file:" + t("another")])
+        with scoped_process(proc):
+            wait_until(lambda: (
+                os.path.exists(t("lircd.sock")) or proc.poll() is not None))
+            testremote = uri_to_remote("lirc:%s:stbt" % t("lircd.sock"))
+
+            testremote.press("KEY_UP")
+            testremote.press("KEY_DOWN")
+            expected = "KEY_UP\nKEY_DOWN\n"
+
+            def filecontains(filename, text):
+                try:
+                    with open(t(filename)) as f:
+                        return text == f.read()
+                except OSError:
+                    return None
+
+            wait_until(lambda: (
+                filecontains("one-file", expected) and
+                filecontains("another", expected)))
+            assert open(t("one-file")).read() == expected
+            assert open(t("another")).read() == expected


### PR DESCRIPTION
`stbt control-relay` allows you to use any stbt remote control using the lirc socket protocol. This for example allows you to control a roku via its HTTP REST API using `irsend`.
