### PR TITLE
stbt.ocr: Passing region=None means no region, not Region.ALL

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1037,14 +1037,6 @@ class DeviceUnderTest(object):
         if frame is None:
             frame = self._display.pull_frame()
 
-        if region is None:
-            warnings.warn(
-                "Passing region=None to ocr is deprecated since 0.21 and the "
-                "meaning will change in a future version.  To OCR an entire "
-                "video frame pass region=Region.ALL instead",
-                DeprecationWarning, stacklevel=2)
-            region = Region.ALL
-
         text, region = _tesseract(
             frame, region, mode, lang, tesseract_config,
             tesseract_user_patterns, tesseract_user_words, text_color)
@@ -2822,12 +2814,13 @@ def _fake_frames_at_half_motion():
 
 def test_ocr_on_static_images():
     for image, expected_text, region, mode in [
-        # pylint: disable=C0301
-        ("Connection-status--white-on-dark-blue.png", "Connection status: Connected", None, None),
+        # pylint: disable=line-too-long
+        ("Connection-status--white-on-dark-blue.png", "Connection status: Connected", Region.ALL, None),
         ("Connection-status--white-on-dark-blue.png", "Connected", Region(x=210, y=0, width=120, height=40), None),
-        ("programme--white-on-black.png", "programme", None, None),
-        ("UJJM--white-text-on-grey-boxes.png", "", None, None),
-        ("UJJM--white-text-on-grey-boxes.png", "UJJM", None, OcrMode.SINGLE_LINE),
+        ("Connection-status--white-on-dark-blue.png", "", None, None),
+        ("programme--white-on-black.png", "programme", Region.ALL, None),
+        ("UJJM--white-text-on-grey-boxes.png", "", Region.ALL, None),
+        ("UJJM--white-text-on-grey-boxes.png", "UJJM", Region.ALL, OcrMode.SINGLE_LINE),
     ]:
         kwargs = {"region": region}
         if mode is not None:

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1037,6 +1037,13 @@ class DeviceUnderTest(object):
         if frame is None:
             frame = self._display.pull_frame()
 
+        if region is None:
+            raise TypeError(
+                "Passing region=None to ocr is deprecated since v0.21. "
+                "In a future version, region=None will mean an empty region "
+                "instead. To OCR an entire video frame, use "
+                "`region=Region.ALL`.")
+
         text, region = _tesseract(
             frame, region, mode, lang, tesseract_config,
             tesseract_user_patterns, tesseract_user_words, text_color)

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -2812,27 +2812,6 @@ def _fake_frames_at_half_motion():
     yield dut
 
 
-def test_ocr_on_static_images():
-    for image, expected_text, region, mode in [
-        # pylint: disable=line-too-long
-        ("Connection-status--white-on-dark-blue.png", "Connection status: Connected", Region.ALL, None),
-        ("Connection-status--white-on-dark-blue.png", "Connected", Region(x=210, y=0, width=120, height=40), None),
-        ("Connection-status--white-on-dark-blue.png", "", None, None),
-        ("programme--white-on-black.png", "programme", Region.ALL, None),
-        ("UJJM--white-text-on-grey-boxes.png", "", Region.ALL, None),
-        ("UJJM--white-text-on-grey-boxes.png", "UJJM", Region.ALL, OcrMode.SINGLE_LINE),
-    ]:
-        kwargs = {"region": region}
-        if mode is not None:
-            kwargs["mode"] = mode
-        text = DeviceUnderTest().ocr(
-            cv2.imread(os.path.join(
-                os.path.dirname(__file__), "..", "tests", "ocr", image)),
-            **kwargs)
-        assert text == expected_text, (
-            "Unexpected text. Expected '%s'. Got: %s" % (expected_text, text))
-
-
 def test_region_replace():
     from nose.tools import raises
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -28,6 +28,11 @@ UNRELEASED
 
 ##### Breaking changes since v27
 
+* Passing `region=None` to `stbt.ocr` means that OCR will return an empty
+  string, instead of treating it as `Region.ALL`. This is consistent with
+  `stbt.match_text`, and it means that you can pass in
+  programmatically-calculated regions, for example from `Region.intersect`.
+
 * The definition of equality for `stbt.MatchResult` objects has changed (see
   below for details). This should only affect you if you were storing
   `MatchResult` objects in a set or as the keys of a dict.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -28,10 +28,12 @@ UNRELEASED
 
 ##### Breaking changes since v27
 
-* Passing `region=None` to `stbt.ocr` means that OCR will return an empty
-  string, instead of treating it as `Region.ALL`. This is consistent with
-  `stbt.match_text`, and it means that you can pass in
-  programmatically-calculated regions, for example from `Region.intersect`.
+* Passing `region=None` to `stbt.ocr` raises a TypeError. Use
+  `region=stbt.Region.ALL` instead. Note that passing `None` has printed a
+  deprecation warning since v0.21 (two and a half years ago); raising an
+  exception will force users to update their test scripts, allowing us to
+  change the behaviour again in a future release to be consistent with
+  `stbt.match_text` where `None` means an empty region.
 
 * The definition of equality for `stbt.MatchResult` objects has changed (see
   below for details). This should only affect you if you were storing

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -175,18 +175,26 @@ def test_that_text_region_is_correct_even_with_regions_larger_than_frame():
     assert region.contains(result.region)
 
 
-def test_that_match_text_still_returns_if_region_doesnt_intersect_with_frame():
+@pytest.mark.parametrize("region", [
+    stbt.Region(1280, 0, 1280, 720),
+    None,
+])
+def test_that_match_text_still_returns_if_region_doesnt_intersect_with_frame(
+        region):
     frame = cv2.imread("tests/ocr/menu.png")
-    result = stbt.match_text("Onion Bhaji", frame=frame,
-                             region=stbt.Region(1280, 0, 1280, 720))
+    result = stbt.match_text("Onion Bhaji", frame=frame, region=region)
     assert result.match is False
     assert result.region is None
     assert result.text == "Onion Bhaji"
 
 
-def test_that_ocr_still_returns_if_region_doesnt_intersect_with_frame():
+@pytest.mark.parametrize("region", [
+    stbt.Region(1280, 0, 1280, 720),
+    None,
+])
+def test_that_ocr_still_returns_if_region_doesnt_intersect_with_frame(region):
     frame = cv2.imread("tests/ocr/menu.png")
-    result = stbt.ocr(frame=frame, region=stbt.Region(1280, 0, 1280, 720))
+    result = stbt.ocr(frame=frame, region=region)
     assert result == u''
 
 

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -17,7 +17,7 @@ import stbt
     # pylint: disable=line-too-long
     ("Connection-status--white-on-dark-blue.png", "Connection status: Connected", stbt.Region.ALL, None),
     ("Connection-status--white-on-dark-blue.png", "Connected", stbt.Region(x=210, y=0, width=120, height=40), None),
-    ("Connection-status--white-on-dark-blue.png", "", None, None),
+    # ("Connection-status--white-on-dark-blue.png", "", None, None),  # uncomment when region=None doesn't raise -- see #433
     ("programme--white-on-black.png", "programme", stbt.Region.ALL, None),
     ("UJJM--white-text-on-grey-boxes.png", "", stbt.Region.ALL, None),
     ("UJJM--white-text-on-grey-boxes.png", "UJJM", stbt.Region.ALL, stbt.OcrMode.SINGLE_LINE),
@@ -28,6 +28,12 @@ def test_ocr_on_static_images(image, expected_text, region, mode):
         kwargs["mode"] = mode
     text = stbt.ocr(cv2.imread("tests/ocr/" + image), **kwargs)
     assert text == expected_text
+
+
+# Remove when region=None doesn't raise -- see #433
+@raises(TypeError)
+def test_that_ocr_region_none_isnt_allowed():
+    stbt.ocr(frame=cv2.imread("tests/ocr/small.png"), region=None)
 
 
 def test_that_ocr_reads_unicode():
@@ -207,7 +213,7 @@ def test_that_match_text_still_returns_if_region_doesnt_intersect_with_frame(
 
 @pytest.mark.parametrize("region", [
     stbt.Region(1280, 0, 1280, 720),
-    None,
+    # None,  # uncomment when region=None doesn't raise -- see #433
 ])
 def test_that_ocr_still_returns_if_region_doesnt_intersect_with_frame(region):
     frame = cv2.imread("tests/ocr/menu.png")

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -13,6 +13,24 @@ import _stbt.core
 import stbt
 
 
+def test_ocr_on_static_images():
+    for image, expected_text, region, mode in [
+        # pylint: disable=line-too-long
+        ("Connection-status--white-on-dark-blue.png", "Connection status: Connected", stbt.Region.ALL, None),
+        ("Connection-status--white-on-dark-blue.png", "Connected", stbt.Region(x=210, y=0, width=120, height=40), None),
+        ("Connection-status--white-on-dark-blue.png", "", None, None),
+        ("programme--white-on-black.png", "programme", stbt.Region.ALL, None),
+        ("UJJM--white-text-on-grey-boxes.png", "", stbt.Region.ALL, None),
+        ("UJJM--white-text-on-grey-boxes.png", "UJJM", stbt.Region.ALL, stbt.OcrMode.SINGLE_LINE),
+    ]:
+        kwargs = {"region": region}
+        if mode is not None:
+            kwargs["mode"] = mode
+        text = stbt.ocr(cv2.imread("tests/ocr/" + image), **kwargs)
+        assert text == expected_text, (
+            "Unexpected text. Expected '%s'. Got: %s" % (expected_text, text))
+
+
 def test_that_ocr_reads_unicode():
     text = stbt.ocr(frame=cv2.imread('tests/ocr/unicode.png'), lang='eng+deu')
     assert isinstance(text, unicode)

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -27,8 +27,7 @@ def test_ocr_on_static_images(image, expected_text, region, mode):
     if mode is not None:
         kwargs["mode"] = mode
     text = stbt.ocr(cv2.imread("tests/ocr/" + image), **kwargs)
-    assert text == expected_text, (
-        "Unexpected text. Expected '%s'. Got: %s" % (expected_text, text))
+    assert text == expected_text
 
 
 def test_that_ocr_reads_unicode():

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -13,22 +13,22 @@ import _stbt.core
 import stbt
 
 
-def test_ocr_on_static_images():
-    for image, expected_text, region, mode in [
-        # pylint: disable=line-too-long
-        ("Connection-status--white-on-dark-blue.png", "Connection status: Connected", stbt.Region.ALL, None),
-        ("Connection-status--white-on-dark-blue.png", "Connected", stbt.Region(x=210, y=0, width=120, height=40), None),
-        ("Connection-status--white-on-dark-blue.png", "", None, None),
-        ("programme--white-on-black.png", "programme", stbt.Region.ALL, None),
-        ("UJJM--white-text-on-grey-boxes.png", "", stbt.Region.ALL, None),
-        ("UJJM--white-text-on-grey-boxes.png", "UJJM", stbt.Region.ALL, stbt.OcrMode.SINGLE_LINE),
-    ]:
-        kwargs = {"region": region}
-        if mode is not None:
-            kwargs["mode"] = mode
-        text = stbt.ocr(cv2.imread("tests/ocr/" + image), **kwargs)
-        assert text == expected_text, (
-            "Unexpected text. Expected '%s'. Got: %s" % (expected_text, text))
+@pytest.mark.parametrize("image, expected_text, region, mode", [
+    # pylint: disable=line-too-long
+    ("Connection-status--white-on-dark-blue.png", "Connection status: Connected", stbt.Region.ALL, None),
+    ("Connection-status--white-on-dark-blue.png", "Connected", stbt.Region(x=210, y=0, width=120, height=40), None),
+    ("Connection-status--white-on-dark-blue.png", "", None, None),
+    ("programme--white-on-black.png", "programme", stbt.Region.ALL, None),
+    ("UJJM--white-text-on-grey-boxes.png", "", stbt.Region.ALL, None),
+    ("UJJM--white-text-on-grey-boxes.png", "UJJM", stbt.Region.ALL, stbt.OcrMode.SINGLE_LINE),
+])
+def test_ocr_on_static_images(image, expected_text, region, mode):
+    kwargs = {"region": region}
+    if mode is not None:
+        kwargs["mode"] = mode
+    text = stbt.ocr(cv2.imread("tests/ocr/" + image), **kwargs)
+    assert text == expected_text, (
+        "Unexpected text. Expected '%s'. Got: %s" % (expected_text, text))
 
 
 def test_that_ocr_reads_unicode():


### PR DESCRIPTION
This was added for backwards compatibility in v0.21 (two and a half
years ago) but since then it has printed a warning that this change
would be made eventually.

This is consistent with `stbt.match_text`. In fact my motivation for
making this change is that the difference in behaviour caused me some
confusion when I was writing a test for the recent `text_color` pull
request. It's also consistent with the output of `Region.intersect`
which means that it's safe to pass regions created from
`Region.intersect` into `stbt.ocr`.