### PR TITLE
Make stbt-run headless by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ _stbt/libxxhash.so
 _stbt/lmdb/
 debian-packages
 docs/stbt.1
+etc/stbt.conf
 extra/debian/changelog
 extra/fedora/stb-tester.spec
 extra/stb-tester*.debian.tar.xz

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ INSTALL_CORE_FILES = \
     stbt-screenshot \
     stbt-tv
 
-all: $(INSTALL_CORE_FILES) $(INSTALL_PYLIB_FILES)
+all: $(INSTALL_CORE_FILES) $(INSTALL_PYLIB_FILES) etc/stbt.conf
 
 INSTALL_VSTB_FILES = \
     stbt_virtual_stb.py
@@ -129,6 +129,8 @@ install-core: all
 	$(INSTALL) -m 0755 irnetbox-proxy $(DESTDIR)$(bindir)
 	$(INSTALL) -m 0644 stbt-completion \
 	    $(DESTDIR)$(sysconfdir)/bash_completion.d/stbt
+	$(INSTALL) -m 0644 etc/stbt.conf \
+	    $(DESTDIR)$(sysconfdir)/stbt/stbt.conf
 	for filename in $(INSTALL_CORE_FILES); do \
 	    [ -x "$$filename" ] && mode=0755 || mode=0644; \
 	    $(INSTALL) -m $$mode $$filename $(DESTDIR)$(libexecdir)/stbt/$$filename; \
@@ -159,6 +161,11 @@ install-gpl: $(INSTALL_GPL_FILES)
 	    [ -x "$$filename" ] && mode=0755 || mode=0644; \
 	    $(INSTALL) -m $$mode $$filename $(DESTDIR)$(pythondir)/$$filename; \
 	done
+
+etc/stbt.conf : _stbt/stbt.conf
+	# Comment out defaults for /etc/stbt/stbt.conf
+	mkdir -p etc
+	awk '/^$$/ { print  }; /^#/ { print "#" $$0}; /^\[/ { print $$0 }; /^[^\[#]/ {print "# " $$0 }' _stbt/stbt.conf >$@
 
 STBT_CONTROL_RELAY_FILES = \
     _stbt/__init__.py \

--- a/_stbt/stbt.conf
+++ b/_stbt/stbt.conf
@@ -1,6 +1,10 @@
 [global]
 source_pipeline=videotestsrc is-live=true
-sink_pipeline=xvimagesink sync=false
+sink_pipeline=
+
+# Uncomment the following line to see the video while running stbt run:
+# sink_pipeline=xvimagesink sync=false
+
 transformation_pipeline = identity
 control=error
 verbose=0

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -38,6 +38,11 @@ open-source project, or update [test_pack.stbt_version] if you're using the
 * `stbt.android.AdbDevice.press` will convert standard Stb-tester key names
   like "KEY_OK" to the equivalent Android KeyEvent keycodes.
 
+* `stbt run` will no longer show an output video window by default. This is a
+  better default for headless environments like stbt-docker.  You can re-enable
+  this by setting `global.sink_pipeline = xvimagesink sync=false` in your
+  `$HOME/.config/stbt/stbt.conf`
+
 ##### Minor fixes and packaging fixes
 
 

--- a/tests/stbt.conf
+++ b/tests/stbt.conf
@@ -1,6 +1,6 @@
 [global]
 source_pipeline = videotestsrc is-live=true ! video/x-raw,format=BGR,width=320,height=240,framerate=10/1
-sink_pipeline = fakesink sync=false
+sink_pipeline =
 transformation_pipeline = identity
 control = test
 restart_source = False


### PR DESCRIPTION
`stbt run` will no longer show an output video window by default. This is a
better default for headless environments like stbt-docker.  You can re-enable
this by setting `global.sink_pipeline = xvimagesink sync=false` in your
`$HOME/.config/stbt/stbt.conf`