### PR TITLE
Hdmi cec control

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
  - sudo apt-get update
  - sudo apt-get -y install
         chromium-browser
+        cmake
         expect
         expect-dev
         gir1.2-gstreamer-1.0
@@ -20,12 +21,14 @@ install:
         gstreamer1.0-plugins-good
         gstreamer1.0-tools
         gstreamer1.0-x
-        libcec-dev
         libgstreamer1.0-dev
         libgstreamer-plugins-base1.0-dev
+        liblockdev1-dev
         libopencv-dev
         liborc-0.4-dev
         librsvg2-bin
+        libudev-dev
+        libxrandr-dev
         lighttpd
         moreutils
         pep8
@@ -51,6 +54,7 @@ install:
         python-zbar
         ratpoison
         socat
+        swig
         tesseract-ocr
         tesseract-ocr-deu
         tesseract-ocr-eng
@@ -64,7 +68,27 @@ install:
         pylint==1.6.4
         pytest==3.0.3
         responses==0.5.1
-        cec==0.2.5
+ - |
+     date &&
+     git clone -b libcec-3.1.0 https://github.com/Pulse-Eight/libcec.git &&
+     git clone -b p8-platform-2.0.1 https://github.com/Pulse-Eight/platform.git &&
+     mkdir platform/build &&
+     cd platform/build &&
+     cmake .. &&
+     make &&
+     sudo make install &&
+     cd ../.. &&
+     mkdir libcec/build &&
+     cd libcec/build &&
+     cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+         -DPYTHON_INCLUDE_DIR:PATH=/usr/include/python2.7 \
+         -DPYTHON_LIBRARY:FILEPATH=/usr/lib/x86_64-linux-gnu/libpython2.7.so \
+         -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python2.7 \
+         .. &&
+     make &&
+     sudo make install &&
+     cd ../.. &&
+     date
  - |
      {
        wget http://ftpmirror.gnu.org/parallel/parallel-20140522.tar.bz2 ||

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
         gstreamer1.0-plugins-good
         gstreamer1.0-tools
         gstreamer1.0-x
+        libcec-dev
         libgstreamer1.0-dev
         libgstreamer-plugins-base1.0-dev
         libopencv-dev
@@ -63,6 +64,7 @@ install:
         pylint==1.6.4
         pytest==3.0.3
         responses==0.5.1
+        cec==0.2.5
  - |
      {
        wget http://ftpmirror.gnu.org/parallel/parallel-20140522.tar.bz2 ||

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,17 @@ install-virtual-stb: $(INSTALL_VSTB_FILES)
 	    $(INSTALL) -m $$mode $$filename $(DESTDIR)$(libexecdir)/stbt/$$filename; \
 	done
 
+INSTALL_GPL_FILES = \
+    _stbt/control_gpl.py
+
+install-gpl: $(INSTALL_GPL_FILES)
+	$(INSTALL) -m 0755 -d \
+	    $(patsubst %,$(DESTDIR)$(libexecdir)/stbt/%,$(sort $(dir $(INSTALL_GPL_FILES))))
+	for filename in $(INSTALL_GPL_FILES); do \
+	    [ -x "$$filename" ] && mode=0755 || mode=0644; \
+	    $(INSTALL) -m $$mode $$filename $(DESTDIR)$(libexecdir)/stbt/$$filename; \
+	done
+
 uninstall:
 	rm -f $(DESTDIR)$(bindir)/stbt
 	rm -f $(DESTDIR)$(bindir)/irnetbox-proxy

--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -16,6 +16,11 @@ from .logging import debug, scoped_debug_level
 
 __all__ = ['uri_to_remote', 'uri_to_remote_recorder']
 
+try:
+    from .control_gpl import controls as gpl_controls
+except ImportError:
+    gpl_controls = None
+
 
 def uri_to_remote(uri, display=None):
     remotes = [
@@ -37,6 +42,8 @@ def uri_to_remote(uri, display=None):
         (r'x11:(?P<display>[^,]+)?(,(?P<mapping>.+)?)?', _X11Remote),
         (r'file(:(?P<filename>[^,]+))?', FileControl),
     ]
+    if gpl_controls is not None:
+        remotes += gpl_controls
     for regex, factory in remotes:
         m = re.match(regex, uri, re.VERBOSE | re.IGNORECASE)
         if m:

--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -22,6 +22,10 @@ except ImportError:
     gpl_controls = None
 
 
+class UnknownKeyError(Exception):
+    pass
+
+
 def uri_to_remote(uri, display=None):
     remotes = [
         (r'''irnetbox:
@@ -44,6 +48,7 @@ def uri_to_remote(uri, display=None):
     ]
     if gpl_controls is not None:
         remotes += gpl_controls
+
     for regex, factory in remotes:
         m = re.match(regex, uri, re.VERBOSE | re.IGNORECASE)
         if m:

--- a/_stbt/control_gpl.py
+++ b/_stbt/control_gpl.py
@@ -1,2 +1,239 @@
+from contextlib import contextmanager
+from textwrap import dedent
+
+from .logging import debug
+
+
+class HdmiCecError(Exception):
+    pass
+
+
+class HdmiCecControl(object):
+    # Map our recommended keynames (from linux input-event-codes.h) to the
+    # equivalent CEC commands.
+    # The mapping between CEC commands and code can be found at
+    # http://www.cec-o-matic.com or in HDMI-CEC specification 1.3a
+    _KEYNAMES = {
+        "KEY_OK": 0,
+        "KEY_UP": 1,
+        "KEY_DOWN": 2,
+        "KEY_LEFT": 3,
+        "KEY_RIGHT": 4,
+        "KEY_RIGHT_UP": 5,
+        "KEY_RIGHT_DOWN": 6,
+        "KEY_LEFT_UP": 7,
+        "KEY_LEFT_DOWN": 8,
+        "KEY_ROOT_MENU": 9,
+        "KEY_SETUP": 10,
+        "KEY_CONTENTS_MENU": 11,  # <- not in input-event-codes.h
+        "KEY_FAVORITE_MENU": 12,  # <- not in input-event-codes.h
+        "KEY_BACK": 13,
+        "KEY_0": 32,
+        "KEY_1": 33,
+        "KEY_2": 34,
+        "KEY_3": 35,
+        "KEY_4": 36,
+        "KEY_5": 37,
+        "KEY_6": 38,
+        "KEY_7": 39,
+        "KEY_8": 40,
+        "KEY_9": 41,
+        "KEY_DOT": 42,
+        "KEY_ENTER": 43,
+        "KEY_CLEAR": 44,
+        "KEY_NEXT_FAVORITE": 47,  # <- not in input-event-codes.h
+        "KEY_CHANNELUP": 48,
+        "KEY_CHANNELDOWN": 49,
+        "KEY_PREVIOUS": 50,
+        "KEY_SOUND_SELECT": 51,  # <- not in input-event-codes.h
+        "KEY_INPUT_SELECT": 52,  # <- not in input-event-codes.h
+        "KEY_INFO": 53,
+        "KEY_HELP": 54,
+        "KEY_PAGEUP": 55,
+        "KEY_PAGEDOWN": 56,
+        "KEY_POWER": 64,
+        "KEY_VOLUMEUP": 65,
+        "KEY_VOLUMEDOWN": 66,
+        "KEY_MUTE": 67,
+        "KEY_PLAY": 68,
+        "KEY_STOP": 69,
+        "KEY_PAUSE": 70,
+        "KEY_RECORD": 71,
+        "KEY_REWIND": 72,
+        "KEY_FASTFORWARD": 73,
+        "KEY_EJECT": 74,
+        "KEY_FORWARD": 75,
+        "KEY_BACKWARD": 76,
+        "KEY_STOP_RECORD": 77,
+        "KEY_PAUSE_RECORD": 78,
+        "KEY_ANGLE": 80,
+        "KEY_SUB_PICTURE": 81,  # <- not in input-event-codes.h
+        "KEY_VOD": 82,
+        "KEY_EPG": 83,
+        "KEY_TIMER_PROGRAMMING": 84,  # <- not in input-event-codes.h
+        "KEY_CONFIG": 85,
+
+        # Not sure what the difference is between KEY_PLAY and KEY_PLAY_FUNCTION
+        # is but none of these _FUNCTION keys are in linux-event-codes.h:
+        "KEY_PLAY_FUNCTION": 96,
+        "KEY_PAUSE_PLAY_FUNCTION": 97,
+        "KEY_RECORD_FUNCTION": 98,
+        "KEY_PAUSE_RECORD_FUNCTION": 99,
+        "KEY_STOP_FUNCTION": 100,
+        "KEY_MUTE_FUNCTION": 101,
+        "KEY_RESTORE_VOLUME_FUNCTION": 102,
+        "KEY_TUNE_FUNCTION": 103,
+        "KEY_SELECT_MEDIA_FUNCTION": 104,
+        "KEY_SELECT_AV_INPUT_FUNCTION": 105,
+        "KEY_SELECT_AUDIO_INPUT_FUNCTION": 106,
+        "KEY_POWER_TOGGLE_FUNCTION": 107,
+        "KEY_POWER_OFF_FUNCTION": 108,
+        "KEY_POWER_ON_FUNCTION": 109,
+
+        # Back to normal keys.  We duplicate these colour buttons because HDMI
+        # doesn't make a distinction:
+        "KEY_F1": 113,
+        "KEY_BLUE": 113,
+        "KEY_F2": 114,
+        "KEY_RED": 114,
+        "KEY_F3": 115,
+        "KEY_GREEN": 115,
+        "KEY_F4": 116,
+        "KEY_YELLOW": 116,
+
+        # And back to normal keys:
+        "KEY_F5": 117,
+        "KEY_DATA": 118,
+    }
+
+    def __init__(self, device, source, destination):
+        import cec
+        if source is None:
+            source = 1
+        if destination is None:
+            destination = 4
+        if isinstance(source, (str, unicode)):
+            source = int(source, 16)
+        if isinstance(destination, (str, unicode)):
+            destination = int(destination, 16)
+
+        self.source = source
+        self.destination = destination
+
+        self.cecconfig = cec.libcec_configuration()
+        self.cecconfig.strDeviceName = "stb-tester"
+        self.cecconfig.bActivateSource = 0
+        self.cecconfig.deviceTypes.Add(cec.CEC_DEVICE_TYPE_RECORDING_DEVICE)
+        self.cecconfig.clientVersion = cec.LIBCEC_VERSION_CURRENT
+        self.lib = cec.ICECAdapter.Create(self.cecconfig)
+        debug("libCEC version %s loaded: %s" % (
+            self.lib.VersionToString(self.cecconfig.serverVersion),
+            self.lib.GetLibInfo()))
+
+        if device is None:
+            device = self.detect_adapter()
+            if device is None:
+                raise HdmiCecError("No adapter found")
+        if not self.lib.Open(device):
+            raise HdmiCecError("Failed to open a connection to the CEC adapter")
+        debug("Connection to CEC adapter opened")
+
+    def press(self, key):
+        from .control import UnknownKeyError
+        keycode = self._KEYNAMES.get(key)
+        if keycode is None:
+            raise UnknownKeyError("HdmiCecControl: Unknown key %r" % key)
+        cec_command = "%X%X:44:%02X" % (self.source, self.destination, keycode)
+        key_down_cmd = self.lib.CommandFromString(cec_command)
+        key_up_cmd = self.lib.CommandFromString(
+            '%X%X:45' % (self.source, self.destination))
+
+        debug("cec: Transmit %s as %s" % (key, cec_command))
+        if not self.lib.Transmit(key_down_cmd):
+            raise HdmiCecError(
+                "Failed to send key down command %s" % cec_command)
+        if not self.lib.Transmit(key_up_cmd):
+            raise HdmiCecError(
+                "Failed to send key up command %s" % cec_command)
+
+    # detect an adapter and return the com port path
+    def detect_adapter(self):
+        retval = None
+        adapters = self.lib.DetectAdapters()
+        for adapter in adapters:
+            debug(
+                dedent("""\
+                    Found a CEC adapter:"
+                    Port:     %s" + adapter.strComName)
+                    Vendor:   %x" + hex(adapter.iVendorId))
+                    Product:  %x" + hex(adapter.iProductId))""") %
+                (adapter.strComName, adapter.iVendorId, adapter.iProductId))
+            retval = adapter.strComName
+        return retval
+
+
+def test_hdmi_cec_control():
+    from .control import uri_to_remote
+    with _fake_cec() as io:
+        r = uri_to_remote('hdmi-cec:test-device:7:a')
+        r.press("KEY_UP")
+        r.press("KEY_UP")
+        r.press("KEY_POWER")
+
+    assert io.getvalue() == dedent("""\
+        Open('test-device')
+        Transmit(dest: 0xa, src: 0x7, op: 0x44, data: <01>)
+        Transmit(dest: 0xa, src: 0x7, op: 0x45, data: <>)
+        Transmit(dest: 0xa, src: 0x7, op: 0x44, data: <01>)
+        Transmit(dest: 0xa, src: 0x7, op: 0x45, data: <>)
+        Transmit(dest: 0xa, src: 0x7, op: 0x44, data: <40>)
+        Transmit(dest: 0xa, src: 0x7, op: 0x45, data: <>)
+        """)
+
+
+def test_hdmi_cec_control_defaults():
+    from .control import uri_to_remote
+    with _fake_cec() as io:
+        r = uri_to_remote('hdmi-cec:test-device')
+        r.press("KEY_OK")
+
+    assert io.getvalue() == dedent("""\
+        Open('test-device')
+        Transmit(dest: 0x4, src: 0x1, op: 0x44, data: <00>)
+        Transmit(dest: 0x4, src: 0x1, op: 0x45, data: <>)
+        """)
+
+
+@contextmanager
+def _fake_cec():
+    import StringIO
+    from mock import patch
+
+    io = StringIO.StringIO()
+
+    def fake_open(_, device):
+        io.write('Open(%r)\n' % device)
+        return True
+
+    def cec_cmd_get_data(cmd):
+        # Ugly, but can't find another way to do it
+        import ctypes
+        return str(buffer(ctypes.cast(
+            int(cmd.parameters.data), ctypes.POINTER(ctypes.c_uint8)).contents,
+            0, cmd.parameters.size))
+
+    def fake_transmit(_, cmd):
+        io.write("Transmit(dest: 0x%x, src: 0x%x, op: 0x%x, data: <%s>)\n" % (
+            cmd.destination, cmd.initiator, cmd.opcode,
+            cec_cmd_get_data(cmd).encode('hex')))
+        return True
+
+    with patch('cec.ICECAdapter.Open', fake_open), \
+            patch('cec.ICECAdapter.Transmit', fake_transmit):
+        yield io
+
 controls = [
+    # pylint: disable=line-too-long
+    (r'hdmi-cec(:(?P<device>[^:]+)(:(?P<source>[^:]+)(:(?P<destination>[^:]+))?)?)?',
+     HdmiCecControl),
 ]

--- a/_stbt/control_gpl.py
+++ b/_stbt/control_gpl.py
@@ -1,0 +1,2 @@
+controls = [
+]

--- a/_stbt/control_gpl.py
+++ b/_stbt/control_gpl.py
@@ -207,7 +207,10 @@ def test_hdmi_cec_control_defaults():
 @contextmanager
 def _fake_cec():
     import StringIO
+    import pytest
     from mock import patch
+
+    pytest.importorskip("cec")
 
     io = StringIO.StringIO()
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -32,6 +32,19 @@ UNRELEASED
   remote control using the lirc socket protocol. This for example allows you to
   control a roku via its HTTP REST API using `irsend`.
 
+* New remote-control type "hdmi-cec". With the help of a USB-CEC adapter such
+  as <https://www.pulse-eight.com/p/104/usb-hdmi-cec-adapter> this allows
+  stb-tester to send keypresses over HDMI, to control devices that don't have
+  infrared input such as Sony PlayStation.
+
+  This remote control isn't included in the `stb-tester` Ubuntu packages we
+  publish, because it uses libcec which has a GPLv2+ license (stb-tester is
+  LGPL licensed). To get the CEC remote control, install the `stb-tester-gpl`
+  package (currently only available for Ubuntu 16.04).
+
+  Thanks to Daniel Andersson (@danielandersson) for the initial prototype and
+  research.
+
 ##### Minor fixes and packaging fixes
 
 * Python API: `stbt.match_text` can take single-channel images (black-and-white

--- a/docs/stbt.1.rst
+++ b/docs/stbt.1.rst
@@ -81,6 +81,36 @@ Global options
     "IR Signal Database Utility".
     stbt supports the irNetBox models II and III.
 
+  hdmi-cec:[<device>]:[<source>]:[<destination>]
+    In conjuction with a USB-CEC adaptor this controls a set-top box by sending
+    key-presses over HDMI.  This is useful for devices that lack an IR input
+    such as the Playstation 4.
+
+    * The USB-CEC adaptor to use.  Leave empty to auto-detect.
+
+    * source/destination - A hexidecimal number between 0 and f indicating the
+      HDMI source/destination.  Source defaults to 1 (Recording 1), destination
+      defaults to 4 (Playback 1).
+
+      The different values mean:
+
+        * 0 - TV
+        * 1 - Recording 1
+        * 2 - Recording 2
+        * 3 - Tuner 1
+        * 4 - Playback 1
+        * 5 - Audio system
+        * 6 - Tuner 2
+        * 7 - Tuner 3
+        * 8 - Playback 2
+        * 9 - Playback 3
+        * a - Tuner 4
+        * b - Playback 3
+        * c - Reserved
+        * d - Reserved
+        * e - Reserved
+        * f - Unregistered (source)/Broadcast (destination)
+
   roku:<hostname>
     Controls Roku players using the Roku's HTTP control protocol. Stb-tester's
     standard key names (like "KEY_HOME") will be converted to the corresponding

--- a/extra/debian/control
+++ b/extra/debian/control
@@ -115,6 +115,7 @@ Description: Support for "virtual" set-top boxes where the stb software runs on
 
 Package: stb-tester-gpl
 Architecture: any
-Depends: stb-tester (>> ${source:Upstream-Version})
+Depends: stb-tester (>> ${source:Upstream-Version}),
+         python-libcec
 Description: Support for additional stb-tester features that depend on GPLed
  libraries, rather than the LGPL that the rest of stb-tester uses.

--- a/extra/debian/control
+++ b/extra/debian/control
@@ -112,3 +112,9 @@ Depends: stb-tester (>> ${source:Upstream-Version}),
          xserver-xorg-video-dummy
 Description: Support for "virtual" set-top boxes where the stb software runs on
  the host PC rather than on specific hardware.
+
+Package: stb-tester-gpl
+Architecture: any
+Depends: stb-tester (>> ${source:Upstream-Version})
+Description: Support for additional stb-tester features that depend on GPLed
+ libraries, rather than the LGPL that the rest of stb-tester uses.

--- a/extra/debian/control
+++ b/extra/debian/control
@@ -1,5 +1,6 @@
 Source: stb-tester
 Maintainer: William Manley <will@stb-tester.com>
+Homepage: https://stb-tester.com
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
@@ -83,10 +84,10 @@ Depends: ${shlibs:Depends},
          tesseract-ocr,
          tesseract-ocr-eng
 Description: Automated User Interface testing for set-top boxes. 
- stb-tester tests a set-top-box by issuing commands to it using a remote-control
- and checking that it has done the right thing by analysing what is on screen.
- Test scripts are written in Python and can be generated with the `stbt record`
- command.
+ stb-tester tests a set-top-box by issuing commands (typically using an
+ infrared transmitter) and checking that it has done the right thing by
+ analysing what is on screen (typically using an HDMI video-capture card).
+ Test scripts are written in Python.
 
 Package: stb-tester-camera
 Architecture: any
@@ -99,8 +100,9 @@ Depends: stb-tester (>> ${source:Upstream-Version}),
          v4l-utils
 Recommends: python-matplotlib,
             python-scipy
-Description: Support for using a camera pointed at a TV as input for
- stb-tester.  This is useful for testing apps running on Smart TVs.
+Description: stb-tester support for using a camera pointed at a TV as input.
+ This is useful for testing apps running on Smart TVs that don't have an HDMI
+ output. Installs the "stbt camera" command.
 
 Package: stb-tester-virtual-stb
 Architecture: any
@@ -110,12 +112,13 @@ Depends: stb-tester (>> ${source:Upstream-Version}),
          xdotool,
          xserver-xorg-input-void,
          xserver-xorg-video-dummy
-Description: Support for "virtual" set-top boxes where the stb software runs on
- the host PC rather than on specific hardware.
+Description: stb-tester support for "virtual" set-top boxes.
+ Allows testing software that runs on the host PC rather than on set-top box
+ hardware. Installs the "stbt virtual-stb" command.
 
 Package: stb-tester-gpl
 Architecture: any
 Depends: stb-tester (>> ${source:Upstream-Version}),
          python-libcec
-Description: Support for additional stb-tester features that depend on GPLed
- libraries, rather than the LGPL that the rest of stb-tester uses.
+Description: Optional stb-tester features that depend on GPL libraries.
+ Installs the "hdmi-cec" control mechanism.

--- a/extra/debian/copyright
+++ b/extra/debian/copyright
@@ -1,12 +1,16 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: stb-tester
 Upstream-Contact: William Manley <will@stb-tester.com>
-Source: http://stb-tester.com/
+Source: https://stb-tester.com/
 
 Files: *
-Copyright: 2012-2014, YouView TV Ltd. <david.rothlisberger@youview.com>
-           2013-2014, stb-tester.com Ltd. <will@stb-tester.com>
-           2012-2014, others
+Copyright: 2013-2016 stb-tester.com Ltd. <will@stb-tester.com>
+           2012-2014 YouView TV Ltd. and other contributors
 License: LGPL-2.1+
   On Debian systems, the complete text of the LGPL-2.1 can be found in
   /usr/share/common-licenses/LGPL-2.1
+
+Files: _stbt/control_gpl.py
+Copyright: 2016 stb-tester.com Ltd. <will@stb-tester.com>
+  On Debian systems, the complete text of the GPL-2 can be found in
+  /usr/share/common-licenses/GPL-2

--- a/extra/debian/rules
+++ b/extra/debian/rules
@@ -19,3 +19,4 @@ override_dh_auto_install :
 	make install-core DESTDIR=debian/stb-tester
 	make install-stbt-camera DESTDIR=debian/stb-tester-camera
 	make install-virtual-stb DESTDIR=debian/stb-tester-virtual-stb
+	make install-gpl DESTDIR=debian/stb-tester-gpl

--- a/extra/fedora/stb-tester.spec.in
+++ b/extra/fedora/stb-tester.spec.in
@@ -81,6 +81,7 @@ rather than on specific hardware.
 Summary: stb-tester GPL package
 
 Requires: stb-tester
+Requires: python-libcec
 
 %description gpl
 Support for additional stb-tester features that depend on GPLed libraries,

--- a/extra/fedora/stb-tester.spec.in
+++ b/extra/fedora/stb-tester.spec.in
@@ -77,6 +77,15 @@ Requires: xorg-x11-drv-dummy
 Support for "virtual" set-top boxes where the stb software runs on the host PC
 rather than on specific hardware.
 
+%package gpl
+Summary: stb-tester GPL package
+
+Requires: stb-tester
+
+%description gpl
+Support for additional stb-tester features that depend on GPLed libraries,
+rather than the LGPL that the rest of stb-tester uses.
+
 %prep
 %setup -n stb-tester-@VERSION@
 
@@ -104,3 +113,6 @@ make install prefix=/usr sysconfdir=/etc libexecdir=%{_libexecdir} gstpluginsdir
 
 %files virtual-stb
 %{_libexecdir}/stbt/stbt_virtual_stb.py
+
+%files gpl
+%{_libexecdir}/stbt/_stbt/control_gpl.py

--- a/extra/pylint.conf
+++ b/extra/pylint.conf
@@ -52,6 +52,7 @@ ignored-classes=
   MainLoop,
   numpy,
   numpy.linalg,
+  pytest,
   Sample,
   scipy.interpolate,
   scipy.optimize,

--- a/extra/pylint.conf
+++ b/extra/pylint.conf
@@ -43,6 +43,7 @@ disable=
 ignored-classes=
   Buffer,
   Caps,
+  cec,
   Client,
   Event,
   Frame,


### PR DESCRIPTION
This is an implementation of #365.  This implementation is based on the work by @danielandersson in #378, but has been fairly heavily modified and reworked such that it's mergable into stb-tester proper.

HdmiCecControl: Implemented CEC support using libCEC
In combination with a USB-CEC adaptor this allows stb-tester to send
keypresses to devices over HDMI-CEC.  This is useful for testing devices
which don't have an IR input like the Sony PlayStation 4.

The URI is of the form:

```
hdmi-cec:[<device>]:[<source>]:[<destination>]
```

If device is not specified then any available CEC adapter will be used.

Similar to the keymapping for Roku, a map is used to lookup the CEC
commands.  We raise `UnknownKeyError` if it's not one we've heard of.  The
list of keys is from http://www.cec-o-matic.com .  I've done my own
interpretation on how they should be mapped onto linux input keynames.

The tests are implemented by monkey-patching out the bits of libcec that
actually interact with the hardware.  I'm not a great fan of this style
of testing, but in the absence of hardware-in-the-loop testing this is
the best we can do.  At least some of this code will actually get run
through during `make check`.

The tests are particularly ugly because the SWIG generated libcec bindings
makes inspecting `cec_commmand` objects inconvenient so I've had to use
`ctypes` :(.

This is based on an initial prototype and research by Daniel Andersson
d.andersson92@gmail.com (@danielandersson).  See PR #378 for more
information.

TODO:
- [x] Release note
- [x] Documentation
- [x] Run tests on Travis
- [x] Review
- [x] Manual hardware-in-the-loop testing of final implementation 

Future work:

- Allow matching the device we want to talk to by osd name e.g. "PlayStation 4".  See the output of

        echo scan | cec-client -s

  for more information