### PR TITLE
Optimisation: Don't import stbt in stbt config

### DIFF
--- a/_stbt/config.py
+++ b/_stbt/config.py
@@ -2,8 +2,6 @@ import ConfigParser
 import os
 from contextlib import contextmanager
 
-from . import utils
-
 _config = None
 
 
@@ -47,6 +45,8 @@ def set_config(section, option, value):
     Writes to the first item in `$STBT_CONFIG_FILE` if set falling back to
     `$HOME/stbt/stbt.conf`.
     """
+    from .utils import mkdir_p
+
     user_config = '%s/stbt/stbt.conf' % xdg_config_dir()
     # Write to the config file with the highest precedence
     custom_config = os.environ.get('STBT_CONFIG_FILE', '').split(':')[0] \
@@ -67,7 +67,7 @@ def set_config(section, option, value):
             pass
 
     d = os.path.dirname(custom_config)
-    utils.mkdir_p(d)
+    mkdir_p(d)
     with _sponge(custom_config) as f:
         parser.write(f)
 

--- a/stbt-config
+++ b/stbt-config
@@ -9,7 +9,7 @@ https://github.com/stb-tester/stb-tester/blob/master/LICENSE for details).
 import argparse
 import sys
 
-import stbt
+from _stbt.config import ConfigurationError, get_config
 
 
 def error(s):
@@ -35,6 +35,6 @@ if args.name.rfind(".") == -1:
 section, key = args.name.rsplit(".", 1)
 
 try:
-    print stbt.get_config(section, key)
-except stbt.ConfigurationError as e:
+    print get_config(section, key)
+except ConfigurationError as e:
     error(e.message)


### PR DESCRIPTION
Importing `stbt` imports a whole bunch of other libraries.  This can even
take more than 1s.  With this change we only import `config.py` which
in-turn only depends on the Python standard library.  This is a lot faster.

`stbt batch run-one` calls `stbt config` 3 times or more for every test
run.  In my testing this change can save up to 5s per test run.

This tiny unexpected change demonstrates the value in profiling to work
out where the time is being spent before optimising.