### PR TITLE
Display: Allow multiple threads to call `get_frame()` and `frames()`

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1911,7 +1911,7 @@ class Display(object):
 
         self.source_pipeline.set_state(Gst.State.PLAYING)
 
-    def _get_sample(self, timeout_secs=10):
+    def _get_frame(self, timeout_secs=10):
         try:
             # Timeout in case no frames are received. This happens when the
             # Hauppauge HDPVR video-capture device loses video.
@@ -1931,7 +1931,7 @@ class Display(object):
         return gst_sample
 
     def pull_frame(self, timeout_secs=10):
-        return array_from_sample(self._get_sample(timeout_secs))
+        return self._get_frame(timeout_secs)
 
     def frames(self, timeout_secs=None):
         import time
@@ -1940,11 +1940,11 @@ class Display(object):
 
         while True:
             ddebug("user thread: Getting sample at %s" % time.time())
-            sample = self._get_sample(max(10, timeout_secs or 0))
+            frame = self._get_frame(max(10, timeout_secs or 0))
             ddebug("user thread: Got sample at %s" % time.time())
-            timestamp = sample.time
+            timestamp = frame.time
 
-            yield array_from_sample(sample)
+            yield frame
 
             if timeout_secs is not None and timestamp > end_time:
                 debug("timed out: %.3f > %.3f" % (timestamp, end_time))
@@ -1963,19 +1963,19 @@ class Display(object):
             warn("Received frame with suspicious timestamp: %f. Check your "
                  "source-pipeline configuration." % sample.time)
 
-        self.tell_user_thread(sample)
+        self.tell_user_thread(array_from_sample(sample))
         self._sink_pipeline.on_sample(sample)
         return Gst.FlowReturn.OK
 
-    def tell_user_thread(self, sample_or_exception):
+    def tell_user_thread(self, frame_or_exception):
         # `self.last_sample` (a synchronised Queue) is how we communicate from
         # this thread (the GLib main loop) to the main application thread
         # running the user's script. Note that only this thread writes to the
         # Queue.
 
-        if isinstance(sample_or_exception, Exception):
+        if isinstance(frame_or_exception, Exception):
             ddebug("glib thread: reporting exception to user thread: %s" %
-                   sample_or_exception)
+                   frame_or_exception)
         else:
             ddebug("glib thread: new sample (time=%s). Queue.qsize: %d" %
                    (sample_or_exception.time, self.last_sample.qsize()))

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1822,7 +1822,6 @@ class Display(object):
         self.last_used_frame = None
         self.source_pipeline = None
         self.init_time = time.time()
-        self.start_timestamp = None
         self.underrun_timeout = None
         self.tearing_down = False
 
@@ -1876,7 +1875,6 @@ class Display(object):
             # Hauppauge HDPVR capture device.
             source_queue = self.source_pipeline.get_by_name(
                 "_stbt_user_data_queue")
-            self.start_timestamp = None
             source_queue.connect("underrun", self.on_underrun)
             source_queue.connect("running", self.on_running)
 
@@ -1917,27 +1915,24 @@ class Display(object):
 
     def frames(self, timeout_secs=None):
         import time
-        self.start_timestamp = None
+        if timeout_secs is not None:
+            end_time = time.time() + timeout_secs
 
         with self.lock:
             while True:
                 ddebug("user thread: Getting sample at %s" % time.time())
-                sample = self._get_sample(max(10, timeout_secs))
+                sample = self._get_sample(max(10, timeout_secs or 0))
                 ddebug("user thread: Got sample at %s" % time.time())
                 timestamp = sample.time
-
-                if timeout_secs is not None:
-                    if not self.start_timestamp:
-                        self.start_timestamp = timestamp
-                    if timestamp - self.start_timestamp > timeout_secs:
-                        debug("timed out: %.3f - %.3f > %.3f" % (
-                            timestamp, self.start_timestamp, timeout_secs))
-                        return
 
                 try:
                     yield array_from_sample(sample)
                 finally:
                     self._sink_pipeline.push_sample(sample)
+
+                if timeout_secs is not None and timestamp > end_time:
+                    debug("timed out: %.3f > %.3f" % (timestamp, end_time))
+                    return
 
     def on_new_sample(self, appsink):
         sample = appsink.emit("pull-sample")

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1840,7 +1840,6 @@ class Display(object):
 
         import time
 
-        self.novideo = False
         self.last_sample = Queue.Queue(maxsize=1)
         self.last_used_frame = None
         self.source_pipeline = None
@@ -1917,9 +1916,7 @@ class Display(object):
             # Timeout in case no frames are received. This happens when the
             # Hauppauge HDPVR video-capture device loses video.
             gst_sample = self.last_sample.get(timeout=timeout_secs)
-            self.novideo = False
         except Queue.Empty:
-            self.novideo = True
             pipeline = self.source_pipeline
             if pipeline:
                 Gst.debug_bin_to_dot_file_with_ts(

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -17,7 +17,6 @@ import functools
 import inspect
 import itertools
 import os
-import Queue
 import re
 import subprocess
 import threading
@@ -878,7 +877,7 @@ class DeviceUnderTest(object):
 
         grabbed_from_live = (frame is None)
         if grabbed_from_live:
-            frame = self._display.pull_frame()
+            frame = self._display.get_frame()
 
         imglog = logging.ImageLogger(
             "match", match_parameters=match_parameters,
@@ -1099,7 +1098,7 @@ class DeviceUnderTest(object):
             tesseract_user_patterns=None, text_color=None):
 
         if frame is None:
-            frame = self._display.pull_frame()
+            frame = self._display.get_frame()
 
         if region is None:
             raise TypeError(
@@ -1164,7 +1163,7 @@ class DeviceUnderTest(object):
             yield f.copy(), int(f.time * 1e9)
 
     def get_frame(self):
-        return self._display.pull_frame().copy()
+        return self._display.get_frame().copy()
 
     def is_screen_black(self, frame=None, mask=None, threshold=None):
         if threshold is None:
@@ -1172,7 +1171,7 @@ class DeviceUnderTest(object):
         if mask:
             mask = _load_mask(mask)
         if frame is None:
-            frame = self._display.pull_frame()
+            frame = self._display.get_frame()
         greyframe = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
         _, greyframe = cv2.threshold(
             greyframe, threshold, 255, cv2.THRESH_BINARY)
@@ -1840,7 +1839,8 @@ class Display(object):
 
         import time
 
-        self.last_sample = Queue.Queue(maxsize=1)
+        self._condition = threading.Condition()  # Protects last_frame
+        self.last_frame = None
         self.last_used_frame = None
         self.source_pipeline = None
         self.init_time = time.time()
@@ -1911,36 +1911,43 @@ class Display(object):
 
         self.source_pipeline.set_state(Gst.State.PLAYING)
 
-    def _get_frame(self, timeout_secs=10):
-        try:
-            # Timeout in case no frames are received. This happens when the
-            # Hauppauge HDPVR video-capture device loses video.
-            gst_sample = self.last_sample.get(timeout=timeout_secs)
-        except Queue.Empty:
-            pipeline = self.source_pipeline
-            if pipeline:
-                Gst.debug_bin_to_dot_file_with_ts(
-                    pipeline, Gst.DebugGraphDetails.ALL, "NoVideo")
-            raise NoVideo("No video")
-        if isinstance(gst_sample, Exception):
-            raise UITestError(str(gst_sample))
+    def get_frame(self, timeout_secs=10, since=None):
+        import time
+        t = time.time()
+        end_time = t + timeout_secs
+        if since is None:
+            # If you want to wait 10s for a frame you're probably not interested
+            # in a frame from 10s ago.
+            since = t - timeout_secs
 
-        if isinstance(gst_sample, Gst.Sample):
-            self.last_used_frame = array_from_sample(gst_sample)
+        with self._condition:
+            while True:
+                if (isinstance(self.last_frame, Frame) and
+                        self.last_frame.time > since):
+                    self.last_used_frame = self.last_frame
+                    return self.last_frame
+                elif isinstance(self.last_frame, Exception):
+                    raise UITestError(str(self.last_frame))
+                t = time.time()
+                if t > end_time:
+                    break
+                self._condition.wait(end_time - t)
 
-        return gst_sample
-
-    def pull_frame(self, timeout_secs=10):
-        return self._get_frame(timeout_secs)
+        pipeline = self.source_pipeline
+        if pipeline:
+            Gst.debug_bin_to_dot_file_with_ts(
+                pipeline, Gst.DebugGraphDetails.ALL, "NoVideo")
+        raise NoVideo("No video")
 
     def frames(self, timeout_secs=None):
         import time
         if timeout_secs is not None:
             end_time = time.time() + timeout_secs
+        timestamp = None
 
         while True:
             ddebug("user thread: Getting sample at %s" % time.time())
-            frame = self._get_frame(max(10, timeout_secs or 0))
+            frame = self.get_frame(max(10, timeout_secs or 0), since=timestamp)
             ddebug("user thread: Got sample at %s" % time.time())
             timestamp = frame.time
 
@@ -1968,25 +1975,20 @@ class Display(object):
         return Gst.FlowReturn.OK
 
     def tell_user_thread(self, frame_or_exception):
-        # `self.last_sample` (a synchronised Queue) is how we communicate from
-        # this thread (the GLib main loop) to the main application thread
-        # running the user's script. Note that only this thread writes to the
-        # Queue.
+        # `self.last_frame` is how we communicate from this thread (the GLib
+        # main loop) to the main application thread running the user's script.
+        # Note that only this thread writes to the Queue.
 
         if isinstance(frame_or_exception, Exception):
             ddebug("glib thread: reporting exception to user thread: %s" %
                    frame_or_exception)
         else:
-            ddebug("glib thread: new sample (time=%s). Queue.qsize: %d" %
-                   (sample_or_exception.time, self.last_sample.qsize()))
+            ddebug("glib thread: new sample (time=%s)." %
+                   frame_or_exception.time)
 
-        # Drop old frame
-        try:
-            self.last_sample.get_nowait()
-        except Queue.Empty:
-            pass
-
-        self.last_sample.put_nowait(sample_or_exception)
+        with self._condition:
+            self.last_frame = frame_or_exception
+            self._condition.notify_all()
 
     def on_error(self, _bus, message):
         assert message.type == Gst.MessageType.ERROR

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1669,6 +1669,7 @@ class SinkPipeline(object):
         self.annotations = []
         self._raise_in_user_thread = raise_in_user_thread
         self.received_eos = threading.Event()
+        self._frames = deque(maxlen=35)
 
         if save_video:
             if not save_video.endswith(".webm"):
@@ -1725,6 +1726,10 @@ class SinkPipeline(object):
         self.sink_pipeline.set_state(Gst.State.PLAYING)
 
     def teardown(self):
+        # Drain the frame queue
+        while self._frames:
+            self._push_sample(self._frames.pop())
+
         debug("teardown: Sending eos on sink pipeline")
         if self.appsrc.emit("end-of-stream") == Gst.FlowReturn.OK:
             if not self.received_eos.wait(10):
@@ -1738,7 +1743,26 @@ class SinkPipeline(object):
         # we won't be raising any errors from now on anyway:
         self._raise_in_user_thread = None
 
-    def push_sample(self, sample):
+    def on_sample(self, sample):
+        """
+        Called from `Display` for each frame.
+        """
+        # The test script can draw on the video, but this happens in a different
+        # thread.  We don't know when they're finished drawing so we just give
+        # them 0.5s instead.
+        SINK_LATENCY_SECS = 0.5
+
+        now = sample.time
+        self._frames.appendleft(sample)
+
+        while self._frames:
+            oldest = self._frames.pop()
+            if oldest.time > now - SINK_LATENCY_SECS:
+                self._frames.append(oldest)
+                break
+            self._push_sample(oldest)
+
+    def _push_sample(self, sample):
         # Calculate whether we need to draw any annotations on the output video.
         now = sample.time
         texts = []
@@ -1803,7 +1827,7 @@ class NoSinkPipeline(object):
     def teardown(self):
         pass
 
-    def push_sample(self, _sample):
+    def on_sample(self, _sample):
         pass
 
     def draw(self, _obj, _duration_secs=None, label=""):
@@ -1817,7 +1841,6 @@ class Display(object):
         import time
 
         self.novideo = False
-        self.lock = threading.RLock()  # Held by whoever is consuming frames
         self.last_sample = Queue.Queue(maxsize=1)
         self.last_used_frame = None
         self.source_pipeline = None
@@ -1918,21 +1941,17 @@ class Display(object):
         if timeout_secs is not None:
             end_time = time.time() + timeout_secs
 
-        with self.lock:
-            while True:
-                ddebug("user thread: Getting sample at %s" % time.time())
-                sample = self._get_sample(max(10, timeout_secs or 0))
-                ddebug("user thread: Got sample at %s" % time.time())
-                timestamp = sample.time
+        while True:
+            ddebug("user thread: Getting sample at %s" % time.time())
+            sample = self._get_sample(max(10, timeout_secs or 0))
+            ddebug("user thread: Got sample at %s" % time.time())
+            timestamp = sample.time
 
-                try:
-                    yield array_from_sample(sample)
-                finally:
-                    self._sink_pipeline.push_sample(sample)
+            yield array_from_sample(sample)
 
-                if timeout_secs is not None and timestamp > end_time:
-                    debug("timed out: %.3f > %.3f" % (timestamp, end_time))
-                    return
+            if timeout_secs is not None and timestamp > end_time:
+                debug("timed out: %.3f > %.3f" % (timestamp, end_time))
+                return
 
     def on_new_sample(self, appsink):
         sample = appsink.emit("pull-sample")
@@ -1948,11 +1967,7 @@ class Display(object):
                  "source-pipeline configuration." % sample.time)
 
         self.tell_user_thread(sample)
-        if self.lock.acquire(False):  # non-blocking
-            try:
-                self._sink_pipeline.push_sample(sample)
-            finally:
-                self.lock.release()
+        self._sink_pipeline.on_sample(sample)
         return Gst.FlowReturn.OK
 
     def tell_user_thread(self, sample_or_exception):

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -94,6 +94,10 @@ UNRELEASED
   reached. This allows you to use a short `timeout_secs` with operations that
   can take a long time.
 
+* `stbt batch run`: New option `--no-save-video` - disables saving video of each
+  test run.  This can be used to reduce resource consumption when videos records
+  aren't required or are being captured in some other way.
+
 ##### Maintainer-visible changes
 
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -98,6 +98,9 @@ UNRELEASED
   test run.  This can be used to reduce resource consumption when videos records
   aren't required or are being captured in some other way.
 
+* `sink_pipeline` can now be set to `disable`.  This will have the same effect
+  as `sink_pipeline = fakesink` but with lower resource utilisation.
+
 ##### Maintainer-visible changes
 
 

--- a/stbt-batch.d/run-one
+++ b/stbt-batch.d/run-one
@@ -71,10 +71,14 @@ main() {
     "$runner"/report --html-only . >/dev/null
   fi
 
+  if [ "$save_video" != "false" ]; then
+    save_video_arg="--save-video video.webm"
+  fi
+
   user_command pre_run start
 
   [ $verbose -gt 0 ] && printf "\n$test $*...\n" || printf "$test $*... "
-  "$runner"/../stbt-run $v --save-thumbnail=always --save-video "video.webm" \
+  "$runner"/../stbt-run $v --save-thumbnail=always $save_video_arg \
     "$testpath" -- "$@" \
     >"$tmpdir"/rawout 2>"$tmpdir"/rawerr &
   stbtpid=$!

--- a/stbt-batch.d/run.py
+++ b/stbt-batch.d/run.py
@@ -57,6 +57,10 @@ def main(argv):
             report can be slow if there are many results in the output
             directory. You can still generate the HTML reports afterwards with
             'stbt batch report'.""")
+    parser.add_argument(
+        '--no-save-video', action='store_true', help="""
+            Don't generate a video of each testrun.  Use this if you're saving
+            video another way.""")
     parser.add_argument('test_name', nargs=argparse.REMAINDER)
     args = parser.parse_args(argv[1:])
 
@@ -105,6 +109,7 @@ def main(argv):
         run_count += 1
         subenv = dict(os.environ)
         subenv['do_html_report'] = "false" if args.no_html_report else "true"
+        subenv['save_video'] = "false" if args.no_save_video else "true"
         subenv['tag'] = tag
         subenv['v'] = '-vv' if args.debug else '-v'
         subenv['verbose'] = str(args.verbose)

--- a/tests/test-stbt-batch.sh
+++ b/tests/test-stbt-batch.sh
@@ -258,6 +258,22 @@ test_stbt_batch_run_without_html_reports() {
     [[ -f latest/my-classifier-ran ]] || fail "Custom classifier didn't run"
 }
 
+test_stbt_batch_run_no_save_video() {
+    create_test_repo
+    { stbt batch run --no-save-video -1 -t "my label" tests/test.py ||
+        fail "stbt batch run failed"
+    } | sed 's/^/stbt batch run: /'
+
+    local expected_commit="$(git -C tests describe --always)"
+    local expected_commit_sha="$(git -C tests rev-parse HEAD)"
+
+    ! [ -e "latest-my label/video.webm" ] ||
+        fail "Video was written even though it shouldn't have been"
+
+    # We still expect an HTML report even if a video is not available
+    validate_html_report "latest-my label" test.py "$expected_commit" "$expected_commit_sha" "my label"
+}
+
 test_stbt_batch_run_with_custom_recovery_script() {
     create_test_repo
     set_config batch.recover "$PWD/my-recover"

--- a/tests/test-stbt-batch.sh
+++ b/tests/test-stbt-batch.sh
@@ -260,6 +260,7 @@ test_stbt_batch_run_without_html_reports() {
 
 test_stbt_batch_run_no_save_video() {
     create_test_repo
+    set_config global.sink_pipeline disable
     { stbt batch run --no-save-video -1 -t "my label" tests/test.py ||
         fail "stbt batch run failed"
     } | sed 's/^/stbt batch run: /'


### PR DESCRIPTION
Previously `get_frame()` would have a side-effect that we'd never get the
same frame twice.  Instead it would block waiting for a new frame.  This is
useful behaviour for simple loops like:

    wait_until(lambda: match("example.png"))

but it's less desirable for:

    wait_until(lambda: match("example.png") or match("alternative.png"))

as waiting for a different frame to match "alternative.png" is unnecessary
and slows the process down.

It goes particularly wrong for cases like:

    for x, y in izip(detect_motion(),
                     iter(lambda: stbt.match("error-dialog.png"))):
        ...

Which frames will be analysed by `detect_motion` and which matched against?
It's unclear.

With this change a call to `get_frame()` will return immediately with the
latest frame and multiple `stbt.frames()` iterators can be used
concurrently (even from separate threads).  This will make it easier to
implement some more complex performance measurement tests.

The effects of this change could be rather subtle.  I would expect there to
be some loops out there that become busy-waits.  Whether that will actually
cause problems or not is a seperate question.

This is built on top of #420 and should provide a solution to #266 and #246