### PR TITLE
stbt.ocr & stbt.match_text: Add upsample parameter to disable upsampling

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1207,7 +1207,7 @@ class DeviceUnderTest(object):
         rts = getattr(frame, "time", None)
 
         xml, region = _tesseract(frame, region, mode, lang, _config,
-                                 user_words=text.split(), text_color=text_color)
+                                 None, text.split(), text_color)
         if xml == '':
             result = TextMatchResult(rts, False, None, frame, text)
         else:
@@ -2863,8 +2863,8 @@ def _tesseract_version(output=None):
     return LooseVersion(line.split()[1])
 
 
-def _tesseract(frame, region, mode, lang, _config,
-               user_patterns=None, user_words=None, text_color=None):
+def _tesseract(frame, region, mode, lang, _config, user_patterns, user_words,
+               text_color):
 
     if _config is None:
         _config = {}

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1160,7 +1160,7 @@ class DeviceUnderTest(object):
     def ocr(self, frame=None, region=Region.ALL,
             mode=OcrMode.PAGE_SEGMENTATION_WITHOUT_OSD,
             lang=None, tesseract_config=None, tesseract_user_words=None,
-            tesseract_user_patterns=None, text_color=None):
+            tesseract_user_patterns=None, upsample=True, text_color=None):
 
         if frame is None:
             frame = self.get_frame()
@@ -1183,7 +1183,7 @@ class DeviceUnderTest(object):
 
         text, region = _tesseract(
             frame, region, mode, lang, tesseract_config,
-            tesseract_user_patterns, tesseract_user_words, text_color)
+            tesseract_user_patterns, tesseract_user_words, upsample, text_color)
         text = text.strip().translate(_ocr_transtab)
         debug(u"OCR in region %s read '%s'." % (region, text))
         return text
@@ -1191,7 +1191,7 @@ class DeviceUnderTest(object):
     def match_text(self, text, frame=None, region=Region.ALL,
                    mode=OcrMode.PAGE_SEGMENTATION_WITHOUT_OSD, lang=None,
                    tesseract_config=None, case_sensitive=False,
-                   text_color=None):
+                   upsample=True, text_color=None):
 
         import lxml.etree
         if frame is None:
@@ -1207,7 +1207,7 @@ class DeviceUnderTest(object):
         rts = getattr(frame, "time", None)
 
         xml, region = _tesseract(frame, region, mode, lang, _config,
-                                 None, text.split(), text_color)
+                                 None, text.split(), upsample, text_color)
         if xml == '':
             result = TextMatchResult(rts, False, None, frame, text)
         else:
@@ -1220,9 +1220,10 @@ class DeviceUnderTest(object):
                     box = _bounding_box(box, _hocr_elem_region(elem))
                 # _tesseract crops to region and scales up by a factor of 3 so
                 # we must undo this transformation here.
+                n = 3 if upsample else 1
                 box = Region.from_extents(
-                    region.x + box.x // 3, region.y + box.y // 3,
-                    region.x + box.right // 3, region.y + box.bottom // 3)
+                    region.x + box.x // n, region.y + box.y // n,
+                    region.x + box.right // n, region.y + box.bottom // n)
                 result = TextMatchResult(rts, True, box, frame, text)
             else:
                 result = TextMatchResult(rts, False, None, frame, text)
@@ -2864,7 +2865,7 @@ def _tesseract_version(output=None):
 
 
 def _tesseract(frame, region, mode, lang, _config, user_patterns, user_words,
-               text_color):
+               upsample, text_color):
 
     if _config is None:
         _config = {}
@@ -2879,21 +2880,24 @@ def _tesseract(frame, region, mode, lang, _config, user_patterns, user_words,
         region = intersection
 
     return (_tesseract_subprocess(crop(frame, region), mode, lang, _config,
-                                  user_patterns, user_words, text_color),
+                                  user_patterns, user_words, upsample,
+                                  text_color),
             region)
 
 
 @imgproc_cache.memoize({"tesseract_version": str(_tesseract_version()),
                         "version": "28"})
 def _tesseract_subprocess(
-        frame, mode, lang, _config, user_patterns, user_words, text_color):
+        frame, mode, lang, _config, user_patterns, user_words, upsample,
+        text_color):
 
-    # We scale image up 3x before feeding it to tesseract as this
-    # significantly reduces the error rate by more than 6x in tests.  This
-    # uses bilinear interpolation which produces the best results.  See
-    # http://stb-tester.com/blog/2014/04/14/improving-ocr-accuracy.html
-    outsize = (frame.shape[1] * 3, frame.shape[0] * 3)
-    frame = cv2.resize(frame, outsize, interpolation=cv2.INTER_LINEAR)
+    if upsample:
+        # We scale image up 3x before feeding it to tesseract as this
+        # significantly reduces the error rate by more than 6x in tests.  This
+        # uses bilinear interpolation which produces the best results.  See
+        # http://stb-tester.com/blog/2014/04/14/improving-ocr-accuracy.html
+        outsize = (frame.shape[1] * 3, frame.shape[0] * 3)
+        frame = cv2.resize(frame, outsize, interpolation=cv2.INTER_LINEAR)
 
     if text_color is not None:
         # Calculate distance of each pixel from `text_color`, then discard

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -153,6 +153,10 @@ UNRELEASED
   default thresholding algorithm doesn't detect the text, for example for
   light-colored text or text on a translucent overlay.
 
+* Python API: The pre-processing performed by `stbt.ocr` and `stbt.match_text`
+  can now be disabled by passing `upscale=False`. This is useful if you want
+  to do your own pre-processing.
+
 * Python API: The default `lang` (language) parameter to `stbt.ocr` and
   `stbt.match_text` is now configurable. Set `lang` in the `[ocr]` section
   of your configuration file.

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -354,7 +354,7 @@ def wait_for_motion(
 def ocr(frame=None, region=Region.ALL,
         mode=OcrMode.PAGE_SEGMENTATION_WITHOUT_OSD,
         lang=None, tesseract_config=None, tesseract_user_words=None,
-        tesseract_user_patterns=None, text_color=None):
+        tesseract_user_patterns=None, upsample=True, text_color=None):
     r"""Return the text present in the video frame as a Unicode string.
 
     Perform OCR (Optical Character Recognition) using the "Tesseract"
@@ -412,20 +412,31 @@ def ocr(frame=None, region=Region.ALL,
             \A         [A-Z]
             \*         *
 
+    :param bool upsample:
+        Upsample the image 3x before passing it to tesseract. This helps to
+        preserve information in the text's anti-aliasing that would otherwise
+        be lost when tesseract binarises the image. This defaults to ``True``;
+        you should only disable it if you are doing your own pre-processing on
+        the image.
+
     :type text_color: 3-element tuple of integers between 0 and 255, BGR order.
     :param text_color:
         Color of the text. Specifying this can improve OCR results when
         tesseract's default thresholding algorithm doesn't detect the text,
         for example for white text on a light-colored background.
 
+    Added in v28: Parameters ``upsample`` (to disable stb-tester's
+    pre-processing of the image) and ``text_color``.
     """
     return _dut.ocr(frame, region, mode, lang, tesseract_config,
-                    tesseract_user_words, tesseract_user_patterns, text_color)
+                    tesseract_user_words, tesseract_user_patterns, upsample,
+                    text_color)
 
 
 def match_text(text, frame=None, region=Region.ALL,
                mode=OcrMode.PAGE_SEGMENTATION_WITHOUT_OSD, lang=None,
-               tesseract_config=None, case_sensitive=False, text_color=None):
+               tesseract_config=None, case_sensitive=False, upsample=True,
+               text_color=None):
     """Search for the specified text in a single video frame.
 
     This can be used as an alternative to `match`, searching for text instead
@@ -437,6 +448,7 @@ def match_text(text, frame=None, region=Region.ALL,
     :param mode: See `ocr`.
     :param lang: See `ocr`.
     :param tesseract_config: See `ocr`.
+    :param upsample: See `ocr`.
     :param text_color: See `ocr`.
     :param case_sensitive bool: Ignore case if False (the default).
 
@@ -451,10 +463,12 @@ def match_text(text, frame=None, region=Region.ALL,
         assert m.match
         while not stbt.match('selected-button.png').region.contains(m.region):
             stbt.press('KEY_DOWN')
+
+    Added in v28: The ``upsample`` and ``text_color`` parameters.
     """
     return _dut.match_text(
         text, frame, region, mode, lang, tesseract_config, case_sensitive,
-        text_color)
+        upsample, text_color)
 
 
 def frames(timeout_secs=None):

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -423,7 +423,8 @@ def ocr(frame=None, region=Region.ALL,
     :param text_color:
         Color of the text. Specifying this can improve OCR results when
         tesseract's default thresholding algorithm doesn't detect the text,
-        for example for white text on a light-colored background.
+        for example white text on a light-colored background or text on a
+        translucent overlay.
 
     Added in v28: Parameters ``upsample`` (to disable stb-tester's
     pre-processing of the image) and ``text_color``.
@@ -450,7 +451,7 @@ def match_text(text, frame=None, region=Region.ALL,
     :param tesseract_config: See `ocr`.
     :param upsample: See `ocr`.
     :param text_color: See `ocr`.
-    :param case_sensitive bool: Ignore case if False (the default).
+    :param bool case_sensitive: Ignore case if False (the default).
 
     :returns:
       A `TextMatchResult`, which will evaluate to True if the text was found,

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -197,8 +197,8 @@ def iterate_menu():
 def test_that_text_location_is_recognised():
     frame = cv2.imread("tests/ocr/menu.png")
 
-    def test(text, region):
-        result = stbt.match_text(text, frame=frame)
+    def test(text, region, upsample):
+        result = stbt.match_text(text, frame=frame, upsample=upsample)
         assert result
         assert region.contains(result.region)  # pylint: disable=E1101
 
@@ -207,7 +207,8 @@ def test_that_text_location_is_recognised():
         if multiline:
             continue
 
-        yield (test, text, region)
+        yield (test, text, region, True)
+        yield (test, text, region, False)
 
 
 def test_match_text_stringify_result():


### PR DESCRIPTION
Stb-tester upsamples the image before passing it to tesseract (since v0.20 in 2014). For details see https://stb-tester.com/blog/2014/04/14/improving-ocr-accuracy
    
With this parameter you can *disable* that behaviour. This is useful if you want to do your own pre-processing before calling `stbt.ocr`. For example this would have made it possible to implement `text_color` in your test-pack without modifying stb-tester.
