### PR TITLE
stbt.FrameObject: `is_visible` can call other public properties

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1639,7 +1639,7 @@ def _mark_in_is_visible(fn):
         # pylint: disable=protected-access
         self._FrameObject__local.in_is_visible += 1
         try:
-            return fn(self)
+            return bool(fn(self))
         finally:
             self._FrameObject__local.in_is_visible -= 1
     return inner

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1647,12 +1647,16 @@ class _FrameObjectMeta(type):
     def __new__(mcs, name, parents, dct):
         for k, v in dct.iteritems():
             if isinstance(v, property):
+                # Properties must not have setters
                 if v.fset is not None:
                     raise Exception(
                         "FrameObjects must be immutable but this property has "
                         "a setter")
                 f = v.fget
+                # The value of any property is cached after the first use
                 f = _memoize_property_fn(f)
+                # Public properties return `None` if the FrameObject isn't
+                # visible.
                 if k != 'is_visible' and not k.startswith('_'):
                     f = _noneify_property_fn(f)
                 dct[k] = property(f)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -183,6 +183,9 @@ UNRELEASED
 * `stbt auto-selftest`: Fix when running for the first time (when the
   auto_selftest directory doesn't exist).
 
+* Python API: The `is_visible` property of `stbt.FrameObject` subclasses can
+  call other public properties.
+
 * Python API: `stbt.wait_until` will try one last time after the timeout is
   reached. This allows you to use a short `timeout_secs` with operations that
   can take a long time.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -184,7 +184,9 @@ UNRELEASED
   auto_selftest directory doesn't exist).
 
 * Python API: The `is_visible` property of `stbt.FrameObject` subclasses can
-  call other public properties.
+  call other public properties. Furthermore, the value of `is_visible` is
+  always a bool, so you don't have to remember to cast it to bool in your
+  implementation.
 
 * Python API: `stbt.wait_until` will try one last time after the timeout is
   reached. This allows you to use a short `timeout_secs` with operations that

--- a/tests/test_frame_object.py
+++ b/tests/test_frame_object.py
@@ -16,6 +16,69 @@ class TruthyFrameObject(stbt.FrameObject):
         return True
 
 
+class FalseyFrameObject(stbt.FrameObject):
+    """Properties aren't listed in repr if the FrameObject is falsey.
+
+    >>> frame = _load_frame("with-dialog")
+    >>> fo = FalseyFrameObject(frame)
+    >>> bool(fo)
+    False
+    >>> fo
+    FalseyFrameObject(is_visible=False)
+    >>> print fo.public
+    None
+    >>> fo._private
+    6
+    """
+    @property
+    def is_visible(self):
+        return False
+
+    @property
+    def public(self):
+        return 5
+
+    @property
+    def _private(self):
+        return 6
+
+
+class FrameObjectWithProperties(stbt.FrameObject):
+    """Only public properties are listed in repr.
+
+    >>> frame = _load_frame("with-dialog")
+    >>> FrameObjectWithProperties(frame)
+    FrameObjectWithProperties(is_visible=True, public=5)
+    """
+    @property
+    def is_visible(self):
+        return True
+
+    @property
+    def public(self):
+        return 5
+
+    @property
+    def _private(self):
+        return 6
+
+
+class FrameObjectThatCallsItsOwnProperties(stbt.FrameObject):
+    """Private properties can be called from is_visible.
+
+    >>> frame = _load_frame("with-dialog")
+    >>> FrameObjectThatCallsItsOwnProperties(frame)
+    FrameObjectThatCallsItsOwnProperties(is_visible=True)
+    """
+    @property
+    def is_visible(self):
+        return bool(self._private)
+
+    @property
+    def _private(self):
+        return 6
+
+
 class OrderedFrameObject(stbt.FrameObject):
     """
     FrameObject defines a default sort order based on the values of the

--- a/tests/test_frame_object.py
+++ b/tests/test_frame_object.py
@@ -144,7 +144,7 @@ class PrintingFrameObject(stbt.FrameObject):
     @property
     def is_visible(self):
         print "is_visible called"
-        return bool(self._helper)
+        return self._helper
 
     @property
     def _helper(self):

--- a/tests/test_frame_object.py
+++ b/tests/test_frame_object.py
@@ -64,15 +64,19 @@ class FrameObjectWithProperties(stbt.FrameObject):
 
 
 class FrameObjectThatCallsItsOwnProperties(stbt.FrameObject):
-    """Private properties can be called from is_visible.
+    """Properties can be called from is_visible.
 
     >>> frame = _load_frame("with-dialog")
     >>> FrameObjectThatCallsItsOwnProperties(frame)
-    FrameObjectThatCallsItsOwnProperties(is_visible=True)
+    FrameObjectThatCallsItsOwnProperties(is_visible=True, public=5)
     """
     @property
     def is_visible(self):
-        return bool(self._private)
+        return bool(self.public < self._private)
+
+    @property
+    def public(self):
+        return 5
 
     @property
     def _private(self):
@@ -149,6 +153,61 @@ class PrintingFrameObject(stbt.FrameObject):
     def another(self):
         print "another called"
         return self._helper + 3
+
+
+class FalseyPrintingFrameObject(stbt.FrameObject):
+    """Another naughty FrameObject. Properties should be cached even when
+    the FrameObject isn't visible.
+
+    >>> frame = _load_frame("with-dialog")
+    >>> m = FalseyPrintingFrameObject(frame)
+    >>> m.is_visible
+    is_visible called
+    public called
+    _private called
+    False
+    >>> m.is_visible
+    False
+    >>> print m.public
+    None
+    >>> print m.another
+    None
+    >>> m._private
+    7
+    >>> m._another
+    _another called
+    11
+    >>> m._another
+    11
+    >>> m
+    FalseyPrintingFrameObject(is_visible=False)
+    """
+    @property
+    def is_visible(self):
+        print "is_visible called"
+        ten = self.public
+        seven = self._private
+        return bool(ten < seven)
+
+    @property
+    def _private(self):
+        print "_private called"
+        return 7
+
+    @property
+    def public(self):
+        print "public called"
+        return self._private + 3
+
+    @property
+    def another(self):
+        print "another called"
+        return 10
+
+    @property
+    def _another(self):
+        print "_another called"
+        return 11
 
 
 def _load_frame(name):


### PR DESCRIPTION
Previously `is_visible` could only call private properties of the
FrameObject. If you tried to call a *public* property from `is_visible`,
you would get "RuntimeError: maximum recursion depth exceeded". This was
a side-effect of the FrameObject design that public properties should
return `None` if the FrameObject isn't visible. To work around this you
had to add a private property that was used by both `is_visible` and the
corresponding public property.

Now each FrameObject instance knows if it's inside a call to
`is_visible`, so that you can call public properties.
