### PR TITLE
stbt.is_screen_black: Return IsScreenBlackResult instead of bool

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -665,6 +665,27 @@ def test_motionresult_repr():
             "frame=<1280x720x3>)")
 
 
+class IsScreenBlackResult(object):
+    """The result from `is_screen_black`.
+
+    :ivar Frame frame: The video frame that was analyzed.
+
+    :ivar bool result: True if the screen was black. This is the same as
+        evaluating the ``IsScreenBlackResult`` as a bool.
+    """
+    def __init__(self, frame, result):
+        self.frame = frame
+        self.result = result
+
+    def __nonzero__(self):
+        return self.result
+
+    def __repr__(self):
+        return ("IsScreenBlackResult(frame=<%s>, result=%r)" % (
+            _str_frame_dimensions(self.frame),
+            self.result))
+
+
 class OcrMode(IntEnum):
     """Options to control layout analysis and assume a certain form of image.
 
@@ -1305,7 +1326,7 @@ class DeviceUnderTest(object):
             else:
                 imglog.imwrite('non-black-regions-after-masking', greyframe)
 
-        return maxVal == 0
+        return IsScreenBlackResult(frame, maxVal == 0)
 
 # Utility functions
 # ===========================================================================

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1304,14 +1304,13 @@ class DeviceUnderTest(object):
         if frame is None:
             frame = self.get_frame()
 
-        region = Region.intersect(_image_region(frame), region)
-
         if mask is None:
             mask = _ImageFromUser(None, None, None)
         else:
             mask = _load_image(mask, cv2.IMREAD_GRAYSCALE)
 
-        greyframe = cv2.cvtColor(crop(frame, region), cv2.COLOR_BGR2GRAY)
+        _region = Region.intersect(_image_region(frame), region)
+        greyframe = cv2.cvtColor(crop(frame, _region), cv2.COLOR_BGR2GRAY)
         _, greyframe = cv2.threshold(
             greyframe, threshold, 255, cv2.THRESH_BINARY)
         _, maxVal, _, _ = cv2.minMaxLoc(greyframe, mask.image)
@@ -1327,10 +1326,11 @@ class DeviceUnderTest(object):
                 imglog.imwrite('non-black-regions-after-masking', greyframe)
 
         result = IsScreenBlackResult(maxVal == 0, frame)
-        if result:
-            debug("is_screen_black: Found black screen: %s" % result)
-        else:
-            debug("is_screen_black: Didn't find black screen: %s" % result)
+        debug("is_screen_black: {found} black screen using mask={mask}, "
+              "threshold={threshold}, region={region}: {result}".format(
+                  found="Found" if result.black else "Didn't find",
+                  mask=mask.friendly_name,
+                  threshold=threshold, region=region, result=result))
         return result
 
 # Utility functions

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -668,22 +668,22 @@ def test_motionresult_repr():
 class IsScreenBlackResult(object):
     """The result from `is_screen_black`.
 
-    :ivar Frame frame: The video frame that was analyzed.
-
-    :ivar bool result: True if the screen was black. This is the same as
+    :ivar bool black: True if the screen was black. This is the same as
         evaluating the ``IsScreenBlackResult`` as a bool.
+
+    :ivar Frame frame: The video frame that was analyzed.
     """
-    def __init__(self, frame, result):
+    def __init__(self, black, frame):
+        self.black = black
         self.frame = frame
-        self.result = result
 
     def __nonzero__(self):
-        return self.result
+        return self.black
 
     def __repr__(self):
-        return ("IsScreenBlackResult(frame=<%s>, result=%r)" % (
-            _str_frame_dimensions(self.frame),
-            self.result))
+        return ("IsScreenBlackResult(black=%r, frame=<%s>)" % (
+            self.black,
+            _str_frame_dimensions(self.frame)))
 
 
 class OcrMode(IntEnum):
@@ -1326,7 +1326,7 @@ class DeviceUnderTest(object):
             else:
                 imglog.imwrite('non-black-regions-after-masking', greyframe)
 
-        result = IsScreenBlackResult(frame, maxVal == 0)
+        result = IsScreenBlackResult(maxVal == 0, frame)
         if result:
             debug("is_screen_black: Found black screen: %s" % result)
         else:

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -1326,7 +1326,12 @@ class DeviceUnderTest(object):
             else:
                 imglog.imwrite('non-black-regions-after-masking', greyframe)
 
-        return IsScreenBlackResult(frame, maxVal == 0)
+        result = IsScreenBlackResult(frame, maxVal == 0)
+        if result:
+            debug("is_screen_black: Found black screen: %s" % result)
+        else:
+            debug("is_screen_black: Didn't find black screen: %s" % result)
+        return result
 
 # Utility functions
 # ===========================================================================

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -486,12 +486,12 @@ class MatchResult(object):
     def __repr__(self):
         return (
             "MatchResult(time=%r, match=%r, region=%r, first_pass_result=%r, "
-            "frame=<%s>, image=%s)" % (
+            "frame=%s, image=%s)" % (
                 self.time,
                 self.match,
                 self.region,
                 self.first_pass_result,
-                _str_frame_dimensions(self.frame),
+                _frame_repr(self.frame),
                 "<Custom Image>" if isinstance(self.image, numpy.ndarray)
                 else repr(self.image)))
 
@@ -510,13 +510,15 @@ class MatchResult(object):
             return int(self.time * 1e9)
 
 
-def _str_frame_dimensions(frame):
+def _frame_repr(frame):
     if frame is None:
         return "None"
+    if isinstance(frame, Frame):
+        return repr(frame)
     if len(frame.shape) == 3:
-        return "%dx%dx%d" % (frame.shape[1], frame.shape[0], frame.shape[2])
+        return "<%dx%dx%d>" % (frame.shape[1], frame.shape[0], frame.shape[2])
     else:
-        return "%dx%d" % (frame.shape[1], frame.shape[0])
+        return "<%dx%d>" % (frame.shape[1], frame.shape[0])
 
 
 class _ImageFromUser(namedtuple(
@@ -642,9 +644,9 @@ class MotionResult(object):
 
     def __repr__(self):
         return (
-            "MotionResult(time=%r, motion=%r, region=%r, frame=<%s>)" % (
+            "MotionResult(time=%r, motion=%r, region=%r, frame=%s)" % (
                 self.time, self.motion, self.region,
-                _str_frame_dimensions(self.frame)))
+                _frame_repr(self.frame)))
 
     @property
     def timestamp(self):
@@ -681,9 +683,9 @@ class IsScreenBlackResult(object):
         return self.black
 
     def __repr__(self):
-        return ("IsScreenBlackResult(black=%r, frame=<%s>)" % (
+        return ("IsScreenBlackResult(black=%r, frame=%s)" % (
             self.black,
-            _str_frame_dimensions(self.frame)))
+            _frame_repr(self.frame)))
 
 
 class OcrMode(IntEnum):
@@ -746,12 +748,12 @@ class TextMatchResult(object):
 
     def __repr__(self):
         return (
-            "TextMatchResult(time=%r, match=%r, region=%r, frame=<%s>, "
+            "TextMatchResult(time=%r, match=%r, region=%r, frame=%s, "
             "text=%r)" % (
                 self.time,
                 self.match,
                 self.region,
-                _str_frame_dimensions(self.frame),
+                _frame_repr(self.frame),
                 self.text))
 
     @property

--- a/_stbt/gst_utils.py
+++ b/_stbt/gst_utils.py
@@ -107,6 +107,14 @@ class Frame(numpy.ndarray):
             return
         self.time = getattr(obj, 'time', None)  # pylint: disable=attribute-defined-outside-init
 
+    def __repr__(self):
+        if len(self.shape) == 3:
+            dimensions = "%dx%dx%d" % (
+                self.shape[1], self.shape[0], self.shape[2])
+        else:
+            dimensions = "%dx%d" % (self.shape[1], self.shape[0])
+        return "<stbt.Frame(time=%r, dimensions=%s)>" % (self.time, dimensions)
+
 
 def array_from_sample(sample, readwrite=False):
     return Frame(

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -43,6 +43,12 @@ open-source project, or update [test_pack.stbt_version] if you're using the
 * `stbt.android.AdbDevice.press` will convert standard Stb-tester key names
   like "KEY_OK" to the equivalent Android KeyEvent keycodes.
 
+* `stbt.is_screen_black` returns an `IsScreenBlackResult` instead of bool.
+  This evaluates to True or False so this change is backwards compatible,
+  unless you were explicitly comparing the result with `== True` or `is True`.
+  This change was made so that you can get the exact frame that was analysed,
+  for more precise performance measurements.
+
 * If your test-pack is a Python module (e.g. contains an `__init__.py` in each
   directory under `tests/`) relative imports from test scripts will now work.
   This allows you to organise your tests into multiple directories easily.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -49,6 +49,9 @@ open-source project, or update [test_pack.stbt_version] if you're using the
   This change was made so that you can get the exact frame that was analysed,
   for more precise performance measurements.
 
+* `stbt.is_screen_black` logs the result of its analysis, similar to
+  `stbt.match`, `stbt.ocr`, etc.
+
 * If your test-pack is a Python module (e.g. contains an `__init__.py` in each
   directory under `tests/`) relative imports from test scripts will now work.
   This allows you to organise your tests into multiple directories easily.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -52,9 +52,10 @@ open-source project, or update [test_pack.stbt_version] if you're using the
 * `stbt.is_screen_black` logs the result of its analysis, similar to
   `stbt.match`, `stbt.ocr`, etc.
 
-* If your test-pack is a Python module (e.g. contains an `__init__.py` in each
-  directory under `tests/`) relative imports from test scripts will now work.
-  This allows you to organise your tests into multiple directories easily.
+* If your test-pack is a Python module (that is, it contains an `__init__.py`
+  in each directory under `tests/`) then relative imports from test scripts
+  will now work. This allows you to organise your tests into multiple
+  directories easily.
 
 ##### Minor fixes and packaging fixes
 

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -22,6 +22,7 @@ from _stbt.core import \
     debug, \
     Frame, \
     get_config, \
+    IsScreenBlackResult, \
     load_image, \
     MatchParameters, \
     MatchResult, \
@@ -53,6 +54,7 @@ __all__ = [
     "get_config",
     "get_frame",
     "is_screen_black",
+    "IsScreenBlackResult",
     "load_image",
     "match",
     "match_all",
@@ -543,9 +545,11 @@ def is_screen_black(frame=None, mask=None, threshold=None, region=Region.ALL):
         If you specify both ``region`` and ``mask``, the mask must be the same
         size as the region.
 
-    :returns: True or False.
+    :returns: An `IsScreenBlackResult`, which will evaluate to True if the
+        frame was black.
 
     Added in v28: The ``region`` parameter.
+    Added in v29: Return `IsScreenBlackResult` instead of bool.
     """
     return _dut.is_screen_black(frame, mask, threshold, region)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -109,7 +109,7 @@ def test_IsScreenBlackResult():
     result = stbt.is_screen_black(frame)
     assert result
     assert numpy.all(result.frame == frame)
-    assert result.result is True
+    assert result.black is True
 
 
 def test_is_screen_black_with_numpy_mask():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -100,7 +100,16 @@ def test_region_replace():
 ])
 def test_is_screen_black(frame, mask, threshold, region, expected):
     frame = stbt.load_image(frame)
-    assert stbt.is_screen_black(frame, mask, threshold, region) == expected
+    assert expected == bool(
+        stbt.is_screen_black(frame, mask, threshold, region))
+
+
+def test_IsScreenBlackResult():
+    frame = stbt.load_image("almost-black.png")
+    result = stbt.is_screen_black(frame)
+    assert result
+    assert numpy.all(result.frame == frame)
+    assert result.result is True
 
 
 def test_is_screen_black_with_numpy_mask():


### PR DESCRIPTION
So that you can get the exact frame that was analysed, for more precise
performance measurements.

TODO:

- [x] Tests.
- [x] Release notes.