### PR TITLE
sink pipeline: Only tee if we have to

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1888,6 +1888,7 @@ class SinkPipeline(object):
 
         debug("teardown: Sending eos on sink pipeline")
         if self.appsrc.emit("end-of-stream") == Gst.FlowReturn.OK:
+            self.sink_pipeline.send_event(Gst.Event.new_eos())
             if not self.received_eos.wait(10):
                 debug("Timeout waiting for sink EOS")
         else:


### PR DESCRIPTION
GStreamer's tee can be a little funny some times when it comes to
caps negotiation and errors.  Avoid it if possible.

This will also save two threads and the associated costs.