### PR TITLE
virtual-stb selftests: Use KeyboardEvent.key instead of .keyIdentifier

### DIFF
--- a/tests/vstb-example-html5/virtual-stb/index.html
+++ b/tests/vstb-example-html5/virtual-stb/index.html
@@ -9,17 +9,17 @@
     }
     function keypress(event) {
       logo = document.getElementById('logo');
-      switch (event.keyIdentifier) {
-      case "Left":
+      switch (event.key) {
+      case "ArrowLeft":
         rotate(logo, 207);
         break;
-      case "Right":
+      case "ArrowRight":
         rotate(logo, 27);
         break;
-      case "Down":
+      case "ArrowDown":
         rotate(logo, 117);
         break;
-      case "Up":
+      case "ArrowUp":
         rotate(logo, 297);
         break;
       case "Enter":


### PR DESCRIPTION
`keyIdentifier` is non-standard, deprecated, and it has been removed
from chromium, which is causing our `stbt virtual-stb` selftests to
fail. See
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyIdentifier