### PR TITLE
NoVideo is a test *error*, not test *failure*

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1545,7 +1545,7 @@ class UITestFailure(Exception):
     pass
 
 
-class NoVideo(UITestFailure):
+class NoVideo(Exception):
     """No video available from the source pipeline."""
     pass
 


### PR DESCRIPTION
Most video-capture hardware we have seen will continue to deliver video
(usually black frames) when the device-under-test is powered off. In
this case NoVideo is an error in your test infrastructure, not of your
device-under-test.