### PR TITLE
Fix virtual-stb with Chrome 59

### DIFF
--- a/tests/test-virtual-stb.sh
+++ b/tests/test-virtual-stb.sh
@@ -13,8 +13,6 @@ with_html5_vstb()
 
 test_that_virtual_stb_configures_stb_tester_for_testing_virtual_stbs()
 {
-    skip "virtual-stb tests don't work with chromium-browser 59.0.3071.109"
-
     with_html5_vstb --x-keymap=$testdir/vstb-example-html5/key-mapping.conf
 
     stbt run $rotate_py::wait_for_vstb_startup &&
@@ -25,8 +23,6 @@ test_that_virtual_stb_configures_stb_tester_for_testing_virtual_stbs()
 
 test_that_virtual_stb_works_without_keymap_file()
 {
-    skip "virtual-stb tests don't work with chromium-browser 59.0.3071.109"
-
     with_html5_vstb
 
     stbt run $rotate_py::wait_for_vstb_startup &&
@@ -36,8 +32,6 @@ test_that_virtual_stb_works_without_keymap_file()
 
 test_that_virtual_stb_stop_clears_up()
 {
-    skip "virtual-stb tests don't work with chromium-browser 59.0.3071.109"
-
     with_html5_vstb &&
     VSTB_PID="$(stbt config global.vstb_pid)"
     kill -0 "$VSTB_PID" || fail "setup failed"
@@ -49,8 +43,6 @@ test_that_virtual_stb_stop_clears_up()
 # Regression test:
 test_that_virtual_stb_works_with_keymap_file_at_relative_path()
 {
-    skip "virtual-stb tests don't work with chromium-browser 59.0.3071.109"
-
     cp $testdir/vstb-example-html5/key-mapping.conf . &&
     with_html5_vstb --x-keymap=key-mapping.conf &&
 

--- a/tests/vstb-example-html5/run.sh
+++ b/tests/vstb-example-html5/run.sh
@@ -2,4 +2,5 @@
 
 this_dir=$(dirname $(readlink -f $0))
 
-chromium-browser --no-sandbox --app=file://$this_dir/virtual-stb/index.html
+chromium-browser --temp-profile --no-sandbox --disable-gpu \
+    --app=file://$this_dir/virtual-stb/index.html


### PR DESCRIPTION
They've started failing since the latest Chromium release (59.0.3071.109). I disabled the tests temporarily in commit 1e490e5. 

Using `stbt tv` to debug the running virtual-stb shows a blank white page. Loading the same page in chromium-browser directly works fine.

```
./stbt_virtual_stb.py run tests/vstb-example-html5/run.sh &
./stbt-tv
```

vs.

```
chromium-browser --no-sandbox --app=file://`pwd`/tests/vstb-example-html5/virtual-stb/index.html
```
