### PR TITLE
stbt-control: Truncate long remote control URI to 80 characters

### DIFF
--- a/stbt-control
+++ b/stbt-control
@@ -151,7 +151,8 @@ def main_loop(control_uri, keymap_file):
             {mapping}
 
             """).format(keymap_file=keymap_file[:term_width - len("Keymap:  ")],
-                        control_uri=control_uri,
+                        control_uri=control_uri[:77] + (
+                            control_uri[77:] and "..."),
                         mapping=keymap_string(keymap))
         if keymap_fits_terminal(term, printed_keymap):
             term.addstr(printed_keymap)


### PR DESCRIPTION
`stbt control` raises the error "Unable to print keymap because the
terminal is too small" if any of the printed lines is longer than the
width of the terminal. If the remote control URI is very long then it
is becoming difficult to launch the app on small screens. (The terminal
has to be made full screen and/or the font size has to be decreased.)