### PR TITLE
stbt.ocr: Make the default value of `lang` configurable

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -58,9 +58,9 @@ class MatchParameters(object):
     `match`, `wait_for_match`, and `press_until_match`.
 
     You can change the default values for these parameters by setting a key
-    (with the same name as the corresponding python parameter) in the `[match]`
-    section of stbt.conf. But we strongly recommend that you don't change the
-    default values from what is documented here.
+    (with the same name as the corresponding python parameter) in the
+    ``[match]`` section of :ref:`.stbt.conf`. But we strongly recommend that
+    you don't change the default values from what is documented here.
 
     You should only need to change these parameters when you're trying to match
     a template image that isn't actually a perfect match -- for example if

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1101,7 +1101,7 @@ class DeviceUnderTest(object):
 
     def ocr(self, frame=None, region=Region.ALL,
             mode=OcrMode.PAGE_SEGMENTATION_WITHOUT_OSD,
-            lang="eng", tesseract_config=None, tesseract_user_words=None,
+            lang=None, tesseract_config=None, tesseract_user_words=None,
             tesseract_user_patterns=None, text_color=None):
 
         if frame is None:
@@ -1114,6 +1114,9 @@ class DeviceUnderTest(object):
                 "instead. To OCR an entire video frame, use "
                 "`region=Region.ALL`.")
 
+        if lang is None:
+            lang = get_config("ocr", "lang", "eng")
+
         text, region = _tesseract(
             frame, region, mode, lang, tesseract_config,
             tesseract_user_patterns, tesseract_user_words, text_color)
@@ -1122,13 +1125,15 @@ class DeviceUnderTest(object):
         return text
 
     def match_text(self, text, frame=None, region=Region.ALL,
-                   mode=OcrMode.PAGE_SEGMENTATION_WITHOUT_OSD, lang="eng",
+                   mode=OcrMode.PAGE_SEGMENTATION_WITHOUT_OSD, lang=None,
                    tesseract_config=None, case_sensitive=False,
                    text_color=None):
 
         import lxml.etree
         if frame is None:
             frame = self.get_frame()
+        if lang is None:
+            lang = get_config("ocr", "lang", "eng")
 
         _config = dict(tesseract_config or {})
         _config['tessedit_create_hocr'] = 1

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -82,6 +82,10 @@ UNRELEASED
   default thresholding algorithm doesn't detect the text, for example for
   light-colored text or text on a translucent overlay.
 
+* Python API: The default `lang` (language) parameter to `stbt.ocr` and
+  `stbt.match_text` is now configurable. Set `lang` in the `[ocr]` section
+  of your configuration file.
+
 ##### Minor fixes and packaging fixes
 
 * The `irnetbox` control now understands "double signals" in the irNetBox

--- a/stbt.conf
+++ b/stbt.conf
@@ -36,6 +36,9 @@ erode_passes=1
 # only its speed. Set to `1` to disable this optimisation.
 pyramid_levels = 3
 
+[ocr]
+lang = eng
+
 [press]
 interpress_delay_secs = 0
 

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -342,7 +342,7 @@ def wait_for_motion(
 
 def ocr(frame=None, region=Region.ALL,
         mode=OcrMode.PAGE_SEGMENTATION_WITHOUT_OSD,
-        lang="eng", tesseract_config=None, tesseract_user_words=None,
+        lang=None, tesseract_config=None, tesseract_user_words=None,
         tesseract_user_patterns=None, text_color=None):
     r"""Return the text present in the video frame as a Unicode string.
 
@@ -365,8 +365,9 @@ def ocr(frame=None, region=Region.ALL,
         language code of the language you are attempting to read; for example
         "eng" for English or "deu" for German. More than one language can be
         specified by joining with '+'; for example "eng+deu" means that the
-        text to be read may be in a mixture of English and German. Defaults to
-        English.
+        text to be read may be in a mixture of English and German. This defaults
+        to "eng" (English). You can override the global default value by setting
+        ``lang`` in the ``[ocr]`` section of :ref:`.stbt.conf`.
 
     :param dict tesseract_config:
         Allows passing configuration down to the underlying OCR engine.
@@ -409,7 +410,7 @@ def ocr(frame=None, region=Region.ALL,
 
 
 def match_text(text, frame=None, region=Region.ALL,
-               mode=OcrMode.PAGE_SEGMENTATION_WITHOUT_OSD, lang="eng",
+               mode=OcrMode.PAGE_SEGMENTATION_WITHOUT_OSD, lang=None,
                tesseract_config=None, case_sensitive=False, text_color=None):
     """Search for the specified text in a single video frame.
 

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -108,7 +108,7 @@ def press(key, interpress_delay_secs=None):
 
         This defaults to 0.3. You can override the global default value by
         setting ``interpress_delay_secs`` in the ``[press]`` section of
-        stbt.conf.
+        :ref:`.stbt.conf`.
     """
     return _dut.press(key, interpress_delay_secs)
 
@@ -225,7 +225,8 @@ def detect_motion(timeout_secs=10, noise_threshold=None, mask=None):
         difference is considered motion).
 
         This defaults to 0.84. You can override the global default value by
-        setting ``noise_threshold`` in the ``[motion]`` section of stbt.conf.
+        setting ``noise_threshold`` in the ``[motion]`` section of
+        :ref:`.stbt.conf`.
 
     :param str mask:
         The filename of a black & white image that specifies which part of the
@@ -283,14 +284,14 @@ def press_until_match(
         Defaults to 3.
 
         You can override the global default value by setting ``interval_secs``
-        in the ``[press_until_match]`` section of stbt.conf.
+        in the ``[press_until_match]`` section of :ref:`.stbt.conf`.
 
     :param int max_presses:
         The number of times to try pressing the key and looking for the image
         before giving up and raising `MatchTimeout`. Defaults to 10.
 
         You can override the global default value by setting ``max_presses``
-        in the ``[press_until_match]`` section of stbt.conf.
+        in the ``[press_until_match]`` section of :ref:`.stbt.conf`.
 
     :param match_parameters: See `match`.
     :param region: See `match`.
@@ -324,7 +325,8 @@ def wait_for_motion(
           motion detected out of a sliding window of "y" frames.
 
         This defaults to "10/20". You can override the global default value by
-        setting ``consecutive_frames`` in the ``[motion]`` section of stbt.conf.
+        setting ``consecutive_frames`` in the ``[motion]`` section of
+        :ref:`.stbt.conf`.
 
     :param float noise_threshold: See `detect_motion`.
 
@@ -496,9 +498,10 @@ def is_screen_black(frame=None, mask=None, threshold=None):
     :param int threshold:
       Even when a video frame appears to be black, the intensity of its pixels
       is not always 0. To differentiate almost-black from non-black pixels, a
-      binary threshold is applied to the frame. The `threshold` value is in the
-      range 0 (black) to 255 (white). The global default can be changed by
-      setting `threshold` in the `[is_screen_black]` section of stbt.conf.
+      binary threshold is applied to the frame. The ``threshold`` value is in
+      the range 0 (black) to 255 (white). The global default can be changed by
+      setting ``threshold`` in the ``[is_screen_black]`` section of
+      :ref:`.stbt.conf`.
 
     :returns: True or False.
 

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -369,7 +369,9 @@ def ocr(frame=None, region=Region.ALL,
         specified by joining with '+'; for example "eng+deu" means that the
         text to be read may be in a mixture of English and German. This defaults
         to "eng" (English). You can override the global default value by setting
-        ``lang`` in the ``[ocr]`` section of :ref:`.stbt.conf`.
+        ``lang`` in the ``[ocr]`` section of :ref:`.stbt.conf`. You may need to
+        install the tesseract language pack; see installation instructions
+        `here <https://stb-tester.com/manual/troubleshooting#install-ocr-language-pack>`_.
 
     :param dict tesseract_config:
         Allows passing configuration down to the underlying OCR engine.

--- a/tests/stbt.conf
+++ b/tests/stbt.conf
@@ -23,6 +23,9 @@ confirm_threshold=0.30
 erode_passes=1
 pyramid_levels = 3
 
+[ocr]
+lang = eng
+
 [press]
 interpress_delay_secs = 0
 

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -127,12 +127,6 @@ def test_that_setting_config_options_has_an_effect():
 
 
 def test_that_passing_patterns_helps_reading_serial_codes():
-    # Test that this test is valid (e.g. tesseract will read it wrong without
-    # help):
-    assert u'UJJM2LGE' != stbt.ocr(
-        frame=cv2.imread('tests/ocr/UJJM2LGE.png'),
-        mode=stbt.OcrMode.SINGLE_WORD)
-
     # pylint: disable=W0212
     if _stbt.core._tesseract_version() < distutils.version.LooseVersion('3.03'):
         raise SkipTest('tesseract is too old')


### PR DESCRIPTION
To avoid specifying it in every single call to `stbt.ocr`.