### PR TITLE
stbt auto-selftest generate: Accept optional source filenames

### DIFF
--- a/stbt-completion
+++ b/stbt-completion
@@ -81,18 +81,19 @@ _stbt_record() {
 }
 
 _stbt_auto_selftest() {
-    case "${COMP_WORDS[COMP_CWORD-1]}" in
-        --help|generate|validate) COMPREPLY=(); return;;
-    esac
-
-    _stbt_get_prev
-    local cur="$_stbt_cur"
-    local prev="$_stbt_prev"
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+    local subcommand="${COMP_WORDS[2]}"
     case "$prev" in
-        *) COMPREPLY=($(compgen \
-            -W "$(_stbt_trailing_space \
-                    --help generate validate)" \
-            -- "$cur"));;
+        auto-selftest)
+            COMPREPLY=($(compgen \
+                -W "$(_stbt_trailing_space --help generate validate)" \
+                -- "$cur"));
+            return;;
+    esac
+    case "$subcommand" in
+        --help|validate) COMPREPLY=();;
+        generate) COMPREPLY=($(_stbt_filenames "$cur"));;
     esac
 }
 

--- a/stbt_auto_selftest.py
+++ b/stbt_auto_selftest.py
@@ -171,16 +171,20 @@ def init_worker():
 
 
 def iterate_with_progress(sequence, width=20, stream=sys.stderr):
-    ANSI_ERASE_LINE = '\033[K'
     stream.write('\n')
     total = len(sequence)
     for n, v in enumerate(sequence):
-        progress = (n * width) // total
-        stream.write(
-            ANSI_ERASE_LINE + '[%s] %8d / %d - Processing %s\r' % (
-                '#' * progress + ' ' * (width - progress), n, total, str(v)))
+        stream.write(_progress_line(width, n, total) +
+                     " - Processing %s\r" % v)
         yield v
-    stream.write('\n')
+    stream.write(_progress_line(width, total, total) + "\n")
+
+
+def _progress_line(width, n, total):
+    ANSI_ERASE_LINE = '\033[K'
+    progress = (n * width) // total
+    return '\r' + ANSI_ERASE_LINE + '[%s] %3d / %d' % (
+        '#' * progress + ' ' * (width - progress), n, total)
 
 
 def generate_into_tmpdir(source_files=None):

--- a/stbt_auto_selftest.py
+++ b/stbt_auto_selftest.py
@@ -175,8 +175,6 @@ def iterate_with_progress(sequence, width=20, stream=sys.stderr):
     stream.write('\n')
     total = len(sequence)
     for n, v in enumerate(sequence):
-        if n == total:
-            break
         progress = (n * width) // total
         stream.write(
             ANSI_ERASE_LINE + '[%s] %8d / %d - Processing %s\r' % (

--- a/stbt_auto_selftest.py
+++ b/stbt_auto_selftest.py
@@ -8,7 +8,7 @@ they still behave correctly.
 
 Usage:
 
-    stbt auto-selftest generate
+    stbt auto-selftest generate [source_file.py ...]
     stbt auto-selftest validate
 
 ``stbt auto-selftest generate`` generates a doctest for every `FrameObject` in
@@ -76,8 +76,12 @@ def main(argv):
         formatter_class=argparse.RawDescriptionHelpFormatter)
     subparsers = parser.add_subparsers(dest="command")
 
-    subparsers.add_parser(
+    subparser_generate = subparsers.add_parser(
         'generate', help="Regenerate auto-selftests from screenshots")
+    subparser_generate.add_argument(
+        "source_files", nargs="*", help="""Python source file(s) to search for
+        FrameObjects (defaults to all python files in the test-pack)""")
+
     subparsers.add_parser('validate', help='Run (and check) the auto-selftests')
 
     cmdline_args = parser.parse_args(argv[1:])
@@ -85,30 +89,48 @@ def main(argv):
     root = _find_test_pack_root()
     if root is None:
         sys.stderr.write(
-            "This command must be run within a test pack.  Couldn't find a "
-            ".stbt.conf in this or any parent directory.\n")
+            "error: This command must be run within a test pack. Couldn't find "
+            "a .stbt.conf in this or any parent directory.\n")
         return 1
 
     os.chdir(root)
 
     if cmdline_args.command == 'generate':
-        generate()
+        return generate(cmdline_args.source_files)
     elif cmdline_args.command == 'validate':
         return validate()
     else:
         assert False
 
 
-def generate():
-    tmpdir = generate_into_tmpdir()
+def generate(source_files):
+    tmpdir = generate_into_tmpdir(source_files)
     try:
-        target = "%s/selftest/auto_selftest" % os.curdir
-        if os.path.exists(target):
-            shutil.rmtree(target)
-        os.rename(tmpdir, target)
-    except:
-        shutil.rmtree(tmpdir)
-        raise
+        if source_files:
+            # Only replace the selftests for the specified files.
+            for f in source_files:
+                newfile = os.path.join(tmpdir, selftest_filename(f))
+                target = os.path.join(os.curdir, "selftest/auto_selftest",
+                                      selftest_filename(f))
+                if os.path.exists(newfile):
+                    mkdir_p(os.path.dirname(target))
+                    os.rename(os.path.join(tmpdir, selftest_filename(f)),
+                              target)
+                else:
+                    sys.stderr.write(
+                        "error: '%s' isn't a valid source file.\n" % f)
+                    return 1
+
+        else:
+            # Replace all selftests, deleting selftests for source files that
+            # no longer exist.
+            target = "%s/selftest/auto_selftest" % os.curdir
+            if os.path.exists(target):
+                shutil.rmtree(target)
+                os.rename(tmpdir, target)
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 def validate():
@@ -163,7 +185,7 @@ def iterate_with_progress(sequence, width=20, stream=sys.stderr):
     stream.write('\n')
 
 
-def generate_into_tmpdir():
+def generate_into_tmpdir(source_files=None):
     start_time = time.time()
 
     selftest_dir = "%s/selftest" % os.curdir
@@ -173,20 +195,12 @@ def generate_into_tmpdir():
         processes=1, maxtasksperchild=1, initializer=init_worker)
     tmpdir = tempfile.mkdtemp(dir=selftest_dir, prefix="auto_selftest")
     try:
-        filenames = []
-        for module_filename in _recursive_glob('*.py'):
-            if module_filename.startswith('selftest'):
-                continue
-            if not is_valid_python_identifier(
-                    os.path.basename(module_filename)[:-3]):
-                continue
-            filenames.append(module_filename)
-
+        if not source_files:
+            source_files = valid_source_files(_recursive_glob('*.py'))
         perf_log = []
         test_file_count = 0
-        for module_filename in iterate_with_progress(filenames):
-            outname = os.path.join(
-                tmpdir, re.sub('.py$', '_selftest.py', module_filename))
+        for module_filename in iterate_with_progress(source_files):
+            outname = os.path.join(tmpdir, selftest_filename(module_filename))
             barename = re.sub('.py$', '_bare.py', outname)
             mkdir_p(os.path.dirname(outname))
 
@@ -218,6 +232,24 @@ def generate_into_tmpdir():
         pool.join()
         shutil.rmtree(tmpdir)
         raise
+
+
+def valid_source_files(source_files):
+    filenames = []
+    for module_filename in source_files:
+        if module_filename.startswith('selftest'):
+            continue
+        if not is_valid_python_identifier(
+                os.path.basename(module_filename)[:-3]):
+            continue
+        if not os.path.exists(module_filename):
+            continue
+        filenames.append(module_filename)
+    return filenames
+
+
+def selftest_filename(module_filename):
+    return re.sub('.py$', '_selftest.py', module_filename)
 
 
 class Module(namedtuple('Module', "filename items")):

--- a/tests/test-stbt-auto-selftest.sh
+++ b/tests/test-stbt-auto-selftest.sh
@@ -1,14 +1,15 @@
+cd_example_testpack()
+{
+    cp -R "$testdir/auto-selftest-example-test-pack" test-pack &&
+    cd test-pack || fail "Test setup failed"
+}
+
 test_auto_selftest_generate()
 {
-    cp -R "$testdir/auto-selftest-example-test-pack" pristine &&
-    cp -R "pristine" "regenerated" &&
-    rm -rf regenerated/selftest/auto_selftest &&
-    cd regenerated &&
+    cd_example_testpack &&
     stbt auto-selftest generate &&
-    cd .. &&
-
-    find . -name '*.pyc' -delete -o -name __pycache__ -delete &&
-    diff -ur "pristine" "regenerated"
+    diff -ur --exclude="*.pyc" --exclude=__pycache__ \
+        "$testdir"/auto-selftest-example-test-pack .
 }
 
 test_that_generated_auto_selftests_pass_as_doctests()
@@ -16,13 +17,6 @@ test_that_generated_auto_selftests_pass_as_doctests()
     PYTHONPATH=$srcdir python -m doctest \
         "$testdir/auto-selftest-example-test-pack/selftest/auto_selftest/tests/example_selftest.py"
 }
-
-cd_example_testpack()
-{
-    cp -R "$testdir/auto-selftest-example-test-pack" test-pack &&
-    cd test-pack || fail "Test setup failed"
-}
-
 
 test_that_generated_auto_selftests_pass_stbt_auto_selftest_validate()
 {

--- a/tests/test-stbt-auto-selftest.sh
+++ b/tests/test-stbt-auto-selftest.sh
@@ -4,7 +4,7 @@ test_auto_selftest_generate()
     cp -R "pristine" "regenerated" &&
     rm -rf regenerated/selftest/auto_selftest &&
     cd regenerated &&
-    stbt --with-experimental auto-selftest generate &&
+    stbt auto-selftest generate &&
     cd .. &&
 
     find . -name '*.pyc' -delete -o -name __pycache__ -delete &&
@@ -27,42 +27,42 @@ cd_example_testpack()
 test_that_generated_auto_selftests_pass_stbt_auto_selftest_validate()
 {
     cd_example_testpack &&
-    stbt --with-experimental auto-selftest validate
+    stbt auto-selftest validate
 }
 
 test_that_no_auto_selftests_fail_stbt_auto_selftest_validate()
 {
     cd_example_testpack &&
     rm -r selftest/auto_selftest &&
-    ! stbt --with-experimental auto-selftest validate
+    ! stbt auto-selftest validate
 }
 
 test_that_new_auto_selftests_fail_stbt_auto_selftest_validate()
 {
     cd_example_testpack &&
     touch selftest/auto_selftest/new.py &&
-    ! stbt --with-experimental auto-selftest validate
+    ! stbt auto-selftest validate
 }
 
 test_that_missing_auto_selftests_fail_stbt_auto_selftest_validate()
 {
     cd_example_testpack &&
     rm selftest/auto_selftest/tests/example_selftest.py &&
-    ! stbt --with-experimental auto-selftest validate
+    ! stbt auto-selftest validate
 }
 
 test_that_modified_auto_selftests_fail_stbt_auto_selftest_validate()
 {
     cd_example_testpack &&
     echo "pass" >>selftest/auto_selftest/tests/example_selftest.py &&
-    ! stbt --with-experimental auto-selftest validate
+    ! stbt auto-selftest validate
 }
 
 test_that_no_screenshots_passes_stbt_auto_selftest_validate()
 {
     cd_example_testpack &&
     rm -r selftest &&
-    stbt --with-experimental auto-selftest validate
+    stbt auto-selftest validate
 }
 
 test_that_no_selftests_expressions_passes_stbt_auto_selftest_validate()
@@ -70,7 +70,7 @@ test_that_no_selftests_expressions_passes_stbt_auto_selftest_validate()
     cd_example_testpack &&
     rm -r tests/example.py tests/unicode_example.py selftest/auto_selftest \
           tests/subdir/subsubdir/subdir_example.py &&
-    stbt --with-experimental auto-selftest validate
+    stbt auto-selftest validate
 }
 
 test_auto_selftest_caching()
@@ -84,19 +84,19 @@ test_auto_selftest_caching()
     gst-inspect-1.0 &>/dev/null
 
     STBT_DISABLE_CACHING=1 /usr/bin/time --format=%e -o without_cache.time \
-        stbt --with-experimental auto-selftest validate
+        stbt auto-selftest validate
 
     ! [ -e cache/stbt/cache.lmdb ] \
         || fail "Cache file created despite STBT_DISABLE_CACHING"
 
     /usr/bin/time --format=%e -o cold_cache.time \
-        stbt --with-experimental auto-selftest validate \
+        stbt auto-selftest validate \
         || fail "auto-selftest failed"
 
     [ -e cache/stbt/cache.lmdb ] || fail "Cache file not created"
 
     /usr/bin/time --format=%e -o hot_cache.time \
-        stbt --with-experimental auto-selftest validate \
+        stbt auto-selftest validate \
         || fail "auto-selftest failed"
 
     python -c "assert ($(<hot_cache.time) * 2) < $(<without_cache.time)" \


### PR DESCRIPTION
Even with our caching, running `stbt auto-selftest generate` on a large
test-pack can take several seconds. When you're iterating on a single
FrameObject it is useful to re-generate the selftests for just the file
you're working on.

Even with a small test-pack this reduces the run-time from 4 seconds to
1 second (when regenerating a single file).
