### PR TITLE
OpenCV 3 Compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ INSTALL_CORE_FILES = \
     _stbt/config.py \
     _stbt/control.py \
     _stbt/core.py \
+    _stbt/cv2_compat.py \
     _stbt/gst_hacks.py \
     _stbt/gst_utils.py \
     _stbt/imgproc_cache.py \

--- a/_stbt/camera/chessboard.py
+++ b/_stbt/camera/chessboard.py
@@ -81,7 +81,7 @@ def find_corrected_corners(params, frame):
 
 def _find_chessboard(input_image):
     success, corners = cv2.findChessboardCorners(
-        input_image, (29, 15), flags=cv2.cv.CV_CALIB_CB_ADAPTIVE_THRESH)
+        input_image, (29, 15), flags=cv2.CALIB_CB_ADAPTIVE_THRESH)
 
     if not success:
         raise NoChessboardError()

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -541,14 +541,14 @@ def _load_template(template):
         absolute_filename = _find_user_file(relative_filename)
         if not absolute_filename:
             raise IOError("No such template file: %s" % relative_filename)
-        image = cv2.imread(absolute_filename, cv2.CV_LOAD_IMAGE_COLOR)
+        image = cv2.imread(absolute_filename, cv2.IMREAD_COLOR)
         if image is None:
             raise IOError("Failed to load template file: %s" %
                           absolute_filename)
         return _AnnotatedTemplate(image, relative_filename, absolute_filename)
 
 
-def load_image(filename, flags=cv2.CV_LOAD_IMAGE_COLOR):
+def load_image(filename, flags=cv2.IMREAD_COLOR):
     """Find & read an image from disk.
 
     If given a relative filename, this will search in the directory of the
@@ -2680,7 +2680,7 @@ def _load_mask(filename):
     debug("Using mask %s" % absolute_filename)
     if not absolute_filename:
         raise IOError("No such mask file: %s" % filename)
-    image = cv2.imread(absolute_filename, cv2.CV_LOAD_IMAGE_GRAYSCALE)
+    image = cv2.imread(absolute_filename, cv2.IMREAD_GRAYSCALE)
     if image is None:
         raise IOError("Failed to load mask file: %s" % absolute_filename)
     return image

--- a/_stbt/cv2_compat.py
+++ b/_stbt/cv2_compat.py
@@ -1,0 +1,37 @@
+"""
+Compatibility so stb-tester will work with both OpenCV 2 and 3.
+"""
+
+from distutils.version import LooseVersion
+
+import cv2
+
+_version = LooseVersion(cv2.__version__)
+
+if _version >= LooseVersion('3.2.0'):
+    def find_contour_boxes(image, mode, method):
+        contours = cv2.findContours(image=image, mode=mode, method=method)[1]
+        return [cv2.boundingRect(x) for x in contours]
+else:
+    def _fix_pre_3_2_rects(r):
+        # In OpenCV 3.2 the behaviour of findContours changed.  It seems more
+        # sensible now but we need to still support the old behaviour.
+        # See 56c133d459248d17165d77eb902a8049680bf896 in OpenCV:
+        # https://github.com/opencv/opencv/commit/56c133d459248d17165d77eb902a8049680bf896
+        x, y, w, h = r
+        return (x - 1, y - 1, w + 2, h + 2)
+
+    def find_contour_boxes(image, mode, method):
+        # In v3.0.0 cv2.findContours started returing (img, contours, hierarchy)
+        # rather than (contours, heirarchy).  Index -2 selects contours on both
+        # versions:
+        contours = cv2.findContours(image=image, mode=mode, method=method)[-2]
+        return [_fix_pre_3_2_rects(cv2.boundingRect(x)) for x in contours]
+
+# We prefer the v3 names here rather than the v2.4 names:
+if _version >= LooseVersion('3.0.0'):
+    FILLED = cv2.FILLED  # pylint: disable=no-member
+    LINE_AA = cv2.LINE_AA  # pylint: disable=no-member
+else:
+    FILLED = cv2.cv.CV_FILLED
+    LINE_AA = cv2.CV_AA

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -107,6 +107,11 @@ UNRELEASED
   `stbt.match_text` is now configurable. Set `lang` in the `[ocr]` section
   of your configuration file.
 
+* OpenCV 3 compatibility: stb-tester will now work with either OpenCV 2.4 or
+  OpenCV 3. This support is in beta, please let us know if you see anything not
+  working properly with OpenCV 3. OpenCV 2.4 is still our primary supported
+  target version of OpenCV.
+
 ##### Minor fixes and packaging fixes
 
 * The `irnetbox` control now understands "double signals" in the irNetBox

--- a/stbt-run
+++ b/stbt-run
@@ -106,7 +106,7 @@ def _save_screenshot(exception):
             'thumbnail.jpg',
             cv2.resize(screenshot, (
                 640, 640 * screenshot.shape[0] // screenshot.shape[1])),
-            [cv2.cv.CV_IMWRITE_JPEG_QUALITY, 50])
+            [cv2.IMWRITE_JPEG_QUALITY, 50])
 
 
 def import_by_filename(filename_):

--- a/stbt/android.py
+++ b/stbt/android.py
@@ -245,7 +245,7 @@ class AdbDevice(object):
                     .replace("\r\n", "\n"))
             img = cv2.imdecode(
                 numpy.asarray(bytearray(data), dtype=numpy.uint8),
-                cv2.CV_LOAD_IMAGE_COLOR)
+                cv2.IMREAD_COLOR)
             if img is None:
                 logging.warning(
                     "AdbDevice.get_frame: Failed to get screenshot "

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -40,7 +40,7 @@ def test_matchresult_region_when_first_pyramid_level_fails_to_match():
 
 @raises(ValueError)
 def test_that_match_rejects_greyscale_template():
-    grey = cv2.cvtColor(_load_template("black.png").image, cv2.cv.CV_BGR2GRAY)
+    grey = cv2.cvtColor(_load_template("black.png").image, cv2.COLOR_BGR2GRAY)
     stbt.match(grey, frame=black())
 
 


### PR DESCRIPTION
Debian testing now has OpenCV 3 so I need this change to make stbt development convenient on my PC.

This isn't necessarily complete, but it does help to get a bunch of more tests to pass.

TODO:

- [x] Clarify what the changes are for `findContours` between 2 and 3.

Further Work:

- Set up Travis to build a configuration with OpenCV 3 too.  We can't call it supported until we've got regular testing happening. Perhaps this can wait until Ubuntu 18.04 is released?