### PR TITLE
SinkPipeline: Don't send EOS if no samples have been pushed

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1821,6 +1821,7 @@ class SinkPipeline(object):
         self.received_eos = threading.Event()
         self._frames = deque(maxlen=35)
         self._time = _time
+        self._sample_count = 0
 
         sink_pipeline_description = (
             "appsrc name=appsrc format=time is-live=true "
@@ -1886,13 +1887,16 @@ class SinkPipeline(object):
         while self._frames:
             self._push_sample(self._frames.pop())
 
-        debug("teardown: Sending eos on sink pipeline")
-        if self.appsrc.emit("end-of-stream") == Gst.FlowReturn.OK:
-            self.sink_pipeline.send_event(Gst.Event.new_eos())
-            if not self.received_eos.wait(10):
-                debug("Timeout waiting for sink EOS")
+        if self._sample_count > 0:
+            debug("teardown: Sending eos on sink pipeline")
+            if self.appsrc.emit("end-of-stream") == Gst.FlowReturn.OK:
+                self.sink_pipeline.send_event(Gst.Event.new_eos())
+                if not self.received_eos.wait(10):
+                    debug("Timeout waiting for sink EOS")
+            else:
+                debug("Sending EOS to sink pipeline failed")
         else:
-            debug("Sending EOS to sink pipeline failed")
+            debug("SinkPipeline teardown: Not sending EOS, no samples sent")
 
         self.sink_pipeline.set_state(Gst.State.NULL)
 
@@ -1952,6 +1956,7 @@ class SinkPipeline(object):
 
         self.appsrc.props.caps = sample.get_caps()
         self.appsrc.emit("push-buffer", sample.get_buffer())
+        self._sample_count += 1
 
     def draw(self, obj, duration_secs=None, label=""):
         with self.annotations_lock:

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1823,7 +1823,7 @@ class SinkPipeline(object):
         self._time = _time
 
         sink_pipeline_description = (
-            "appsrc name=appsrc format=time "
+            "appsrc name=appsrc format=time is-live=true "
             "caps=video/x-raw,format=(string)BGR ")
 
         if save_video and user_sink_pipeline:


### PR DESCRIPTION
GStreamer elements don't seem to be all that reliable when you send EOS without any elements.  Some elements will hang.  This only really affects testing stb-tester itself as most real uses of stb-tester will last long-enough to push some frames.