### PR TITLE
core.py: EOS on source pipeline teardown is configurable (off by default)

### DIFF
--- a/_stbt/config.py
+++ b/_stbt/config.py
@@ -23,7 +23,10 @@ def get_config(section, key, default=None, type_=str):
     config = _config_init()
 
     try:
-        return type_(config.get(section, key))
+        if type_ is bool:
+            return config.getboolean(section, key)
+        else:
+            return type_(config.get(section, key))
     except ConfigParser.Error as e:
         if default is None:
             raise ConfigurationError(e.message)

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -723,6 +723,12 @@ class TextMatchResult(object):
 def new_device_under_test_from_config(
         gst_source_pipeline=None, gst_sink_pipeline=None, control_uri=None,
         save_video=False, restart_source=None, transformation_pipeline=None):
+
+    # Note that all callers (stbt-run etc, via stbt.init_run) pass in all
+    # parameters explicitly; but the behaviour of reading the default values
+    # from config is useful for integrating with a different test-runner like
+    # pytest, or from a Jupyter Notebook.
+
     from _stbt.control import uri_to_remote
 
     if gst_source_pipeline is None:

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -2069,7 +2069,7 @@ class Display(object):
         self.source_pipeline, source = None, self.source_pipeline
         if source:
             for elem in gst_iterate(source.iterate_sources()):
-                elem.send_event(Gst.Event.new_eos())  # pylint: disable=E1120
+                elem.send_event(Gst.Event.new_eos())
             if not self.appsink_await_eos(
                     source.get_by_name('appsink'), timeout=10):
                 debug("teardown: Source pipeline did not teardown gracefully")

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -738,7 +738,7 @@ def new_device_under_test_from_config(
     if control_uri is None:
         control_uri = get_config('global', 'control')
     if restart_source is None:
-        restart_source = get_config('global', 'restart_source')
+        restart_source = get_config('global', 'restart_source', type_=bool)
     if transformation_pipeline is None:
         transformation_pipeline = get_config('global',
                                              'transformation_pipeline')
@@ -1530,8 +1530,7 @@ def argparser():
              '(default: %(default)s)')
     parser.add_argument(
         '--restart-source', action='store_true',
-        default=(get_config('global', 'restart_source').lower() in
-                 ("1", "yes", "true", "on")),
+        default=get_config('global', 'restart_source', type_=bool),
         help='Restart the GStreamer source pipeline when video loss is '
              'detected')
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -56,6 +56,10 @@ UNRELEASED
   change the behaviour again in a future release to be consistent with
   `stbt.match_text` where `None` means an empty region.
 
+* Passing `type_=bool` to `stbt.get_config` now returns False for values of
+  "0", "false", "off", and "no" (all of these are checked in a case-insensitive
+  manner). Previously it would always return True for any non-empty value.
+
 ##### New features
 
 * New Android control mechanism to send taps, swipes, and key events. See the

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -60,6 +60,11 @@ UNRELEASED
   "0", "false", "off", and "no" (all of these are checked in a case-insensitive
   manner). Previously it would always return True for any non-empty value.
 
+* Removed workaround for 3½ year old deadlock bug in decklinksrc. If this is
+  still necessary, set `source_teardown_eos = True` in the `[global]` section
+  of your stbt config file, and let us know on the mailing list as we may
+  remove the workaround completely in a future release.
+
 ##### New features
 
 * New Android control mechanism to send taps, swipes, and key events. See the

--- a/stbt-camera.d/stbt_camera_calibrate.py
+++ b/stbt-camera.d/stbt_camera_calibrate.py
@@ -614,8 +614,8 @@ def main(argv):
     sink_pipeline = ('textoverlay text="After correction" ! ' +
                      args.sink_pipeline)
 
-    stbt.init_run(args.source_pipeline, sink_pipeline, 'none', False, False,
-                  transformation_pipeline)
+    stbt.init_run(args.source_pipeline, sink_pipeline, 'none',
+                  transformation_pipeline=transformation_pipeline)
 
     tv = tv_driver.create_from_args(args, videos)
 

--- a/stbt-record
+++ b/stbt-record
@@ -42,7 +42,9 @@ def main(argv):
             args.source_pipeline, args.sink_pipeline, args.control,
             restart_source=args.restart_source,
             transformation_pipeline=(
-                stbt.get_config('global', 'transformation_pipeline')))
+                stbt.get_config('global', 'transformation_pipeline')),
+            source_teardown_eos=(
+                stbt.get_config('global', 'source_teardown_eos', type_=bool)))
         record(args.control_recorder, script)
     finally:
         stbt.teardown_run()

--- a/stbt-run
+++ b/stbt-run
@@ -124,7 +124,8 @@ try:
     stbt.init_run(
         args.source_pipeline, args.sink_pipeline, args.control,
         args.save_video, args.restart_source,
-        stbt.get_config('global', 'transformation_pipeline'))
+        stbt.get_config('global', 'transformation_pipeline'),
+        stbt.get_config('global', 'source_teardown_eos', type_=bool))
     _tracer = new_state_sender(args.save_trace)  # pylint: disable=W0212
 
     _absfilename = None

--- a/stbt.conf
+++ b/stbt.conf
@@ -11,6 +11,11 @@ v4l2_ctls=
 # device. Set to "True" if you're using the Hauppauge HD PVR.
 restart_source = False
 
+# Send EOS before stopping source pipeline, to work around a bug in decklinksrc.
+# Set to "True" if you're using a Blackmagic capture card and it hangs when the
+# test ends.
+source_teardown_eos = False
+
 # stbt camera settings that have to be in global as Python's configparse
 # doesn't allow substitutions between sections.
 geometriccorrection_params =

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -806,11 +806,12 @@ class FrameObject(_stbt.core.FrameObject):
 
 def init_run(
         gst_source_pipeline, gst_sink_pipeline, control_uri, save_video=False,
-        restart_source=False, transformation_pipeline='identity'):
+        restart_source=False, transformation_pipeline='identity',
+        source_teardown_eos=False):
     global _dut
     dut = _stbt.core.new_device_under_test_from_config(
         gst_source_pipeline, gst_sink_pipeline, control_uri, save_video,
-        restart_source, transformation_pipeline)
+        restart_source, transformation_pipeline, source_teardown_eos)
     dut.__enter__()
     _dut = dut
 

--- a/tests/stbt.conf
+++ b/tests/stbt.conf
@@ -4,6 +4,7 @@ sink_pipeline = fakesink sync=false
 transformation_pipeline = identity
 control = test
 restart_source = False
+source_teardown_eos = False
 verbose = 0
 power_outlet = none
 

--- a/tests/stbt.conf
+++ b/tests/stbt.conf
@@ -12,6 +12,9 @@ v4l2_device = /dev/null
 test_key = this is a test value
 not_special = this is another test value
 
+should_be_true = True
+should_be_false = False
+
 [camera]
 video_format = mp4
 

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -43,6 +43,8 @@ test_get_config() {
 	assert stbt.get_config("global", "test_key") == "this is a test value"
 	assert stbt.get_config("special", "test_key") == \
 	    "not the global value"
+	assert stbt.get_config("global", "should_be_true", type_=bool) is True
+	assert stbt.get_config("global", "should_be_false", type_=bool) is False
 	try:
 	    stbt.get_config("global", "no_such_key")
 	    assert False


### PR DESCRIPTION
We added this in 52579fa to work around a deadlock bug in decklinksrc.
This caused additional problems:

* That commit itself had a race, fixed in cc125fb;
* Non-live sources (e.g. filesrc for self-tests) now would take 10
  seconds to teardown, presumably because the EOS was caught behind a
  long queue of buffers. We tried to fix this in fadfe6e and e051ba8
  but we reverted those two commits (in 8f1b48c and 8ee2ab5) because it
  caused intermittent long teardown in live v4l sources.

Now I've just made it configurable, and we don't send the EOS at all by
default.
