### PR TITLE
_stbt/control.py: Add "error" remote control 

### DIFF
--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -27,6 +27,7 @@ class UnknownKeyError(Exception):
 
 def uri_to_remote(uri, display=None):
     remotes = [
+        (r'error(:(?P<message>.*))?', ErrorControl),
         (r'file(:(?P<filename>[^,]+))?', FileControl),
         (r'''irnetbox:
              (?P<hostname>[^:]+)
@@ -75,6 +76,16 @@ class NullRemote(object):
     @staticmethod
     def press(key):
         debug('NullRemote: Ignoring request to press "%s"' % key)
+
+
+class ErrorControl(object):
+    def __init__(self, message):
+        if message is None:
+            message = "No remote control configured"
+        self.message = message
+
+    def press(self, key):  # pylint:disable=unused-argument
+        raise RuntimeError(self.message)
 
 
 class FileControl(object):

--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -27,6 +27,7 @@ class UnknownKeyError(Exception):
 
 def uri_to_remote(uri, display=None):
     remotes = [
+        (r'file(:(?P<filename>[^,]+))?', FileControl),
         (r'''irnetbox:
              (?P<hostname>[^:]+)
              (:(?P<port>\d+))?
@@ -42,7 +43,6 @@ def uri_to_remote(uri, display=None):
          _new_samsung_tcp_remote),
         (r'test', lambda: VideoTestSrcControl(display)),
         (r'x11:(?P<display>[^,]+)?(,(?P<mapping>.+)?)?', _X11Remote),
-        (r'file(:(?P<filename>[^,]+))?', FileControl),
     ]
     if gpl_controls is not None:
         remotes += gpl_controls

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -52,6 +52,12 @@ UNRELEASED
 * Python API: `stbt.match_text` has a new parameter `case_sensitive`. It
   defaults to False (that is, ignore case), which was the previous behaviour.
 
+* Remote controls: Added `error:` remote control that raises `RuntimeError`
+  when the test script calls `stbt.press`. If you don't want to use any of the
+  built-in remote controls, this allows you to catch unintended uses of
+  `stbt.press` in your test script, which would be silently ignored if you used
+  the `none` remote control.
+
 * Remote controls: Added `file:` remote control which writes keys pressed to a
   file.  Mostly intended for debugging.
 

--- a/docs/stbt.1.rst
+++ b/docs/stbt.1.rst
@@ -122,6 +122,10 @@ Global options
   none
     Ignores key press commands.
 
+  error[:message]
+    Raises `RuntimeError` when the test script calls `stbt.press`, with the
+    optional error message.
+
   test
     Used by the selftests to change the input video stream. Only works with
     `--source-pipeline=videotestsrc`. A script like `press("18")` will change

--- a/tests/test-stbt-run.sh
+++ b/tests/test-stbt-run.sh
@@ -266,3 +266,15 @@ test_that_stbt_run_can_print_exceptions_with_encoded_utf8_string() {
     LANG=C.UTF-8 unbuffer bash -c 'stbt run test.py'
     assert_correct_unicode_error
 }
+
+test_that_error_control_raises_exception() {
+    cat > test.py <<-EOF
+	import stbt
+	stbt.press("KEY_UP")
+	EOF
+    ! stbt run --control=error test.py &&
+    grep -q 'FAIL: test.py: RuntimeError: No remote control configured' log &&
+
+    ! stbt run --control="error:My custom error message" test.py &&
+    grep -q 'FAIL: test.py: RuntimeError: My custom error message' log
+}


### PR DESCRIPTION
It raises `RuntimeError` when the test script calls `stbt.press`.

If you don't want to use any of the built-in remote controls, this
allows you to catch unintended uses of `stbt.press` in your test script,
which would be silently ignored if you used the `none` remote control.