### PR TITLE
debian packages: Install gdb (`stbt batch run` dependency)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
         cmake
         expect
         expect-dev
+        gdb
         gir1.2-gstreamer-1.0
         gir1.2-gudev-1.0
         gstreamer1.0-libav

--- a/extra/debian/control
+++ b/extra/debian/control
@@ -7,6 +7,7 @@ Standards-Version: 3.9.2
 Build-Depends: curl,
                debhelper (>= 9),
                expect,
+               gdb,
                gir1.2-gstreamer-1.0,
                gir1.2-gudev-1.0,
                git,

--- a/tests/test-stbt-completion.sh
+++ b/tests/test-stbt-completion.sh
@@ -93,6 +93,7 @@ test_completion_filename_possibly_with_test_functions() {
 	tests/test_functions.py::test_that_does_nothing 
 	tests/test_functions.py::test_that_asserts_the_impossible 
 	tests/test_functions.py::test_that_chdirs 
+	tests/test_functions.py::test_that_dumps_core 
 	EOF
     fail "unexpected completions for file with 'test_' functions"
 
@@ -107,6 +108,7 @@ test_completion_filename_possibly_with_test_functions() {
 	test_that_does_nothing 
 	test_that_asserts_the_impossible 
 	test_that_chdirs 
+	test_that_dumps_core 
 EOF
     fail "unexpected completions for file + ambiguous function prefix"
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -15,3 +15,7 @@ def test_that_asserts_the_impossible():
 
 def test_that_chdirs():
     os.chdir("/tmp")
+
+
+def test_that_dumps_core():
+    os.abort()


### PR DESCRIPTION
`stbt batch run` uses gdb to generate a backtrace.log file if a core
file (core dump) is present after the test-run. This is useful because
it ensures that gdb is run against the same libraries that the core file
was generated from. `stbt batch` has had this functionality since day
one, but we've never specified gdb as a dependency in the debian
packages. Without gdb installed, backtrace.log says "gdb: command not
found" instead of the backtrace.