### PR TITLE
New travis images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ install:
  - sudo apt-get update
  - sudo apt-get -y install
         chromium-browser
-        cmake
         expect
         expect-dev
         gdb

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,6 @@ install:
  - |
      date &&
      python -c 'from distutils.sysconfig import get_python_inc; print get_python_inc(); import sysconfig; print sysconfig.get_config_var("LIBDIR"); print sysconfig.get_config_var("LDLIBRARY"); print sysconfig.get_paths()' &&
-     ls -l /usr/lib/libpython* /usr/bin/python* &&
      git clone -b libcec-3.1.0 https://github.com/Pulse-Eight/libcec.git &&
      git clone -b p8-platform-2.0.1 https://github.com/Pulse-Eight/platform.git &&
      mkdir platform/build &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
  - sudo apt-get update
  - sudo apt-get -y install
         chromium-browser
+        cmake
         expect
         expect-dev
         gdb
@@ -20,8 +21,6 @@ install:
         gstreamer1.0-plugins-good
         gstreamer1.0-tools
         gstreamer1.0-x
-        libcec-dev
-        libcec2
         libgstreamer1.0-dev
         libgstreamer-plugins-base1.0-dev
         liblockdev1-dev
@@ -65,11 +64,33 @@ install:
         xterm
  - sudo pip install
         astroid==1.4.8
-        cec==0.2.6
         isort==3.9.0
         pylint==1.6.4
         pytest==3.3.1
         responses==0.5.1
+ - |
+     date &&
+     ls -l /usr/include/python* &&
+     ls -l /usr/lib/x86_64-linux-gnu/libpython* && \
+     git clone -b libcec-3.1.0 https://github.com/Pulse-Eight/libcec.git &&
+     git clone -b p8-platform-2.0.1 https://github.com/Pulse-Eight/platform.git &&
+     mkdir platform/build &&
+     cd platform/build &&
+     cmake .. &&
+     make &&
+     sudo make install &&
+     cd ../.. &&
+     mkdir libcec/build &&
+     cd libcec/build &&
+     cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+         -DPYTHON_INCLUDE_DIR:PATH=/usr/include/python2.7 \
+         -DPYTHON_LIBRARY:FILEPATH=/usr/lib/x86_64-linux-gnu/libpython2.7.so \
+         -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python2.7 \
+         .. &&
+     make &&
+     sudo make install &&
+     cd ../.. &&
+     date
  - |
      {
        wget http://ftpmirror.gnu.org/parallel/parallel-20140522.tar.bz2 ||

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: c
 dist: trusty
 sudo: required
-group: deprecated-2017Q4
 
 install:
  - cat /etc/os-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
  - sudo apt-get update
  - sudo apt-get -y install
         chromium-browser
+        cmake
         expect
         expect-dev
         gdb

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,10 +82,10 @@ install:
      cd ../.. &&
      mkdir libcec/build &&
      cd libcec/build &&
-     cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr \
-         -DPYTHON_INCLUDE_DIR:PATH=/usr/include/python2.7 \
-         -DPYTHON_LIBRARY:FILEPATH=/usr/lib/x86_64-linux-gnu/libpython2.7.so \
-         -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python2.7 \
+     cmake -DCMAKE_INSTALL_PREFIX=/usr \
+         -DPYTHON_INCLUDE_DIR=/usr/include/python2.7 \
+         -DPYTHON_LIBRARY=/usr/lib/libpython2.7.so \
+         -DPYTHON_EXECUTABLE=/usr/bin/python2.7 \
          .. &&
      make &&
      sudo make install &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,8 +70,7 @@ install:
         responses==0.5.1
  - |
      date &&
-     ls -l /usr/include/python* &&
-     ls -l /usr/lib/x86_64-linux-gnu/libpython* && \
+     python -c 'from distutils.sysconfig import get_python_inc; print get_python_inc(); import sysconfig; print sysconfig.get_config_var("LIBDIR"); import sysconfig; print sysconfig.get_paths()' &&
      git clone -b libcec-3.1.0 https://github.com/Pulse-Eight/libcec.git &&
      git clone -b p8-platform-2.0.1 https://github.com/Pulse-Eight/platform.git &&
      mkdir platform/build &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,8 @@ install:
         responses==0.5.1
  - |
      date &&
+     ls -l /usr/include/python* &&
+     ls -l /usr/lib/x86_64-linux-gnu/libpython* && \
      git clone -b libcec-3.1.0 https://github.com/Pulse-Eight/libcec.git &&
      git clone -b p8-platform-2.0.1 https://github.com/Pulse-Eight/platform.git &&
      mkdir platform/build &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ install:
      cd libcec/build &&
      cmake -DCMAKE_INSTALL_PREFIX=/usr \
          -DPYTHON_INCLUDE_DIR=/usr/include/python2.7 \
-         -DPYTHON_LIBRARY=/usr/lib/libpython2.7.so \
+         -DPYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython2.7.so \
          -DPYTHON_EXECUTABLE=/usr/bin/python2.7 \
          .. &&
      make &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ install:
         responses==0.5.1
  - |
      date &&
-     python -c 'from distutils.sysconfig import get_python_inc; print get_python_inc(); import sysconfig; print sysconfig.get_config_var("LIBDIR"); import sysconfig; print sysconfig.get_paths()' &&
+     python -c 'from distutils.sysconfig import get_python_inc; print get_python_inc(); import sysconfig; print sysconfig.get_config_var("LIBDIR"); print sysconfig.get_config_var("LDLIBRARY"); print sysconfig.get_paths()' &&
      git clone -b libcec-3.1.0 https://github.com/Pulse-Eight/libcec.git &&
      git clone -b p8-platform-2.0.1 https://github.com/Pulse-Eight/platform.git &&
      mkdir platform/build &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ install:
  - |
      date &&
      python -c 'from distutils.sysconfig import get_python_inc; print get_python_inc(); import sysconfig; print sysconfig.get_config_var("LIBDIR"); print sysconfig.get_config_var("LDLIBRARY"); print sysconfig.get_paths()' &&
+     ls -l /usr/lib/libpython* /usr/bin/python* &&
      git clone -b libcec-3.1.0 https://github.com/Pulse-Eight/libcec.git &&
      git clone -b p8-platform-2.0.1 https://github.com/Pulse-Eight/platform.git &&
      mkdir platform/build &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ install:
  - sudo apt-get update
  - sudo apt-get -y install
         chromium-browser
-        cmake
         expect
         expect-dev
         gdb
@@ -21,6 +20,8 @@ install:
         gstreamer1.0-plugins-good
         gstreamer1.0-tools
         gstreamer1.0-x
+        libcec-dev
+        libcec2
         libgstreamer1.0-dev
         libgstreamer-plugins-base1.0-dev
         liblockdev1-dev
@@ -64,33 +65,11 @@ install:
         xterm
  - sudo pip install
         astroid==1.4.8
+        cec==0.2.6
         isort==3.9.0
         pylint==1.6.4
         pytest==3.3.1
         responses==0.5.1
- - |
-     date &&
-     ls -l /usr/include/python* &&
-     ls -l /usr/lib/x86_64-linux-gnu/libpython* && \
-     git clone -b libcec-3.1.0 https://github.com/Pulse-Eight/libcec.git &&
-     git clone -b p8-platform-2.0.1 https://github.com/Pulse-Eight/platform.git &&
-     mkdir platform/build &&
-     cd platform/build &&
-     cmake .. &&
-     make &&
-     sudo make install &&
-     cd ../.. &&
-     mkdir libcec/build &&
-     cd libcec/build &&
-     cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr \
-         -DPYTHON_INCLUDE_DIR:PATH=/usr/include/python2.7 \
-         -DPYTHON_LIBRARY:FILEPATH=/usr/lib/x86_64-linux-gnu/libpython2.7.so \
-         -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python2.7 \
-         .. &&
-     make &&
-     sudo make install &&
-     cd ../.. &&
-     date
  - |
      {
        wget http://ftpmirror.gnu.org/parallel/parallel-20140522.tar.bz2 ||


### PR DESCRIPTION
The tests for https://github.com/stb-tester/stb-tester/pull/474
failed because of new Travis images[1] so I configured .travis.yml to
use the old (now deprecated) images while I investigated further.

[1]: https://blog.travis-ci.com/2017-12-12-new-trusty-images-q4-launch

This pull request will fix the issue with the new images.