### PR TITLE
_stbt.core.SinkPipeline.draw: Fix check for "time" attr

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1786,7 +1786,7 @@ class SinkPipeline(object):
                     ' ' + obj)
                 self.text_annotations.append(
                     {"text": obj, "duration": duration_secs})
-            elif hasattr(obj, "region") and hasattr(obj, "timestamp"):
+            elif hasattr(obj, "region") and hasattr(obj, "time"):
                 annotation = _Annotation.from_result(obj, label=label)
                 if annotation.time:
                     self.annotations.append(annotation)


### PR DESCRIPTION
`_Annotation.from_result` uses the result's "time" attr (not
"timestamp") since commit 9c110be "core: Use wall-clock timestamp
everywhere instead of pts".