### PR TITLE
make check-pylint: Speed up pylint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,8 +231,9 @@ check-hardware: install-for-test
 	tests/run-tests.sh -i tests/hardware/test-hardware.sh
 check-pylint: all
 	printf "%s\n" $(PYTHON_FILES) \
-	| grep -v tests/auto-selftest-example-test-pack/tests/syntax_error.py \
-	| PYTHONPATH=$$PWD $(parallel) extra/pylint.sh
+	| grep -v -e tests/auto-selftest-example-test-pack/tests/syntax_error.py \
+	          -e tests/auto-selftest-example-test-pack/selftest \
+	| PYTHONPATH=$$PWD xargs extra/pylint.sh
 
 ifeq ($(enable_stbt_camera), yes)
 check: check-cameratests

--- a/extra/pylint.sh
+++ b/extra/pylint.sh
@@ -8,43 +8,37 @@
 
 [ $# -gt 0 ] || { grep '^#/' "$0" | cut -c4- >&2; exit 1; }
 
-pep8options() {
-    # E124: closing bracket does not match visual indentation
-    # E402: module level import not at top of file (because isort does it)
-    # E501: line too long > 80 chars (because pylint does it)
-    # E721: do not compare types, use 'isinstance()' (because pylint does it)
-    # E731: do not assign a lambda expression, use a def
-    # W291: trailing whitespace (because pylint does it)
-    echo --ignore=E124,E402,E501,E721,E731,W291
-}
-
 ret=0
+
+# E124: closing bracket does not match visual indentation
+# E402: module level import not at top of file (because isort does it)
+# E501: line too long > 80 chars (because pylint does it)
+# E721: do not compare types, use 'isinstance()' (because pylint does it)
+# E731: do not assign a lambda expression, use a def
+# W291: trailing whitespace (because pylint does it)
+pep8  --ignore=E124,E402,E501,E721,E731,W291 "$@" || ret=1
+
+out=$(pylint --rcfile="$(dirname "$0")/pylint.conf" "$@" 2>&1) || ret=1
+printf "%s" "$out" |
+    grep -v \
+        -e 'libdc1394 error: Failed to initialize libdc1394' \
+        -e 'pygobject_register_sinkfunc is deprecated' \
+        -e "assertion .G_TYPE_IS_BOXED (boxed_type). failed" \
+        -e "assertion .G_IS_PARAM_SPEC (pspec). failed" \
+        -e "return isinstance(object, (type, types.ClassType))" \
+        -e "gsignal.c:.*: parameter 1 of type '<invalid>' for signal \".*\" is not a value type" \
+        -e "astroid.* Use gi.require_version" \
+        -e "^  __import__(m)$"
+
 for f in "$@"; do
-    r=0
-
-    out=$(pylint --rcfile="$(dirname "$0")/pylint.conf" $f 2>&1) || r=1 ret=1
-    printf "%s" "$out" |
-        grep -v \
-            -e 'libdc1394 error: Failed to initialize libdc1394' \
-            -e 'pygobject_register_sinkfunc is deprecated' \
-            -e "assertion .G_TYPE_IS_BOXED (boxed_type). failed" \
-            -e "assertion .G_IS_PARAM_SPEC (pspec). failed" \
-            -e "return isinstance(object, (type, types.ClassType))" \
-            -e "gsignal.c:.*: parameter 1 of type '<invalid>' for signal \".*\" is not a value type" \
-            -e "astroid.* Use gi.require_version" \
-            -e "^  __import__(m)$"
-
-    pep8 $(pep8options $f) $f || r=1 ret=1
-
     # PEP8-compliant order of 'import' statements
     if which isort &>/dev/null; then
         if ! isort --check-only $f >/dev/null; then
             isort --version
             isort --diff $f
-            r=1 ret=1
+            ret=1
         fi
     fi
-
-    [ $r -eq 0 ] && echo "$f OK"
 done
+
 exit $ret


### PR DESCRIPTION
...by passing all python files to a single pylint process, instead of
one at a time. This way pylint doesn't have to re-load every imported
file (recursively) from scratch every time.

On my laptop this cuts the runtime of `make check-pylint` by 30 seconds
(from 53 seconds to 23 seconds) even though I was using 4 cores before
and now only 1 core. On Travis this saves about 70 seconds (the gains
are larger as there is less concurrency available on Travis).

Curiously this caused pylint to flag a few new problems in the
auto-generated files in `tests/auto-selftest-example-test-pack/selftest`
so I've added those to the list of excluded files.