### PR TITLE
stbt-run: Fix relative imports within your test-pack

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -43,6 +43,10 @@ open-source project, or update [test_pack.stbt_version] if you're using the
 * `stbt.android.AdbDevice.press` will convert standard Stb-tester key names
   like "KEY_OK" to the equivalent Android KeyEvent keycodes.
 
+* If your test-pack is a Python module (e.g. contains an `__init__.py` in each
+  directory under `tests/`) relative imports from test scripts will now work.
+  This allows you to organise your tests into multiple directories easily.
+
 ##### Minor fixes and packaging fixes
 
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -29,6 +29,11 @@ open-source project, or update [test_pack.stbt_version] if you're using the
 
 ##### Breaking changes since v28
 
+* `stbt run` will no longer show an output video window by default. This is a
+  better default for headless environments like stbt-docker.  You can re-enable
+  this by setting `global.sink_pipeline = xvimagesink sync=false` in your
+  `$HOME/.config/stbt/stbt.conf`
+
 ##### New features
 
 * `stbt.press` can be configured to use the ADB keypress mechanism from
@@ -37,11 +42,6 @@ open-source project, or update [test_pack.stbt_version] if you're using the
 
 * `stbt.android.AdbDevice.press` will convert standard Stb-tester key names
   like "KEY_OK" to the equivalent Android KeyEvent keycodes.
-
-* `stbt run` will no longer show an output video window by default. This is a
-  better default for headless environments like stbt-docker.  You can re-enable
-  this by setting `global.sink_pipeline = xvimagesink sync=false` in your
-  `$HOME/.config/stbt/stbt.conf`
 
 ##### Minor fixes and packaging fixes
 


### PR DESCRIPTION
This provides more flexibility in how you organise your test-pack.  If you
put `__init__.py` under `tests/` you will now be able to do:

    from .helpers import test_helper

Note the `.` before helpers indicating that this is a relative import.
Relative imports becomes more important when there is a file hierarchy as
you can import from a parent package:

    from ..utils.helpers import test_helpers

This follows the same [behaviour from py.test][1].

[1]: https://docs.pytest.org/en/latest/goodpractices.html#test-package-name
