### PR TITLE
stbt-batch: Performance improvements: Record screenshots in stbt-run

### DIFF
--- a/stbt-batch.d/run-one
+++ b/stbt-batch.d/run-one
@@ -74,7 +74,8 @@ main() {
   user_command pre_run start
 
   [ $verbose -gt 0 ] && printf "\n$test $*...\n" || printf "$test $*... "
-  "$runner"/../stbt-run $v --save-video "video.webm" "$testpath" -- "$@" \
+  "$runner"/../stbt-run $v --save-thumbnail=always --save-video "video.webm" \
+    "$testpath" -- "$@" \
     >"$tmpdir"/rawout 2>"$tmpdir"/rawerr &
   stbtpid=$!
   local start_time=$(date +%s)
@@ -94,19 +95,7 @@ main() {
   # Data that must be collected ASAP
   echo $(( $(date +%s) - $start_time )) > duration
   which sensors &>/dev/null && sensors &> sensors.log
-  [[ -f screenshot.png ]] || "$runner"/../stbt-screenshot &>/dev/null
   echo $exit_status > exit-status
-
-  cat <<-EOF | python &&
-		import cv2
-		im = cv2.imread('screenshot.png')
-		if im is not None:
-		    cv2.imwrite(
-		        'thumbnail.jpg',
-		        cv2.resize(im, (640, 640 * im.shape[0] // im.shape[1])),
-		        [cv2.cv.CV_IMWRITE_JPEG_QUALITY, 50])
-		EOF
-  [[ $exit_status -eq 0 ]] && rm -f screenshot.png
 
   user_command post_run stop
 

--- a/stbt-run
+++ b/stbt-run
@@ -25,6 +25,14 @@ parser.add_argument(
     '--save-trace', metavar='FILE', default=None,
     help='Write state to this file, as xz compressed newline-seperated JSON')
 parser.add_argument(
+    '--save-screenshot', default='on-failure',
+    choices=['always', 'on-failure', 'never'],
+    help="Save a screenshot at the end of the test to screenshot.png")
+parser.add_argument(
+    '--save-thumbnail', default='never',
+    choices=['always', 'on-failure', 'never'],
+    help="Save a thumbnail at the end of the test to thumbnail.jpg")
+parser.add_argument(
     'script', metavar='FILE[::TESTCASE]', help=(
         "The python test script to run. Optionally specify a python function "
         "name to run that function; otherwise only the script's top-level will "
@@ -70,6 +78,35 @@ def _print_exc_utf8(file_=None):
         traceback.print_exc(file=file_)
     finally:
         traceback._some_str = _old_some_str
+
+
+def _save_screenshot(exception):
+    import cv2
+
+    jpg = (args.save_thumbnail == 'always' or
+           (args.save_thumbnail == 'on-failure' and exception))
+    png = (args.save_screenshot == 'always' or
+           (args.save_screenshot == 'on-failure' and exception))
+
+    if not jpg and not png:
+        return
+
+    screenshot = getattr(exception, "screenshot", None)
+    if screenshot is None and stbt._dut._display:  # pylint: disable=protected-access
+        screenshot = stbt._dut._display.last_used_frame  # pylint: disable=protected-access
+    if screenshot is None:
+        screenshot = stbt._dut.get_frame()  # pylint: disable=protected-access
+
+    if png:
+        cv2.imwrite("screenshot.png", screenshot)
+        sys.stderr.write("Saved screenshot to 'screenshot.png'.\n")
+
+    if jpg:
+        cv2.imwrite(
+            'thumbnail.jpg',
+            cv2.resize(screenshot, (
+                640, 640 * screenshot.shape[0] // screenshot.shape[1])),
+            [cv2.cv.CV_IMWRITE_JPEG_QUALITY, 50])
 
 
 def import_by_filename(filename_):
@@ -131,21 +168,14 @@ except Exception as e:  # pylint: disable=W0703
         error_message = traceback.extract_tb(sys.exc_info()[2])[-1][3]
     sys.stdout.write("FAIL: %s: %s: %s\n" % (
         args.script, type(e).__name__, error_message))
-    if hasattr(e, "screenshot") and e.screenshot is not None:  # pylint:disable=no-member
-        screenshot = e.screenshot  # pylint:disable=no-member
-    elif stbt._dut._display:  # pylint: disable=W0212
-        screenshot = stbt._dut._display.last_used_frame  # pylint: disable=W0212
-    else:
-        screenshot = None
-
-    if screenshot is not None:
-        stbt.save_frame(screenshot, "screenshot.png")
-        sys.stderr.write("Saved screenshot to '%s'.\n" % ("screenshot.png"))
+    _save_screenshot(exception=e)
     _print_exc_utf8(file_=sys.stderr)
     if isinstance(e, (stbt.UITestFailure, AssertionError)):
         sys.exit(1)  # Failure
     else:
         sys.exit(2)  # Error
+else:
+    _save_screenshot(exception=None)
 finally:
     sys.settrace(None)
     if _tracer:

--- a/stbt-run
+++ b/stbt-run
@@ -168,8 +168,11 @@ except Exception as e:  # pylint: disable=W0703
         error_message = traceback.extract_tb(sys.exc_info()[2])[-1][3]
     sys.stdout.write("FAIL: %s: %s: %s\n" % (
         args.script, type(e).__name__, error_message))
-    _save_screenshot(exception=e)
     _print_exc_utf8(file_=sys.stderr)
+    try:
+        _save_screenshot(exception=e)
+    except Exception:  # pylint: disable=broad-except
+        pass
     if isinstance(e, (stbt.UITestFailure, AssertionError)):
         sys.exit(1)  # Failure
     else:

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -10,6 +10,7 @@ test_that_invalid_control_doesnt_hang() {
 test_invalid_source_pipeline() {
     touch test.py
     stbt run -v --source-pipeline viddily-boo test.py &> stbt.log
+    cat stbt.log
     tail -n1 stbt.log | grep -q 'no element "viddily-boo"' ||
         fail "The last error message in '$scratchdir/stbt.log' wasn't the" \
             "expected 'no element \"viddily-boo\"', " \

--- a/tests/test-stbt-run.sh
+++ b/tests/test-stbt-run.sh
@@ -224,13 +224,13 @@ test_that_stbt_run_tracing_is_written_to_socket() {
 assert_correct_unicode_error() {
     cat >expected.log <<-EOF
 		FAIL: test.py: AssertionError: ü
-		Saved screenshot to 'screenshot.png'.
 		Traceback (most recent call last):
 		  File ".../stbt-run", line ..., in <module>
 		    execfile(_filename)
 		  File "...", line 2, in <module>
 		    assert False, $u"ü"
 		AssertionError: ü
+		Saved screenshot to 'screenshot.png'.
 		EOF
     diff -u <(grep -v -e File expected.log) \
             <(grep -v -e 'libdc1394 error: Failed to initialize libdc1394' \

--- a/tests/test-stbt-run.sh
+++ b/tests/test-stbt-run.sh
@@ -78,7 +78,8 @@ test_that_stbt_run_saves_screenshot_on_match_timeout() {
 	    "$testdir/videotestsrc-redblue-flipped.png", timeout_secs=0)
 	EOF
     ! stbt run -v test.py &&
-    [ -f screenshot.png ]
+    [ -f screenshot.png ] &&
+    ! [ -f thumbnail.jpg ]
 }
 
 test_that_stbt_run_saves_screenshot_on_precondition_error() {
@@ -89,7 +90,8 @@ test_that_stbt_run_saves_screenshot_on_precondition_error() {
 	        "$testdir/videotestsrc-redblue-flipped.png", timeout_secs=0)
 	EOF
     ! stbt run -v test.py &&
-    [ -f screenshot.png ]
+    [ -f screenshot.png ] &&
+    ! [ -f thumbnail.jpg ]
 }
 
 test_that_stbt_run_saves_last_grabbed_screenshot_on_error() {
@@ -103,6 +105,7 @@ test_that_stbt_run_saves_last_grabbed_screenshot_on_error() {
 	EOF
     ! stbt run -v test.py &&
     [ -f screenshot.png ] &&
+    ! [ -f thumbnail.jpg ] &&
     python <<-EOF
 	import cv2, numpy
 	ss = cv2.imread('screenshot.png')
@@ -221,6 +224,7 @@ test_that_stbt_run_tracing_is_written_to_socket() {
 assert_correct_unicode_error() {
     cat >expected.log <<-EOF
 		FAIL: test.py: AssertionError: ü
+		Saved screenshot to 'screenshot.png'.
 		Traceback (most recent call last):
 		  File ".../stbt-run", line ..., in <module>
 		    execfile(_filename)


### PR DESCRIPTION
stbt batch run wants a JPG thumbnail of the system under test at the end
of a test run.  Previously it would spawn an additional python instance
after the test run, load the PNG screenshot and then save it as a jpeg.
If the test run succeeded it would even spawn yet another stbt run just
to create a screenshot.png before deleting it after converting it to JPG.

This commit tidies this up.  stbt-run is responsible for creating all
screenshots and thumbnails as it has access to the uncompressed source
screenshot to start with.  This can save 1s for each test run by
`stbt batch`.