### PR TITLE
stbt.match_text: Add `case_sensitive` parameter

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1043,7 +1043,7 @@ class DeviceUnderTest(object):
 
     def match_text(self, text, frame=None, region=Region.ALL,
                    mode=OcrMode.PAGE_SEGMENTATION_WITHOUT_OSD, lang="eng",
-                   tesseract_config=None):
+                   tesseract_config=None, case_sensitive=False):
 
         import lxml.etree
         if frame is None:
@@ -1062,7 +1062,7 @@ class DeviceUnderTest(object):
             result = TextMatchResult(rts, False, None, frame, text)
         else:
             hocr = lxml.etree.fromstring(xml.encode('utf-8'))
-            p = _hocr_find_phrase(hocr, text.split())
+            p = _hocr_find_phrase(hocr, text.split(), case_sensitive)
             if p:
                 # Find bounding box
                 box = None
@@ -2666,10 +2666,15 @@ def _hocr_iterate(hocr):
                     need_space = True
 
 
-def _hocr_find_phrase(hocr, phrase):
-    words_only = [(w.lower().translate(_ocr_transtab), elem)
+def _hocr_find_phrase(hocr, phrase, case_sensitive):
+    if case_sensitive:
+        lower = lambda s: s
+    else:
+        lower = lambda s: s.lower()
+
+    words_only = [(lower(w).translate(_ocr_transtab), elem)
                   for w, elem in _hocr_iterate(hocr) if w.strip() != u'']
-    phrase = [_to_unicode(w).lower().translate(_ocr_transtab) for w in phrase]
+    phrase = [lower(_to_unicode(w)).translate(_ocr_transtab) for w in phrase]
 
     # Dumb and poor algorithmic complexity but succint and simple
     if len(phrase) <= len(words_only):

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -53,6 +53,9 @@ UNRELEASED
 * Python API: `stbt.match_text` normalises punctuation such as em-dash and
   en-dash, just like `stbt.ocr` already does.
 
+* Python API: `stbt.match_text` has a new parameter `case_sensitive`. It
+  defaults to False (that is, ignore case), which was the previous behaviour.
+
 * Remote controls: Added `file:` remote control which writes keys pressed to a
   file.  Mostly intended for debugging.
 

--- a/extra/pylint.sh
+++ b/extra/pylint.sh
@@ -12,7 +12,8 @@ pep8options() {
     # E402: module level import not at top of file (because isort does it)
     # E501: line too long > 80 chars (because pylint does it)
     # E721: do not compare types, use 'isinstance()' (because pylint does it)
-    echo --ignore=E402,E501,E721
+    # E731: do not assign a lambda expression, use a def
+    echo --ignore=E402,E501,E721,E731
 }
 
 ret=0

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -393,7 +393,7 @@ def ocr(frame=None, region=Region.ALL,
 
 def match_text(text, frame=None, region=Region.ALL,
                mode=OcrMode.PAGE_SEGMENTATION_WITHOUT_OSD, lang="eng",
-               tesseract_config=None):
+               tesseract_config=None, case_sensitive=False):
     """Search for the specified text in a single video frame.
 
     This can be used as an alternative to `match`, searching for text instead
@@ -405,6 +405,7 @@ def match_text(text, frame=None, region=Region.ALL,
     :param mode: See `ocr`.
     :param lang: See `ocr`.
     :param tesseract_config: See `ocr`.
+    :param case_sensitive bool: Ignore case if False (the default).
 
     :returns:
       A `TextMatchResult`, which will evaluate to True if the text was found,
@@ -418,9 +419,11 @@ def match_text(text, frame=None, region=Region.ALL,
         while not stbt.match('selected-button.png').region.contains(m.region):
             stbt.press('KEY_DOWN')
 
+    The ``case_sensitive`` parameter was added in v27. Previously it always
+    ignored case.
     """
     return _dut.match_text(
-        text, frame, region, mode, lang, tesseract_config)
+        text, frame, region, mode, lang, tesseract_config, case_sensitive)
 
 
 def frames(timeout_secs=None):

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -208,6 +208,13 @@ def test_match_text_on_single_channel_image():
     assert stbt.match_text("Onion Bhaji", frame)
 
 
+def test_match_text_case_sensitivity():
+    frame = cv2.imread("tests/ocr/menu.png", cv2.IMREAD_GRAYSCALE)
+    assert stbt.match_text("ONION BHAJI", frame)
+    assert stbt.match_text("ONION BHAJI", frame, case_sensitive=False)
+    assert not stbt.match_text("ONION BHAJI", frame, case_sensitive=True)
+
+
 def test_ocr_on_text_next_to_image_match():
     frame = cv2.imread("tests/action-panel.png")
     m = stbt.match("tests/action-panel-blue-button.png", frame)


### PR DESCRIPTION
The current behaviour is to ignore case. With this parameter at least we
can disable this behaviour if we need to.

Note that none of the ligatures in `_ocr_transtab` (like ﬃ -> ffi) exist
in uppercase versions. There *are* other ligatures that do have
uppercase & lowercase versions (œ -> oe and Œ -> OE) but they aren't in
`_ocr_transtab` and adding them is outside the scope of this commit,
as I haven't seen them in the wild and finding some test cases would
take some time I don't have right now.