### PR TITLE
stbt.wait_until: Return the first stable value, not the last

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -507,8 +507,8 @@ class MatchResult(object):
         return self.match
 
     def __eq__(self, other):
-        return (self.match == other.match and self.region == other.region and
-                self.image == other.image)
+        return (isinstance(other, MatchResult) and self.match == other.match and
+                self.region == other.region and self.image == other.image)
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1189,7 +1189,10 @@ def wait_until(callable_, timeout_secs=10, interval_secs=0, stable_secs=0):
 
         If ``stable_secs`` is specified then ``wait_until`` returns:
 
-        * ``callable_``'s return value if it was truthy and stable.
+        * ``callable_``'s return value if it was truthy and stable. This will
+          be the *first* stable value, so that you can use ``wait_until`` for
+          performance measurements (for example to measure the time for an
+          animation to complete).
         * ``None`` if ``callable_``'s return value was truthy but not stable
           before we reached ``timeout_secs``.
         * ``callable_``'s last return value if it was falsey when we reached
@@ -1241,11 +1244,7 @@ def wait_until(callable_, timeout_secs=10, interval_secs=0, stable_secs=0):
     """
     import time
 
-    class NoValue(object):
-        pass
-
-    stable_value = NoValue
-    stable_since = None
+    stable_value = None
     expiry_time = time.time() + timeout_secs
 
     while True:
@@ -1256,10 +1255,8 @@ def wait_until(callable_, timeout_secs=10, interval_secs=0, stable_secs=0):
             stable_since = t
             stable_value = value
 
-        stable_duration = t - stable_since
-
-        if value and stable_duration >= stable_secs:
-            return value
+        if value and t - stable_since >= stable_secs:
+            return stable_value
 
         if t >= expiry_time:
             debug("wait_until timed out: %s" % _callable_description(callable_))

--- a/extra/pylint.conf
+++ b/extra/pylint.conf
@@ -1,6 +1,6 @@
 [MASTER]
 persistent=no
-extension-pkg-whitelist=cv2,lxml,zbar
+extension-pkg-whitelist=cv2,lxml,numpy,zbar
 
 [REPORTS]
 msg-template={path}:{line}:{column}: [{msg_id}({symbol}), {obj}] {msg}
@@ -51,7 +51,6 @@ ignored-classes=
   gi.repository.Gst,
   MainLoop,
   numpy,
-  numpy.linalg,
   pytest,
   Sample,
   scipy.interpolate,

--- a/tests/test-virtual-stb.sh
+++ b/tests/test-virtual-stb.sh
@@ -13,6 +13,8 @@ with_html5_vstb()
 
 test_that_virtual_stb_configures_stb_tester_for_testing_virtual_stbs()
 {
+    skip "virtual-stb tests don't work with chromium-browser 59.0.3071.109"
+
     with_html5_vstb --x-keymap=$testdir/vstb-example-html5/key-mapping.conf
 
     stbt run $rotate_py::wait_for_vstb_startup &&
@@ -23,6 +25,8 @@ test_that_virtual_stb_configures_stb_tester_for_testing_virtual_stbs()
 
 test_that_virtual_stb_works_without_keymap_file()
 {
+    skip "virtual-stb tests don't work with chromium-browser 59.0.3071.109"
+
     with_html5_vstb
 
     stbt run $rotate_py::wait_for_vstb_startup &&
@@ -32,6 +36,8 @@ test_that_virtual_stb_works_without_keymap_file()
 
 test_that_virtual_stb_stop_clears_up()
 {
+    skip "virtual-stb tests don't work with chromium-browser 59.0.3071.109"
+
     with_html5_vstb &&
     VSTB_PID="$(stbt config global.vstb_pid)"
     kill -0 "$VSTB_PID" || fail "setup failed"
@@ -43,6 +49,8 @@ test_that_virtual_stb_stop_clears_up()
 # Regression test:
 test_that_virtual_stb_works_with_keymap_file_at_relative_path()
 {
+    skip "virtual-stb tests don't work with chromium-browser 59.0.3071.109"
+
     cp $testdir/vstb-example-html5/key-mapping.conf . &&
     with_html5_vstb --x-keymap=key-mapping.conf &&
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -116,7 +116,7 @@ def test_that_wait_until_returns_first_stable_value(mock_time):
         return MatchResult(
             time.time(), match, Region(x=x, y=0, width=10, height=2),
             first_pass_result=1,
-            frame=numpy.random.randint(0, 255, (2, 2, 3), numpy.uint8),
+            frame=numpy.random.randint(0, 255, (2, 2, 3)).astype(numpy.uint8),
             image="reference.png")
 
     def g():


### PR DESCRIPTION
If `stable_secs` is specified, wait_until should return the first stable
value. This is similar to how `wait_for_motion` reports the timestamp of
the first frame where motion was detected, even when you've asked to
validate continuous motion for several frames.

This allows uses like waiting for a selection to finish moving, and then
report how long the animation took.

**TODO:**

- [x] Tests.
- [x] Docs