### PR TITLE
FrameObject: Fix AttributeError with multiple threads

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1657,7 +1657,10 @@ def _mark_in_is_visible(fn):
     @functools.wraps(fn)
     def inner(self):
         # pylint: disable=protected-access
-        self._FrameObject__local.in_is_visible += 1
+        try:
+            self._FrameObject__local.in_is_visible += 1
+        except AttributeError:
+            self._FrameObject__local.in_is_visible = 1
         try:
             return bool(fn(self))
         finally:
@@ -1669,7 +1672,8 @@ def _noneify_property_fn(fn):
     @functools.wraps(fn)
     def inner(self):
         # pylint: disable=protected-access
-        if self._FrameObject__local.in_is_visible or self.is_visible:
+        if (getattr(self._FrameObject__local, "in_is_visible", 0) or
+                self.is_visible):
             return fn(self)
         else:
             return None
@@ -1720,7 +1724,6 @@ class FrameObject(object):
             raise ValueError("FrameObject: frame must not be None")
         self.__frame_object_cache = {}
         self.__local = threading.local()
-        self.__local.in_is_visible = 0
         self._frame = frame
 
     def __repr__(self):

--- a/tests/test_frame_object.py
+++ b/tests/test_frame_object.py
@@ -229,7 +229,7 @@ def test_that_is_visible_and_properties_arent_racy():
     for t in threads:
         t.join()
     print results
-    assert all(v is None for v in results.values())
+    assert results == {n: None for n in range(10)}
 
 
 def _load_frame(name):


### PR DESCRIPTION
See 78478e02a1 and the discussion on #483 for the background behind this
thread-local.

Traceback:

    Traceback (most recent call last):
      ...
      File ".../stb-tester/_stbt/core.py", line 1727, in __repr__
        args = ", ".join(("%s=%r" % x) for x in self._iter_attrs())
      File ".../stb-tester/_stbt/core.py", line 1727, in <genexpr>
        args = ", ".join(("%s=%r" % x) for x in self._iter_attrs())
      File ".../stb-tester/_stbt/core.py", line 1731, in _iter_attrs
        if self:
      File ".../stb-tester/_stbt/core.py", line 1739, in __nonzero__
        return bool(self.is_visible)
      File ".../stb-tester/_stbt/core.py", line 1660, in inner
        self._FrameObject__local.in_is_visible += 1
    AttributeError: 'thread._local' object has no attribute 'in_is_visible'

TODO:

- [x] Add a test