### PR TITLE
Fix stbt.MatchResult and wait_until's stable_secs

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -471,14 +471,7 @@ class MatchResult(object):
     :ivar int timestamp: DEPRECATED. Timestamp in nanoseconds. Use ``time``
         instead.
 
-    Two ``MatchResult`` objects compare equal to each other if the same
-    reference image matches at the same position (even if the frames and
-    timestamps are different). This makes it possible to use `match` with
-    `wait_until`'s ``stable_secs`` parameter, for example to wait for a
-    selection to stop moving.
-
-    The ``time`` attribute was added in stb-tester v26. The equality rules
-    where changed in stb-tester v28.
+    The ``time`` attribute was added in stb-tester v26.
     """
     def __init__(
             self, time, match, region, first_pass_result, frame, image,
@@ -505,16 +498,6 @@ class MatchResult(object):
 
     def __nonzero__(self):
         return self.match
-
-    def __eq__(self, other):
-        return (isinstance(other, MatchResult) and self.match == other.match and
-                self.region == other.region and self.image == other.image)
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
-    def __hash__(self):
-        return hash((self.match, self.region, self.image))
 
     @property
     def position(self):
@@ -1182,7 +1165,7 @@ def wait_until(callable_, timeout_secs=10, interval_secs=0, stable_secs=0):
     :type stable_secs: int or float, in seconds
     :param stable_secs: Wait for ``callable_``'s return value to remain the same
         (as determined by ``==``) for this duration before returning. This can
-        be used to wait for the position of a `MatchResult` to stabilise.
+        be used to wait for a `FrameObject` to stabilise.
 
     :returns: The return value from ``callable_`` (which will be truthy if it
         succeeded, or falsey if ``wait_until`` timed out).

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1234,19 +1234,22 @@ def wait_until(callable_, timeout_secs=10, interval_secs=0, stable_secs=0):
         t = time.time()
         value = callable_()
 
-        if value != stable_value:
-            stable_since = t
-            stable_value = value
-
-        if value and t - stable_since >= stable_secs:
-            return stable_value
+        if stable_secs:
+            if value != stable_value:
+                stable_since = t
+                stable_value = value
+            if value and t - stable_since >= stable_secs:
+                return stable_value
+        else:
+            if value:
+                return value
 
         if t >= expiry_time:
             debug("wait_until timed out: %s" % _callable_description(callable_))
-            if stable_secs == 0:
-                return value
-            else:
+            if stable_secs:
                 return None
+            else:
+                return value  # it's falsey
 
         time.sleep(interval_secs)
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -35,10 +35,6 @@ UNRELEASED
   change the behaviour again in a future release to be consistent with
   `stbt.match_text` where `None` means an empty region.
 
-* The definition of equality for `stbt.MatchResult` objects has changed (see
-  below for details). This should only affect you if you were storing
-  `MatchResult` objects in a set or as the keys of a dict.
-
 ##### New features
 
 * New Android control mechanism to send taps, swipes, and key events. See the
@@ -54,8 +50,7 @@ UNRELEASED
   for a discussion of the trade-offs of each video-capture mechanism.
 
 * Python API: `stbt.wait_until` has a new parameter `stable_secs` to wait for
-  the return value to stabilise (for example to wait for the position of a
-  `MatchResult` to stabilise).
+  the return value to stabilise.
 
 * Python API: `stbt.ocr` and `stbt.match_text` have a new parameter
   `text_color`. Specifying this can improve OCR results when tesseract's
@@ -73,13 +68,6 @@ UNRELEASED
 * Python API: `stbt.wait_until` will try one last time after the timeout is
   reached. This allows you to use a short `timeout_secs` with operations that
   can take a long time.
-
-* Python API: `stbt.MatchResult` objects are now considered equal if they
-  correspond to the same reference image, matching (or not matching) at the
-  same position. That is, two `MatchResult` objects corresponding to different
-  video-frames (with different timestamps) can now be considered equal. This
-  makes it more convenient to use `stbt.match` with `wait_until`'s
-  `stable_secs` parameter.
 
 ##### Maintainer-visible changes
 

--- a/tests/test-match.sh
+++ b/tests/test-match.sh
@@ -444,31 +444,6 @@ test_match_reports_no_match() {
     stbt run -v test.py
 }
 
-test_matchresults_are_equal() {
-    cat > test.py <<-EOF
-	import stbt
-	m1 = stbt.match("$testdir/videotestsrc-redblue.png")
-	m2 = stbt.match("$testdir/videotestsrc-redblue.png")
-	assert m1 == m2
-	EOF
-    stbt run -v test.py
-}
-
-test_matchresults_are_not_equal() {
-    cat > test.py <<-EOF
-	import stbt, time
-	mp = stbt.MatchParameters(confirm_method="none")
-	m1 = stbt.match("$testdir/videotestsrc-ball.png", match_parameters=mp)
-	time.sleep(0.1)
-	m2 = stbt.match("$testdir/videotestsrc-ball.png", match_parameters=mp)
-	assert m1 != m2
-	EOF
-    stbt run -v --source-pipeline \
-        "videotestsrc pattern=ball is-live=true \
-         ! video/x-raw,format=BGR,width=320,height=240" \
-        test.py
-}
-
 test_detect_match_times_out() {
     cat > test.py <<-EOF
 	for match_result in detect_match("$testdir/videotestsrc-redblue.png",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,7 +8,8 @@ import mock
 import numpy
 import pytest
 
-from stbt import MatchResult, Region, wait_until
+import stbt
+from stbt import wait_until
 
 
 # pylint:disable=redefined-outer-name,unused-argument
@@ -113,8 +114,8 @@ def test_that_wait_until_returns_first_stable_value(mock_time):
 
     def MR(match, x):
         time.sleep(1)  # advance the mock time by 1 second
-        return MatchResult(
-            time.time(), match, Region(x=x, y=0, width=10, height=2),
+        return stbt.MatchResult(
+            time.time(), match, stbt.Region(x=x, y=0, width=10, height=2),
             first_pass_result=1,
             frame=numpy.random.randint(0, 255, (2, 2, 3)).astype(numpy.uint8),
             image="reference.png")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -133,9 +133,8 @@ def test_that_wait_until_returns_first_stable_value(mock_time):
     results = g()
 
     def match():
-        return next(results)
+        match_result = next(results)
+        return match_result and match_result.region
 
     result = wait_until(match, stable_secs=2)
-    assert result.match
-    assert result.region.x == 4
-    assert result.time == 1497000004
+    assert result == stbt.Region(x=4, y=0, width=10, height=2)


### PR DESCRIPTION
TODO:

- [x] Remove MatchResult `__eq__` and `__hash__`.
- [x] Don't use value comparison in `wait_until` if you aren't using `stable_secs`.