### PR TITLE
Change the default remote control to "error"

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -55,8 +55,8 @@ UNRELEASED
 * Remote controls: Added `error:` remote control that raises `RuntimeError`
   when the test script calls `stbt.press`. If you don't want to use any of the
   built-in remote controls, this allows you to catch unintended uses of
-  `stbt.press` in your test script, which would be silently ignored if you used
-  the `none` remote control.
+  `stbt.press` in your test script. This is now the default remote control,
+  instead of `none` (which ignores keypresses).
 
 * Remote controls: Added `file:` remote control which writes keys pressed to a
   file.  Mostly intended for debugging.

--- a/stbt.conf
+++ b/stbt.conf
@@ -2,7 +2,7 @@
 source_pipeline=videotestsrc is-live=true
 sink_pipeline=xvimagesink sync=false
 transformation_pipeline = identity
-control=none
+control=error
 verbose=0
 power_outlet=none
 v4l2_ctls=

--- a/tests/test-stbt-run.sh
+++ b/tests/test-stbt-run.sh
@@ -272,9 +272,19 @@ test_that_error_control_raises_exception() {
 	import stbt
 	stbt.press("KEY_UP")
 	EOF
-    ! stbt run --control=error test.py &&
+    ! stbt run -v --control=error test.py &&
     grep -q 'FAIL: test.py: RuntimeError: No remote control configured' log &&
 
-    ! stbt run --control="error:My custom error message" test.py &&
+    ! stbt run -v --control="error:My custom error message" test.py &&
     grep -q 'FAIL: test.py: RuntimeError: My custom error message' log
+}
+
+test_that_default_control_raises_exception() {
+    sed '/^control/ d' config/stbt/stbt.conf | sponge config/stbt/stbt.conf
+    cat > test.py <<-EOF
+	import stbt
+	stbt.press("KEY_UP")
+	EOF
+    ! stbt run -v test.py &&
+    grep -q 'FAIL: test.py: RuntimeError: No remote control configured' log
 }


### PR DESCRIPTION
If your test calls `stbt.press` but you haven't configured a remote
control, it should fail noisily instead of silently swallowing the
keypress.