### PR TITLE
Debug logging: Log timestamps with 3 decimal places 

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -656,17 +656,6 @@ class MotionResult(object):
             return int(self.time * 1e9)
 
 
-def test_motionresult_repr():
-    assert repr(MotionResult(
-        time=1466002032.335607, motion=True,
-        region=Region(x=321, y=32, right=334, bottom=42),
-        frame=numpy.zeros((720, 1280, 3)))) \
-        == ("MotionResult("
-            "time=1466002032.335607, motion=True, "
-            "region=Region(x=321, y=32, right=334, bottom=42), "
-            "frame=<1280x720x3>)")
-
-
 class IsScreenBlackResult(object):
     """The result from `is_screen_black`.
 

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -485,9 +485,9 @@ class MatchResult(object):
 
     def __repr__(self):
         return (
-            "MatchResult(time=%r, match=%r, region=%r, first_pass_result=%r, "
+            "MatchResult(time=%s, match=%r, region=%r, first_pass_result=%r, "
             "frame=%s, image=%s)" % (
-                self.time,
+                "None" if self.time is None else "%.3f" % self.time,
                 self.match,
                 self.region,
                 self.first_pass_result,
@@ -644,9 +644,9 @@ class MotionResult(object):
 
     def __repr__(self):
         return (
-            "MotionResult(time=%r, motion=%r, region=%r, frame=%s)" % (
-                self.time, self.motion, self.region,
-                _frame_repr(self.frame)))
+            "MotionResult(time=%s, motion=%r, region=%r, frame=%s)" % (
+                "None" if self.time is None else "%.3f" % self.time,
+                self.motion, self.region, _frame_repr(self.frame)))
 
     @property
     def timestamp(self):
@@ -737,9 +737,9 @@ class TextMatchResult(object):
 
     def __repr__(self):
         return (
-            "TextMatchResult(time=%r, match=%r, region=%r, frame=%s, "
+            "TextMatchResult(time=%s, match=%r, region=%r, frame=%s, "
             "text=%r)" % (
-                self.time,
+                "None" if self.time is None else "%.3f" % self.time,
                 self.match,
                 self.region,
                 _frame_repr(self.frame),

--- a/_stbt/gst_utils.py
+++ b/_stbt/gst_utils.py
@@ -113,7 +113,9 @@ class Frame(numpy.ndarray):
                 self.shape[1], self.shape[0], self.shape[2])
         else:
             dimensions = "%dx%d" % (self.shape[1], self.shape[0])
-        return "<stbt.Frame(time=%r, dimensions=%s)>" % (self.time, dimensions)
+        return "<stbt.Frame(time=%s, dimensions=%s)>" % (
+            "None" if self.time is None else "%.3f" % self.time,
+            dimensions)
 
 
 def array_from_sample(sample, readwrite=False):

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -9,11 +9,12 @@ def test_motionresult_repr():
     assert repr(stbt.MotionResult(
         time=1466002032.335607, motion=True,
         region=stbt.Region(x=321, y=32, right=334, bottom=42),
-        frame=numpy.zeros((720, 1280, 3)))) \
+        frame=stbt.Frame(numpy.zeros((720, 1280, 3)),
+                         time=1466002032.335607))) \
         == ("MotionResult("
-            "time=1466002032.335607, motion=True, "
+            "time=1466002032.336, motion=True, "
             "region=Region(x=321, y=32, right=334, bottom=42), "
-            "frame=<1280x720x3>)")
+            "frame=<stbt.Frame(time=1466002032.336, dimensions=1280x720x3)>)")
 
 
 def test_wait_for_motion_half_motion_str_2of4():

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -5,6 +5,17 @@ import numpy
 import stbt
 
 
+def test_motionresult_repr():
+    assert repr(stbt.MotionResult(
+        time=1466002032.335607, motion=True,
+        region=stbt.Region(x=321, y=32, right=334, bottom=42),
+        frame=numpy.zeros((720, 1280, 3)))) \
+        == ("MotionResult("
+            "time=1466002032.335607, motion=True, "
+            "region=Region(x=321, y=32, right=334, bottom=42), "
+            "frame=<1280x720x3>)")
+
+
 def test_wait_for_motion_half_motion_str_2of4():
     with _fake_frames_at_half_motion() as dut:
         res = dut.wait_for_motion(consecutive_frames='2/4')


### PR DESCRIPTION
60fps is 17ms per frame, or 0.017s; having timestamps more precise than
that is misleading and distracting.