### PR TITLE
[WIP] {detect,wait_for}_motion: Set default noise_threshold to 1.0

### DIFF
--- a/stbt.conf
+++ b/stbt.conf
@@ -52,7 +52,7 @@ interval_secs = 3
 max_presses = 10
 
 [motion]
-noise_threshold=0.84
+noise_threshold=1.0
 consecutive_frames=10/20
 
 [is_screen_black]

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -224,9 +224,10 @@ def detect_motion(timeout_secs=10, noise_threshold=None, mask=None):
         considered noise; a value of 0 will never report motion) to 1.0 (any
         difference is considered motion).
 
-        This defaults to 0.84. You can override the global default value by
-        setting ``noise_threshold`` in the ``[motion]`` section of
-        :ref:`.stbt.conf`.
+        This defaults to 1.0. Reduce it if you are capturing from noisy sources
+        (for example if your UI rendering involves video compression). You can
+        override the global default value by setting ``noise_threshold`` in the
+        ``[motion]`` section of :ref:`.stbt.conf`.
 
     :param str mask:
         The filename of a black & white image that specifies which part of the

--- a/tests/stbt.conf
+++ b/tests/stbt.conf
@@ -38,7 +38,7 @@ interval_secs = 3
 max_presses = 10
 
 [motion]
-noise_threshold=0.84
+noise_threshold=1.0
 consecutive_frames=10/20
 
 [is_screen_black]


### PR DESCRIPTION
This means that any differences will be considered motion. This is more
suitable for lossless video capture.

TODO:

- [ ] What about lossless video capture but watching broadcast TV which will have compression artifacts that change even for a still image? Maybe it's a *good* thing to count that as motion?
