### PR TITLE
stbt.load_image: Add errno to IOError exceptions

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -538,10 +538,11 @@ def _load_template(template):
         relative_filename = template
         absolute_filename = _find_user_file(relative_filename)
         if not absolute_filename:
-            raise IOError("No such template file: %s" % relative_filename)
+            raise IOError(errno.ENOENT, "No such template file",
+                          relative_filename)
         image = cv2.imread(absolute_filename, cv2.CV_LOAD_IMAGE_COLOR)
         if image is None:
-            raise IOError("Failed to load template file: %s" %
+            raise IOError(errno.EIO, "Failed to load template file",
                           absolute_filename)
         return _AnnotatedTemplate(image, relative_filename, absolute_filename)
 
@@ -575,10 +576,10 @@ def load_image(filename, flags=cv2.CV_LOAD_IMAGE_COLOR):
 
     absolute_filename = _find_user_file(filename)
     if not absolute_filename:
-        raise IOError("No such file: %s" % filename)
+        raise IOError(errno.ENOENT, "No such file", filename)
     image = cv2.imread(absolute_filename, flags)
     if image is None:
-        raise IOError("Failed to load image: %s" % absolute_filename)
+        raise IOError(errno.EIO, "Failed to load image", absolute_filename)
     return image
 
 
@@ -2584,10 +2585,10 @@ def _load_mask(filename):
     absolute_filename = _find_user_file(filename)
     debug("Using mask %s" % absolute_filename)
     if not absolute_filename:
-        raise IOError("No such mask file: %s" % filename)
+        raise IOError(errno.ENOENT, "No such mask file", filename)
     image = cv2.imread(absolute_filename, cv2.CV_LOAD_IMAGE_GRAYSCALE)
     if image is None:
-        raise IOError("Failed to load mask file: %s" % absolute_filename)
+        raise IOError(errno.EIO, "Failed to load mask file", absolute_filename)
     return image
 
 

--- a/tests/test-match.sh
+++ b/tests/test-match.sh
@@ -35,9 +35,9 @@ test_wait_for_match_nonexistent_template() {
 	wait_for_match("idontexist.png")
 	EOF
     ! stbt run -v test.py &> test.log || fail "Test should have failed"
-    grep -q "No such template file: idontexist.png" test.log ||
-        fail "Expected 'No such template file: idontexist.png' but saw '$(
-            grep 'No such template file' test.log | head -n1)'"
+    grep -q "No such template file: 'idontexist.png'" test.log ||
+        fail "Expected 'No such template file: 'idontexist.png'' but saw '$(
+            grep FAIL test.log)'"
 }
 
 test_wait_for_match_opencv_image_can_be_used_as_template() {

--- a/tests/test-motion.sh
+++ b/tests/test-motion.sh
@@ -52,9 +52,9 @@ test_wait_for_motion_nonexistent_mask() {
     timeout 10 stbt run -v test.py &> test.log
     local ret=$?
     [ $ret -ne $timedout -a $ret -ne 0 ] || fail "Unexpected exit status $ret"
-    grep -q "No such mask file: idontexist.png" test.log ||
+    grep -q "No such mask file: 'idontexist.png'" test.log ||
         fail "Expected 'No such mask file: idontexist.png' but saw '$(
-            grep 'No such mask file' test.log | head -n1)'"
+            grep FAIL test.log)'"
 }
 
 test_wait_for_motion_with_high_noisethreshold_reports_motion() {


### PR DESCRIPTION
We change the exception type In 68c0d92 ("stbt.load_image: Raise IOError
instead of ValueError") but it turns out that IOErrors can (should?)
have an errno & filename attribute:

> When exceptions of this type are created with a 2-tuple, the first
> item is available on the instance’s errno attribute (it is assumed to
> be an error number), and the second item is available on the strerror
> attribute (it is usually the associated error message). The tuple
> itself is also available on the args attribute.
>
> When an EnvironmentError exception is instantiated with a 3-tuple, the
> first two items are available as above, while the third item is
> available on the filename attribute. However, for backwards
> compatibility, the args attribute contains only a 2-tuple of the first
> two constructor arguments.

https://docs.python.org/2/library/exceptions.html#exceptions.EnvironmentError

(Note that IOError inherits from EnvironmentError.)

---

TODO:

- [ ] Fix `stbt run` output "FAIL: test.py: IOError: 2"