### PR TITLE
Install stbt control relay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ nosetest-issue-49-workaround-stbt-control.py
 rpmbuild
 stb-tester-*.tar.gz
 stb-tester_*.deb
+stbt-control-relay
 stbt-controlc
 stbt-debug
 stbt.sh

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ RELEASE?=1
 .DELETE_ON_ERROR:
 
 
-extra/fedora/stb-tester.spec stbt.sh: \
+extra/fedora/stb-tester.spec stbt.sh stbt-control-relay: \
   %: %.in .stbt-prefix VERSION
 	sed -e 's,@VERSION@,$(VERSION),g' \
 	    -e 's,@ESCAPED_VERSION@,$(ESCAPED_VERSION),g' \
@@ -154,6 +154,29 @@ install-gpl: $(INSTALL_GPL_FILES)
 	    [ -x "$$filename" ] && mode=0755 || mode=0644; \
 	    $(INSTALL) -m $$mode $$filename $(DESTDIR)$(libexecdir)/stbt/$$filename; \
 	done
+
+STBT_CONTROL_RELAY_FILES = \
+    _stbt/__init__.py \
+    _stbt/config.py \
+    _stbt/control.py \
+    _stbt/control_gpl.py \
+    _stbt/irnetbox.py \
+    _stbt/logging.py \
+    _stbt/utils.py \
+    stbt_control_relay.py
+
+install-stbt-control-relay: $(STBT_CONTROL_RELAY_FILES) stbt-control-relay defaults.conf
+	$(INSTALL) -m 0755 -d $(DESTDIR)$(bindir)
+	$(INSTALL) -m 0755 stbt-control-relay $(DESTDIR)$(bindir)/
+	$(INSTALL) -m 0755 -d \
+	    $(patsubst %,$(DESTDIR)$(libexecdir)/stbt-control-relay/%,$(sort $(dir $(STBT_CONTROL_RELAY_FILES))))
+	for filename in $(STBT_CONTROL_RELAY_FILES); do \
+	    [ -x "$$filename" ] && mode=0755 || mode=0644; \
+	    $(INSTALL) -m $$mode $$filename \
+	        $(DESTDIR)$(libexecdir)/stbt-control-relay/$$filename; \
+	done
+	$(INSTALL) -m 0644 defaults.conf \
+	    $(DESTDIR)$(libexecdir)/stbt-control-relay/stbt.conf
 
 uninstall:
 	rm -f $(DESTDIR)$(bindir)/stbt

--- a/_stbt/logging.py
+++ b/_stbt/logging.py
@@ -7,9 +7,6 @@ import sys
 from collections import OrderedDict
 from contextlib import contextmanager
 
-import cv2
-import numpy
-
 from .config import get_config
 from .utils import mkdir_p
 
@@ -122,6 +119,8 @@ class ImageLogger(object):
             self.data[k].append(v)
 
     def imwrite(self, name, image, region=None, colour=None):
+        import cv2
+        import numpy
         if not self.enabled:
             return
         if name in self.images:

--- a/stbt-control-relay.in
+++ b/stbt-control-relay.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+PYTHONPATH=@LIBEXECDIR@/stbt-control-relay exec @LIBEXECDIR@/stbt-control-relay/stbt_control_relay.py "$@"

--- a/stbt_control_relay.py
+++ b/stbt_control_relay.py
@@ -49,7 +49,10 @@ def main(argv):
     listener = uri_to_remote_recorder(args.input)
     for key in listener:
         sys.stderr.write("Received %s\n" % key)
-        r.press(key)
+        try:
+            r.press(key)
+        except Exception as e:  # pylint: disable=broad-except
+            sys.stderr.write("Error pressing key %r: %s\n" % (key, e))
 
 if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/tests/test_stbt_control_relay.py
+++ b/tests/test_stbt_control_relay.py
@@ -2,9 +2,15 @@ import os
 import subprocess
 from contextlib import contextmanager
 
+import pytest
+
 from _stbt.control import uri_to_remote
 from _stbt.core import wait_until
 from _stbt.utils import named_temporary_directory
+
+
+# For py.test fixtures:
+# pylint: disable=redefined-outer-name
 
 
 @contextmanager
@@ -17,16 +23,45 @@ def scoped_process(process):
             process.wait()
 
 
+@contextmanager
+def scoped_path_addition(path):
+    os.environ['PATH'] = "%s:%s" % (path, os.environ['PATH'])
+    try:
+        yield
+    finally:
+        if os.environ['PATH'] == "%s:" % path:
+            os.environ['PATH'] = os.environ['PATH'][len(path) + 1:]
+
+
 def srcdir(filename="", here=os.path.abspath(__file__)):
     return os.path.join(os.path.dirname(here), "..", filename)
 
 
-def test_stbt_control_relay():
+@pytest.yield_fixture(scope='session')
+def installed_stbt_control_relay():
+    with named_temporary_directory("stbt-control-relay-install.XXXXXX") as tmp:
+        oldprefix = open(srcdir(".stbt-prefix")).read()
+        subprocess.check_call(
+            ["make", "prefix=%s" % tmp, "install-stbt-control-relay"],
+            cwd=srcdir())
+        open(srcdir(".stbt-prefix"), 'w').write(oldprefix)
+
+        os.environ['PATH'] = "%s/bin:%s" % (tmp, os.environ['PATH'])
+        yield "%s/bin/stbt-control-relay" % tmp
+
+
+@pytest.yield_fixture(scope='function')
+def stbt_control_relay_on_path(installed_stbt_control_relay):
+    with scoped_path_addition(os.path.dirname(installed_stbt_control_relay)):
+        yield installed_stbt_control_relay
+
+
+def test_stbt_control_relay(stbt_control_relay_on_path):  # pylint: disable=unused-argument
     with named_temporary_directory("stbt-control-relay-test.XXXXXX") as tmpdir:
         def t(filename):
             return os.path.join(tmpdir, filename)
         proc = subprocess.Popen(
-            [srcdir("stbt_control_relay.py"),
+            ["stbt-control-relay",
              "--input=lircd:" + t("lircd.sock"),
              "file:" + t("one-file"), "file:" + t("another")])
         with scoped_process(proc):


### PR DESCRIPTION
To make it easier to use without a dependency on the rest of stbt - for example for running a running a CEC control on a Raspberry Pi, or X11 on a remote PC.

I could have built a debian package for this but I don't think it's worth it.