### PR TITLE
irnetbox-proxy: set SO_REUSEADDR on listening socket

### DIFF
--- a/irnetbox-proxy
+++ b/irnetbox-proxy
@@ -222,6 +222,8 @@ class IRNetBoxProxy(object):
     def connect(self):
         try:
             self.listen_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.listen_sock.setsockopt(socket.SOL_SOCKET,
+                                        socket.SO_REUSEADDR, 1)
             self.listen_sock.bind(self.listen_addr)
             self.listen_sock.listen(5)
         except Exception, e:  # pylint: disable=W0703


### PR DESCRIPTION
After the service had terminated due to a dropped connection from
the irnetbox, restarting it was failing for several minutes with:

irnetbox-proxy: Traceback (most recent call last):
irnetbox-proxy: File "/usr/local/bin/irnetbox-proxy", line 225, in connect
irnetbox-proxy: self.listen_sock.bind(self.listen_addr)
irnetbox-proxy: File "/usr/lib64/python2.7/socket.py", line 224, in meth
irnetbox-proxy: return getattr(self._sock,name)(*args)
irnetbox-proxy: error: [Errno 98] Address already in use
irnetbox-proxy: Could not bind to local address

because the listening socket was left in TIME_WAIT state.  Set
the SO_REUSEADDR option on the socket to avoid this.