### PR TITLE
power: fix ATEN oid for ports above 8

### DIFF
--- a/_stbt/power.py
+++ b/_stbt/power.py
@@ -200,7 +200,8 @@ class _ATEN_PE6108G(object):
         self.hostname = hostname
         self.outlet = int(outlet)
         oid_string = "1.3.6.1.4.1.21317.1.3.2.2.2.2.{0}.0"
-        self.outlet_oid = oid_string.format(self.outlet + 1)
+        outlet_offset = 1 if self.outlet <= 8 else 2
+        self.outlet_oid = oid_string.format(self.outlet + outlet_offset)
 
     def set(self, power):
         new_state = self.aten_cmd(power=power)


### PR DESCRIPTION
The ATEN MIB is using 1.3.6.1.4.1.21317.1.3.2.2.2.2.10 for
`outletConfigTable`, so on models with more than 8 ports `outlet9Status`
and up (at least up to 36 currently) are offset by 2.