### PR TITLE
Ensure that thumbnail and screenshot are written to results dir

### DIFF
--- a/_stbt/stbt_run.py
+++ b/_stbt/stbt_run.py
@@ -8,7 +8,7 @@ import stbt
 from _stbt.state_watch import new_state_sender
 
 
-def _save_screenshot(dut, exception, save_jpg, save_png):
+def _save_screenshot(dut, result_dir, exception, save_jpg, save_png):
     import cv2
 
     if not save_jpg and not save_png:
@@ -21,12 +21,12 @@ def _save_screenshot(dut, exception, save_jpg, save_png):
         screenshot = dut.get_frame()  # pylint: disable=protected-access
 
     if save_png:
-        cv2.imwrite("screenshot.png", screenshot)
+        cv2.imwrite(os.path.join(result_dir, "screenshot.png"), screenshot)
         sys.stderr.write("Saved screenshot to 'screenshot.png'.\n")
 
     if save_jpg:
         cv2.imwrite(
-            'thumbnail.jpg',
+            os.path.join(result_dir, 'thumbnail.jpg'),
             cv2.resize(screenshot, (
                 640, 640 * screenshot.shape[0] // screenshot.shape[1])),
             [cv2.IMWRITE_JPEG_QUALITY, 50])
@@ -34,19 +34,20 @@ def _save_screenshot(dut, exception, save_jpg, save_png):
 
 @contextmanager
 def video(args, dut):
+    result_dir = os.path.abspath(os.curdir)
     with stbt._set_dut_singleton(dut), dut:  # pylint: disable=protected-access
         try:
             yield
         except Exception as e:  # pylint: disable=broad-except
             try:
-                _save_screenshot(dut, exception=e,
+                _save_screenshot(dut, result_dir, exception=e,
                                  save_jpg=(args.save_thumbnail != 'never'),
                                  save_png=(args.save_screenshot != 'never'))
             except Exception:  # pylint: disable=broad-except
                 pass
             raise
         else:
-            _save_screenshot(dut, exception=None,
+            _save_screenshot(dut, result_dir, exception=None,
                              save_jpg=(args.save_thumbnail == 'always'),
                              save_png=(args.save_screenshot == 'always'))
 

--- a/tests/test-stbt-batch.sh
+++ b/tests/test-stbt-batch.sh
@@ -606,6 +606,12 @@ test_that_stbt_batch_failure_reason_shows_the_failing_assert_statement() {
     assert grep -q "AssertionError: assert 1 + 1 == 3" latest/failure-reason
 }
 
+test_that_stbt_batch_thumbnail_is_present_even_with_chdir() {
+    create_test_repo
+    stbt batch run -1 tests/test_functions.py::test_that_chdirs
+    assert [ -e latest/thumbnail.jpg ]
+}
+
 test_that_stbt_batch_run_shuffle_runs_tests() {
     create_test_repo
     stbt batch run -1 --shuffle \

--- a/tests/test-stbt-completion.sh
+++ b/tests/test-stbt-completion.sh
@@ -92,6 +92,7 @@ test_completion_filename_possibly_with_test_functions() {
 	tests/test_functions.py::test_that_this_test_is_run 
 	tests/test_functions.py::test_that_does_nothing 
 	tests/test_functions.py::test_that_asserts_the_impossible 
+	tests/test_functions.py::test_that_chdirs 
 	EOF
     fail "unexpected completions for file with 'test_' functions"
 
@@ -105,6 +106,7 @@ test_completion_filename_possibly_with_test_functions() {
 	test_that_this_test_is_run 
 	test_that_does_nothing 
 	test_that_asserts_the_impossible 
+	test_that_chdirs 
 EOF
     fail "unexpected completions for file + ambiguous function prefix"
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,3 +1,6 @@
+import os
+
+
 def test_that_this_test_is_run():
     open("touched", "w").close()
 
@@ -8,3 +11,7 @@ def test_that_does_nothing():
 
 def test_that_asserts_the_impossible():
     assert 1 + 1 == 3
+
+
+def test_that_chdirs():
+    os.chdir("/tmp")


### PR DESCRIPTION
...even if the test-script calls `os.chdir`.

Note: this isn't a supported way of running `stbt batch`, but we have seen it happen in practice and it's an easy fix.