### PR TITLE
Add stbt.press(hold_secs) parameter, and stbt.pressing context manager

### DIFF
--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -428,7 +428,7 @@ class IRNetBoxRemote(object):
 class RokuHttpControl(object):
     """Send a key-press via Roku remote control protocol.
 
-    See https://sdkdocs.roku.com/display/sdkdoc/External+Control+Guide
+    See https://sdkdocs.roku.com/display/sdkdoc/External+Control+API
     """
 
     # Map our recommended keynames (from linux input-event-codes.h) to the

--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -214,9 +214,12 @@ def _read_lircd_reply(stream):
             % stream.gettimeout())
     if "SUCCESS" not in reply:
         if "ERROR" in reply and len(reply) >= 6 and reply[3] == "DATA":
-            num_data_lines = int(reply[4])
-            raise RuntimeError("LIRC remote control returned error: %s"
-                               % " ".join(reply[5:5 + num_data_lines]))
+            try:
+                num_data_lines = int(reply[4])
+                raise RuntimeError("LIRC remote control returned error: %s"
+                                   % " ".join(reply[5:5 + num_data_lines]))
+            except ValueError:
+                pass
         raise RuntimeError("LIRC remote control returned unknown error")
 
 DEFAULT_LIRCD_SOCKET = '/var/run/lirc/lircd'

--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -63,7 +63,7 @@ def uri_to_control(uri, display=None):
         (r'samsung:(?P<hostname>[^:/]+)(:(?P<port>\d+))?',
          _new_samsung_tcp_control),
         (r'test', lambda: VideoTestSrcControl(display)),
-        (r'x11:(?P<display>[^,]+)?(,(?P<mapping>.+)?)?', _X11Control),
+        (r'x11:(?P<display>[^,]+)?(,(?P<mapping>.+)?)?', X11Control),
         (r'rfb:(?P<hostname>[^:/]+)(:(?P<port>\d+))?', RemoteFrameBuffer),
     ]
     if gpl_controls is not None:
@@ -544,7 +544,7 @@ class RokuHttpControl(object):
         debug("Released " + key)
 
 
-class _SamsungTCPControl(RemoteControl):
+class SamsungTCPControl(RemoteControl):
     """Send a key-press via Samsung remote control protocol.
 
     See http://sc0ty.pl/2012/02/samsung-tv-network-remote-control-protocol/
@@ -556,7 +556,7 @@ class _SamsungTCPControl(RemoteControl):
     @staticmethod
     def _encode_string(string):
         r"""
-        >>> _SamsungTCPControl._encode_string('192.168.0.10')
+        >>> SamsungTCPControl._encode_string('192.168.0.10')
         '\x10\x00MTkyLjE2OC4wLjEw'
         """
         from base64 import b64encode
@@ -589,7 +589,7 @@ class _SamsungTCPControl(RemoteControl):
 
 
 def _new_samsung_tcp_control(hostname, port):
-    return _SamsungTCPControl(_connect_tcp_socket(hostname, int(port or 55000)))
+    return SamsungTCPControl(_connect_tcp_socket(hostname, int(port or 55000)))
 
 
 def _load_key_mapping(filename):
@@ -602,7 +602,7 @@ def _load_key_mapping(filename):
     return out
 
 
-class _X11Control(RemoteControl):
+class X11Control(RemoteControl):
     """Simulate key presses using xdotool.
     """
     def __init__(self, display=None, mapping=None):
@@ -848,7 +848,7 @@ def test_samsung_tcp_control():
         def getsockname(self):
             return ['192.168.0.8', 12345]
 
-    r = _SamsungTCPControl(TestSocket())
+    r = SamsungTCPControl(TestSocket())
     assert len(sent_data) == 1
     assert sent_data[0] == (
         b'\x00\x13\x00iphone.iapp.samsung0\x00d\x00\x10\x00MTkyLjE2OC4wLjg=' +

--- a/_stbt/control_gpl.py
+++ b/_stbt/control_gpl.py
@@ -1,4 +1,6 @@
 import re
+import threading
+import time
 from contextlib import contextmanager
 from textwrap import dedent
 
@@ -159,8 +161,88 @@ class HdmiCecControl(object):
         self.source = source
         self.destination = destination
 
+        self.press_and_hold_thread = None
+        self.press_and_holding = False
+        self.lock = threading.Condition()
+
     def press(self, key):
+        with self.lock:
+            if self.press_and_holding:
+                raise HdmiCecError(
+                    "Can't call 'press' while holding another key")
+
+            if not self.lib.Transmit(self.keydown_command(key)):
+                raise HdmiCecError("Failed to send keydown for %s" % key)
+            if not self.lib.Transmit(self.keyup_command()):
+                raise HdmiCecError("Failed to send keyup for %s" % key)
+
+        debug("Pressed %s" % key)
+
+    def keydown(self, key):
+        # CEC spec section 13.13.3 says that the receiver should assume a
+        # keyup if it hasn't seen one within a receiver-determined timeframe
+        # which can't be less than 550ms. For press-and-hold the initiator
+        # should send repeated keydown commands (200 to 450ms apart) followed
+        # by the final keyup.
+
+        with self.lock:
+            if self.press_and_holding:
+                raise HdmiCecError(
+                    "Can't call 'keydown' while holding another key")
+            self.press_and_holding = True
+
+            if not self.lib.Transmit(self.keydown_command(key)):
+                raise HdmiCecError("Failed to send keydown for %s" % key)
+
+            self.press_and_hold_thread = threading.Thread(
+                target=self.send_keydowns, args=(key,))
+            self.press_and_hold_thread.daemon = True
+            self.press_and_hold_thread.start()
+        debug("Holding %s" % key)
+
+    def keyup(self, key):
+        with self.lock:
+            if not self.press_and_holding:
+                raise HdmiCecError("Called 'keyup' when not holding a key down")
+            self.press_and_holding = False
+            thread = self.press_and_hold_thread
+            self.press_and_hold_thread = None
+            self.lock.notify_all()
+
+        thread.join()
+
+        with self.lock:
+            if not self.lib.Transmit(self.keyup_command()):
+                raise HdmiCecError("Failed to send keyup for %s" % key)
+        debug("Released %s" % key)
+
+    def send_keydowns(self, key):
+        end_time = time.time() + 60
+        with self.lock:
+            while True:
+                self.lock.wait(0.450)
+                if not self.press_and_holding:
+                    return
+                if time.time() > end_time:
+                    debug("cec: Warning: Releasing %s as I've been holding it "
+                          "longer than 60 seconds" % key)
+                    return
+                if not self.lib.Transmit(self.keydown_command(key)):
+                    debug("cec: Warning: Failed to send repeated keydown for %s"
+                          % key)
+
+    def keydown_command(self, key):
+        keycode = self.get_keycode(key)
+        keydown_str = "%X%X:44:%02X" % (self.source, self.destination, keycode)
+        return self.lib.CommandFromString(keydown_str)
+
+    def keyup_command(self):
+        keyup_str = "%X%X:45" % (self.source, self.destination)
+        return self.lib.CommandFromString(keyup_str)
+
+    def get_keycode(self, key):
         from .control import UnknownKeyError
+
         keycode = self._KEYNAMES.get(key)
         if keycode is None:
             if isinstance(key, int):
@@ -172,26 +254,7 @@ class HdmiCecControl(object):
         if keycode is None or (isinstance(keycode, int) and
                                not 0 <= keycode <= 255):
             raise UnknownKeyError("HdmiCecControl: Unknown key %r" % key)
-
-        key_down_str = "%X%X:44:%02X" % (self.source, self.destination, keycode)
-        key_down_cmd = self.lib.CommandFromString(key_down_str)
-        key_up_str = "%X%X:45" % (self.source, self.destination)
-        key_up_cmd = self.lib.CommandFromString(key_up_str)
-
-        debug("cec: Transmit %s as %s" % (key, key_down_str))
-        if not self.lib.Transmit(key_down_cmd):
-            raise HdmiCecError(
-                "Failed to send key down command %s" % key_down_str)
-        if not self.lib.Transmit(key_up_cmd):
-            raise HdmiCecError("Failed to send key up command %s" % key_up_str)
-
-    def keydown(self, key):
-        raise NotImplementedError(
-            "HdmiCecControl: pressing (holding) not implemented")
-
-    def keyup(self, key):
-        raise NotImplementedError(
-            "HdmiCecControl: pressing (holding) not implemented")
+        return keycode
 
     # detect an adapter and return the com port path
     def detect_adapter(self):
@@ -231,8 +294,11 @@ def test_hdmi_cec_control():
         r.press("74")
         r.press("0x4A")
         r.press("0x4a")
+        r.keydown("KEY_ROOT_MENU")
+        time.sleep(1)
+        r.keyup("KEY_ROOT_MENU")
 
-    assert io.getvalue() == dedent("""\
+    expected = dedent("""\
         Open('test-device')
         Transmit(dest: 0xa, src: 0x7, op: 0x44, data: <01>)
         Transmit(dest: 0xa, src: 0x7, op: 0x45, data: <>)
@@ -248,7 +314,12 @@ def test_hdmi_cec_control():
         Transmit(dest: 0xa, src: 0x7, op: 0x45, data: <>)
         Transmit(dest: 0xa, src: 0x7, op: 0x44, data: <4a>)
         Transmit(dest: 0xa, src: 0x7, op: 0x45, data: <>)
+        Transmit(dest: 0xa, src: 0x7, op: 0x44, data: <09>)
+        Transmit(dest: 0xa, src: 0x7, op: 0x44, data: <09>)
+        Transmit(dest: 0xa, src: 0x7, op: 0x44, data: <09>)
+        Transmit(dest: 0xa, src: 0x7, op: 0x45, data: <>)
         """)
+    assert expected == io.getvalue()
 
 
 def test_hdmi_cec_control_defaults():

--- a/_stbt/control_gpl.py
+++ b/_stbt/control_gpl.py
@@ -172,18 +172,18 @@ class HdmiCecControl(object):
         if keycode is None or (isinstance(keycode, int) and
                                not 0 <= keycode <= 255):
             raise UnknownKeyError("HdmiCecControl: Unknown key %r" % key)
-        cec_command = "%X%X:44:%02X" % (self.source, self.destination, keycode)
-        key_down_cmd = self.lib.CommandFromString(cec_command)
-        key_up_cmd = self.lib.CommandFromString(
-            '%X%X:45' % (self.source, self.destination))
 
-        debug("cec: Transmit %s as %s" % (key, cec_command))
+        key_down_str = "%X%X:44:%02X" % (self.source, self.destination, keycode)
+        key_down_cmd = self.lib.CommandFromString(key_down_str)
+        key_up_str = "%X%X:45" % (self.source, self.destination)
+        key_up_cmd = self.lib.CommandFromString(key_up_str)
+
+        debug("cec: Transmit %s as %s" % (key, key_down_str))
         if not self.lib.Transmit(key_down_cmd):
             raise HdmiCecError(
-                "Failed to send key down command %s" % cec_command)
+                "Failed to send key down command %s" % key_down_str)
         if not self.lib.Transmit(key_up_cmd):
-            raise HdmiCecError(
-                "Failed to send key up command %s" % cec_command)
+            raise HdmiCecError("Failed to send key up command %s" % key_up_str)
 
     def keydown(self, key):
         raise NotImplementedError(

--- a/_stbt/control_gpl.py
+++ b/_stbt/control_gpl.py
@@ -185,6 +185,14 @@ class HdmiCecControl(object):
             raise HdmiCecError(
                 "Failed to send key up command %s" % cec_command)
 
+    def keydown(self, key):
+        raise NotImplementedError(
+            "HdmiCecControl: pressing (holding) not implemented")
+
+    def keyup(self, key):
+        raise NotImplementedError(
+            "HdmiCecControl: pressing (holding) not implemented")
+
     # detect an adapter and return the com port path
     def detect_adapter(self):
         retval = None

--- a/_stbt/control_gpl.py
+++ b/_stbt/control_gpl.py
@@ -284,9 +284,9 @@ class HdmiCecControl(object):
 
 
 def test_hdmi_cec_control():
-    from .control import uri_to_remote
+    from .control import uri_to_control
     with _fake_cec() as io:
-        r = uri_to_remote('hdmi-cec:test-device:7:a')
+        r = uri_to_control('hdmi-cec:test-device:7:a')
         r.press("KEY_UP")
         r.press("KEY_UP")
         r.press("KEY_POWER")
@@ -323,9 +323,9 @@ def test_hdmi_cec_control():
 
 
 def test_hdmi_cec_control_defaults():
-    from .control import uri_to_remote
+    from .control import uri_to_control
     with _fake_cec() as io:
-        r = uri_to_remote('hdmi-cec:test-device')
+        r = uri_to_control('hdmi-cec:test-device')
         r.press("KEY_OK")
 
     assert io.getvalue() == dedent("""\

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -770,7 +770,7 @@ def new_device_under_test_from_config(
     """
     `parsed_args` if present should come from calling argparser().parse_args().
     """
-    from _stbt.control import uri_to_remote
+    from _stbt.control import uri_to_control
 
     if parsed_args is None:
         args = argparser().parse_args([])
@@ -825,7 +825,7 @@ def new_device_under_test_from_config(
         args.source_pipeline, sink_pipeline, args.restart_source,
         transformation_pipeline, source_teardown_eos)
     return DeviceUnderTest(
-        display=display[0], control=uri_to_remote(args.control, display[0]),
+        display=display[0], control=uri_to_control(args.control, display[0]),
         sink_pipeline=sink_pipeline, mainloop=mainloop,
         use_old_threading_behaviour=use_old_threading_behaviour)
 

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -19,6 +19,7 @@ import itertools
 import os
 import re
 import subprocess
+import sys
 import threading
 import traceback
 import warnings
@@ -901,7 +902,48 @@ class DeviceUnderTest(object):
             self._mainloop.__exit__(exc_type, exc_value, tb)
         self._control = None
 
-    def press(self, key, interpress_delay_secs=None):
+    def press(self, key, interpress_delay_secs=None, hold_secs=None):
+        if hold_secs is not None and hold_secs > 60:
+            # You must ensure that lircd's --repeat-max is set high enough.
+            raise ValueError("press: hold_secs must be less than 60 seconds")
+
+        if hold_secs is None:
+            with self._interpress_delay(interpress_delay_secs):
+                self._control.press(key)
+            self.draw_text(key, duration_secs=3)
+
+        else:
+            try:
+                self._control.keydown(key)
+                self.draw_text("Holding %s" % key,
+                               duration_secs=min(3, hold_secs))
+                self._time.sleep(hold_secs)
+            finally:
+                self._control.keyup(key)
+                self.draw_text("Released %s" % key, duration_secs=3)
+
+    @contextmanager
+    def pressing(self, key, interpress_delay_secs=None):
+        with self._interpress_delay(interpress_delay_secs):
+            try:
+                self._control.keydown(key)
+                self.draw_text("Holding %s" % key, duration_secs=3)
+                yield
+            finally:
+                original_exc_type, exc_value, exc_traceback = sys.exc_info()
+                try:
+                    self._control.keyup(key)
+                    self.draw_text("Released %s" % key, duration_secs=3)
+                except Exception:  # pylint:disable=broad-except
+                    # Raise an exception if we fail to release the key, but
+                    # not if it would mask an exception from the test script.
+                    if original_exc_type is None:
+                        raise
+                if original_exc_type is not None:
+                    raise original_exc_type, exc_value, exc_traceback  # pylint:disable=raising-bad-type
+
+    @contextmanager
+    def _interpress_delay(self, interpress_delay_secs):
         if interpress_delay_secs is None:
             interpress_delay_secs = get_config(
                 "press", "interpress_delay_secs", type_=float)
@@ -918,9 +960,10 @@ class DeviceUnderTest(object):
                 else:
                     break
 
-        self._control.press(key)
-        self._time_of_last_press = datetime.datetime.now()
-        self.draw_text(key, duration_secs=3)
+        try:
+            yield
+        finally:
+            self._time_of_last_press = datetime.datetime.now()
 
     def draw_text(self, text, duration_secs=3):
         self._sink_pipeline.draw(text, duration_secs)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -44,7 +44,7 @@ open-source project, or update [test_pack.stbt_version] if you're using the
   like "KEY_OK" to the equivalent Android KeyEvent keycodes.
 
 * `stbt.press` accepts a new `hold_secs` parameter to hold a key down for the
-  specified duration. This is only implemented for the LIRC and Roku controls.
+  specified duration. This is implemented for the LIRC, CEC, and Roku controls.
 
 * Added `stbt.pressing`: A context manager that will hold a key down for as
   long as the code in the `with` block is executing.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -43,6 +43,12 @@ open-source project, or update [test_pack.stbt_version] if you're using the
 * `stbt.android.AdbDevice.press` will convert standard Stb-tester key names
   like "KEY_OK" to the equivalent Android KeyEvent keycodes.
 
+* `stbt.press` accepts a new `hold_secs` parameter to hold a key down for the
+  specified duration. This is only implemented for the LIRC and Roku controls.
+
+* Added `stbt.pressing`: A context manager that will hold a key down for as
+  long as the code in the `with` block is executing.
+
 * `stbt.is_screen_black` returns an `IsScreenBlackResult` instead of bool.
   This evaluates to True or False so this change is backwards compatible,
   unless you were explicitly comparing the result with `== True` or `is True`.

--- a/stbt-control
+++ b/stbt-control
@@ -42,13 +42,13 @@ def main(argv):
     if args.help_keymap:
         sys.exit(show_help_keymap())
 
-    remote = _stbt.control.uri_to_remote(args.control, None)
+    control = _stbt.control.uri_to_control(args.control, None)
 
     if args.remote_control_key:  # Send a single key and exit
-        remote.press(args.remote_control_key)
+        control.press(args.remote_control_key)
     else:  # Interactive
         for key in main_loop(args.control, args.keymap):
-            remote.press(key)
+            control.press(key)
 
 
 def test_main():
@@ -79,11 +79,11 @@ def argparser():
     parser.add_argument(
         "--control", default=get_config("global", "control"),
         help="Equivalent to the --control parameter of `stbt run`. "
-             "See `man stbt` for available remote types and configuration.")
+             "See `man stbt` for available control types and configuration.")
     parser.add_argument(
         "remote_control_key", default=None, nargs='?',
         help=(
-            "The name of a remote control key as in the remote config file "
+            "The name of a remote control key as in the control's config file "
             "(that is /etc/lirc/lircd.conf in case of a LIRC control device). "
             "Specifying this argument sends remote_control_key and exits. "
             "Omitting this argument brings up the printed keymap."))
@@ -165,13 +165,13 @@ def main_loop(control_uri, keymap_file):
             if keycode == ord('q'):  # 'q' for 'Quit' is pre-defined
                 return
 
-            remote_key, _ = keymap.get(decoded(keycode), (None, None))
+            control_key, _ = keymap.get(decoded(keycode), (None, None))
             if timer:
                 timer.cancel()
                 clear_last_command(term)
-            if remote_key:
-                yield remote_key
-            term.addstr(str(remote_key))
+            if control_key:
+                yield control_key
+            term.addstr(str(control_key))
             timer = threading.Timer(1, clear_last_command, [term])
             timer.start()
             time.sleep(.2)

--- a/stbt-record
+++ b/stbt-record
@@ -56,7 +56,7 @@ def record(dut, control_recorder, script_out):
     script_out.write("import stbt\n\n\n")
     script_out.write("def test_that_WRITE_TESTCASE_DESCRIPTION_HERE():\n")
     try:
-        for key in _stbt.control.uri_to_remote_recorder(control_recorder):
+        for key in _stbt.control.uri_to_control_recorder(control_recorder):
             write_wait_for_match()
             script_out.write("    stbt.press('%s')\n" % key)
             dut.press(key)

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -87,7 +87,7 @@ _dut = _stbt.core.DeviceUnderTest()
 # ===========================================================================
 
 
-def press(key, interpress_delay_secs=None):
+def press(key, interpress_delay_secs=None, hold_secs=None):
     """Send the specified key-press to the device under test.
 
     :param str key:
@@ -109,8 +109,35 @@ def press(key, interpress_delay_secs=None):
         This defaults to 0.3. You can override the global default value by
         setting ``interpress_delay_secs`` in the ``[press]`` section of
         :ref:`.stbt.conf`.
+
+    :type hold_secs: int or float
+    :param hold_secs:
+        Hold the key down for the specified duration (in seconds). Currently
+        this only works for infrared controls; and if your infrared protocol
+        requires a special "repeat" signal, then your device-under-test might
+        see the same button pressed repeatedly instead of a single
+        press-and-hold. There is a maximum limit of 60 seconds.
+
+    Added in v29: The ``hold_secs`` parameter.
     """
-    return _dut.press(key, interpress_delay_secs)
+    return _dut.press(key, interpress_delay_secs, hold_secs)
+
+
+def pressing(key, interpress_delay_secs=None):
+    """Context manager that will press and hold the specified key for the
+    duration of the ``with`` code block.
+
+    For example, this will hold KEY_RIGHT until ``wait_for_match`` finds a
+    match or times out::
+
+        with stbt.pressing("KEY_RIGHT"):
+            stbt.wait_for_match("last-page.png")
+
+    The same limitations apply as `stbt.press`'s ``hold_secs`` parameter.
+
+    This function was added in v29.
+    """
+    return _dut.pressing(key, interpress_delay_secs)
 
 
 def draw_text(text, duration_secs=3):

--- a/stbt_control_relay.py
+++ b/stbt_control_relay.py
@@ -69,16 +69,23 @@ def main(argv):
             if not cmd:
                 break
             cmd = cmd.rstrip("\n")
-            m = re.match(r"SEND_ONCE (?P<ctrl>\S+) (?P<key>\S+)", cmd)
+            m = re.match(r"(?P<action>SEND_ONCE|SEND_START|SEND_STOP) "
+                         r"(?P<ctrl>\S+) (?P<key>\S+)", cmd)
             if not m:
                 debug("Invalid command: %s" % cmd)
                 send_response(conn, cmd, success=False,
                               data="Invalid command: %s" % cmd)
                 continue
+            action = m.groupdict()["action"]
             key = m.groupdict()["key"]
-            debug("Received %s" % key)
+            debug("Received %s %s" % (action, key))
             try:
-                control.press(key)
+                if action == "SEND_ONCE":
+                    control.press(key)
+                elif action == "SEND_START":
+                    control.keydown(key)
+                elif action == "SEND_STOP":
+                    control.keyup(key)
             except Exception as e:  # pylint: disable=broad-except
                 debug("Error pressing key %r: %r" % (key, e))
                 send_response(conn, cmd, success=False, data=str(e))

--- a/stbt_control_relay.py
+++ b/stbt_control_relay.py
@@ -35,7 +35,7 @@ import socket
 import sys
 
 import _stbt.logging
-from _stbt.control import uri_to_remote
+from _stbt.control import uri_to_control
 
 
 def main(argv):
@@ -59,7 +59,7 @@ def main(argv):
         s.bind(args.socket)
         s.listen(5)
 
-    control = uri_to_remote(args.output)
+    control = uri_to_control(args.output)
 
     while True:
         conn, _ = s.accept()

--- a/tests/fake-lircd
+++ b/tests/fake-lircd
@@ -35,7 +35,7 @@ def main():
                     r = response(line)
                     if r:
                         print "\n".join(
-                            "fake-lircd: Sending: " + x for x in r.split())
+                            "fake-lircd: Sending: " + x for x in r.split("\n"))
                         client.sendall(r)
                 except socket.error as e:
                     if e.errno == socket.errno.EPIPE:
@@ -50,7 +50,7 @@ def response(req):
         s += "BEGIN\nSIGHUP\nEND\n"
     if re.search("broadcast", req):
         s += "000f00b 01 OK My-IR-remote\n"
-    if req.startswith("SEND_ONCE"):
+    if req.startswith("SEND_"):
         if re.search("error", req):
             s += "BEGIN\n%s\nERROR\nDATA\n1\nfake-lircd error\nEND\n" % req
         elif re.search("timeout", req):

--- a/tests/test-stbt-control.sh
+++ b/tests/test-stbt-control.sh
@@ -1,7 +1,7 @@
 test_that_stbt_control_sends_a_single_key() {
     set_config global.verbose 1 &&
     stbt control --control none MENU &&
-    cat log | grep -q 'NullRemote: Ignoring request to press "MENU"'
+    cat log | grep -q 'NullControl: Ignoring request to press "MENU"'
 }
 
 validate_stbt_record_control_recorder() {

--- a/tests/test_press.py
+++ b/tests/test_press.py
@@ -1,0 +1,42 @@
+import pytest
+
+from _stbt.core import DeviceUnderTest, NoSinkPipeline
+
+
+def test_that_pressing_context_manager_raises_keyup_exceptions():
+    dut = DeviceUnderTest(control=FakeControl(raises_on_keyup=True),
+                          sink_pipeline=NoSinkPipeline())
+    with pytest.raises(RuntimeError) as excinfo:
+        with dut.pressing("KEY_MENU"):
+            pass
+    assert "keyup KEY_MENU failed" in str(excinfo.value)
+
+
+def test_that_pressing_context_manager_suppresses_keyup_exceptions():
+    # ...if doing so would hide an exception raised by the test script.
+    control = FakeControl(raises_on_keyup=True)
+    dut = DeviceUnderTest(control=control, sink_pipeline=NoSinkPipeline())
+    with pytest.raises(AssertionError):
+        with dut.pressing("KEY_MENU"):
+            assert False
+    assert control.keyup_called == 1
+
+
+class FakeControl(object):
+    def __init__(self, raises_on_keydown=False, raises_on_keyup=False):
+        self.raises_on_keydown = raises_on_keydown
+        self.raises_on_keyup = raises_on_keyup
+        self.keydown_called = 0
+        self.keyup_called = 0
+
+    def keydown(self, key):
+        print "keydown %s" % key
+        self.keydown_called += 1
+        if self.raises_on_keydown:
+            raise RuntimeError("keydown %s failed" % key)
+
+    def keyup(self, key):
+        print "keyup %s" % key
+        self.keyup_called += 1
+        if self.raises_on_keyup:
+            raise RuntimeError("keyup %s failed" % key)

--- a/tests/test_stbt_control_relay.py
+++ b/tests/test_stbt_control_relay.py
@@ -3,6 +3,7 @@ import socket
 import subprocess
 from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
+from textwrap import dedent
 
 import pytest
 
@@ -77,11 +78,18 @@ def test_stbt_control_relay(stbt_control_relay_on_path):  # pylint: disable=unus
                 os.path.exists(t("lircd.sock")) or proc.poll() is not None))
             testremote = uri_to_remote("lirc:%s:stbt-test" % t("lircd.sock"))
 
-            testremote.press("KEY_UP")
-            testremote.press("KEY_DOWN")
-            expected = "KEY_UP\nKEY_DOWN\n"
+            testremote.press("KEY_LEFT")
+            testremote.press("KEY_RIGHT")
+            testremote.keydown("KEY_MENU")
+            testremote.keyup("KEY_MENU")
+            expected = dedent("""\
+                KEY_LEFT
+                KEY_RIGHT
+                Holding KEY_MENU
+                Released KEY_MENU
+                """)
 
-            assert open(t("one-file")).read() == expected
+            assert expected == open(t("one-file")).read()
 
 
 def socket_passing_setup(socket):

--- a/tests/test_stbt_control_relay.py
+++ b/tests/test_stbt_control_relay.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 
 import pytest
 
-from _stbt.control import uri_to_remote
+from _stbt.control import uri_to_control
 from _stbt.core import wait_until
 from _stbt.utils import named_temporary_directory
 
@@ -76,12 +76,12 @@ def test_stbt_control_relay(stbt_control_relay_on_path):  # pylint: disable=unus
         with scoped_process(proc):
             wait_until(lambda: (
                 os.path.exists(t("lircd.sock")) or proc.poll() is not None))
-            testremote = uri_to_remote("lirc:%s:stbt-test" % t("lircd.sock"))
+            testcontrol = uri_to_control("lirc:%s:stbt-test" % t("lircd.sock"))
 
-            testremote.press("KEY_LEFT")
-            testremote.press("KEY_RIGHT")
-            testremote.keydown("KEY_MENU")
-            testremote.keyup("KEY_MENU")
+            testcontrol.press("KEY_LEFT")
+            testcontrol.press("KEY_RIGHT")
+            testcontrol.keydown("KEY_MENU")
+            testcontrol.keyup("KEY_MENU")
             expected = dedent("""\
                 KEY_LEFT
                 KEY_RIGHT
@@ -114,10 +114,10 @@ def test_stbt_control_relay_with_socket_passing(stbt_control_relay_on_path):  # 
             ["stbt-control-relay", "-vv", "file:" + tmpfile.name],
             preexec_fn=socket_passing_setup(s))
         with scoped_process(proc):
-            testremote = uri_to_remote("lirc:%s:%i:stbt" % s.getsockname())
+            testcontrol = uri_to_control("lirc:%s:%i:stbt" % s.getsockname())
 
-            testremote.press("KEY_UP")
-            testremote.press("KEY_DOWN")
+            testcontrol.press("KEY_UP")
+            testcontrol.press("KEY_DOWN")
             expected = "KEY_UP\nKEY_DOWN\n"
 
             assert tmpfile.read() == expected


### PR DESCRIPTION
Allows holding down a key on the remote-control for a certain duration, or (for the `stbt.pressing` context manager) while a block of code executes.

Only implemented for LIRC, Roku, and CEC controls. I haven't implemented the other controls because I don't know how, or it's impossible. I specifically know that the IRNetBox doesn't have separate keydown/keyup commands.

[lircd(8)]: http://www.lirc.org/html/lircd.html

---

**TODO**

- [x] Test lircd repeat behaviour with irsend.
- [x] Unit test for exception handling behaviour in the `pressing` context manager?
- [x] Implement for LIRC.
- [x] Implement for CEC.
- [x] Implement for stbt-control-relay.
- [x] Test stbt-run with RedRat3 receiver.
- [x] Compare hold signal vs. real remote control.
- [x] Base class for remote controls.
- [x] Lower CEC sleep to 300ms and calculate a deadline for intervals rather than just sleeping for a set amount of time.
- [x] Test hold with IR: Roku.
- [x] Test hold with RokuHttpControl
    - Does it have a time limit after which it considers the key released? No, I tested keydown "Down" and after 4 minutes it's still happily scrolling down the menu.
- [ ] Test hold with CEC: PS4
- [x] Test hold with CEC: FireTV.
