### PR TITLE
stbt-control-relay: Add --verbose parameter

### DIFF
--- a/_stbt/logging.py
+++ b/_stbt/logging.py
@@ -65,12 +65,6 @@ def argparser_add_verbose_argument(argparser):
         help='Enable debug output (specify twice to enable GStreamer element '
              'dumps to ./stbt-debug directory)')
 
-    argparser.add_argument(
-        '--structured-logging', metavar="FILENAME", default=None,
-        help="Writes structed logging data to given filename.  The format of "
-             "the data is newline delimited JSON objects with xz compression "
-             "applied")
-
 
 class ImageLogger(object):
     """Log intermediate images used in image processing (such as `match`).

--- a/stbt_control_relay.py
+++ b/stbt_control_relay.py
@@ -34,6 +34,7 @@ import signal
 import sys
 
 from _stbt.control import MultiRemote, uri_to_remote, uri_to_remote_recorder
+from _stbt.logging import argparser_add_verbose_argument, debug
 
 
 def main(argv):
@@ -44,6 +45,7 @@ def main(argv):
         presses. Values are the same as stbt record's --control-recorder.""")
     parser.add_argument("output", nargs="+", help="""One or more remote control
         configurations. Values are the same as stbt run's --control.""")
+    argparser_add_verbose_argument(parser)
     args = parser.parse_args(argv[1:])
 
     signal.signal(signal.SIGTERM, lambda _signo, _stack_frame: sys.exit(0))
@@ -51,7 +53,7 @@ def main(argv):
     r = MultiRemote(uri_to_remote(x) for x in args.output)
     listener = uri_to_remote_recorder(args.input)
     for key in listener:
-        sys.stderr.write("Received %s\n" % key)
+        debug("Received %s" % key)
         try:
             r.press(key)
         except Exception as e:  # pylint: disable=broad-except

--- a/stbt_control_relay.py
+++ b/stbt_control_relay.py
@@ -39,8 +39,11 @@ from _stbt.control import MultiRemote, uri_to_remote, uri_to_remote_recorder
 def main(argv):
     parser = argparse.ArgumentParser(
         epilog=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("--input", default="lircd")
-    parser.add_argument("output", nargs="+")
+    parser.add_argument(
+        "--input", default="lircd", help="""The source of remote control
+        presses. Values are the same as stbt record's --control-recorder.""")
+    parser.add_argument("output", nargs="+", help="""One or more remote control
+        configurations. Values are the same as stbt run's --control.""")
     args = parser.parse_args(argv[1:])
 
     signal.signal(signal.SIGTERM, lambda _signo, _stack_frame: sys.exit(0))

--- a/stbt_control_relay.py
+++ b/stbt_control_relay.py
@@ -40,7 +40,7 @@ def main(argv):
     parser = argparse.ArgumentParser(
         epilog=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--input", default="lircd")
-    parser.add_argument("output", nargs="*")
+    parser.add_argument("output", nargs="+")
     args = parser.parse_args(argv[1:])
 
     signal.signal(signal.SIGTERM, lambda _signo, _stack_frame: sys.exit(0))


### PR DESCRIPTION
So that we can see debug output from each of the remote-control
implementations that are sending output.

Also require at last 1 output control to be specified.