### PR TITLE
Don't expose IsScreenBlackResult in public API 

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -657,14 +657,7 @@ class MotionResult(object):
             return int(self.time * 1e9)
 
 
-class IsScreenBlackResult(object):
-    """The result from `is_screen_black`.
-
-    :ivar bool black: True if the screen was black. This is the same as
-        evaluating the ``IsScreenBlackResult`` as a bool.
-
-    :ivar Frame frame: The video frame that was analyzed.
-    """
+class _IsScreenBlackResult(object):
     def __init__(self, black, frame):
         self.black = black
         self.frame = frame
@@ -673,7 +666,7 @@ class IsScreenBlackResult(object):
         return self.black
 
     def __repr__(self):
-        return ("IsScreenBlackResult(black=%r, frame=%s)" % (
+        return ("_IsScreenBlackResult(black=%r, frame=%s)" % (
             self.black,
             _frame_repr(self.frame)))
 
@@ -1358,7 +1351,7 @@ class DeviceUnderTest(object):
                                            cv2.THRESH_BINARY)
             imglog.imwrite('non-black-regions-after-masking', thresholded)
 
-        result = IsScreenBlackResult(bool(maxVal <= threshold), frame)
+        result = _IsScreenBlackResult(bool(maxVal <= threshold), frame)
         debug("is_screen_black: {found} black screen using mask={mask}, "
               "threshold={threshold}, region={region}: "
               "{result}, maximum_intensity={maxVal}".format(

--- a/_stbt/gst_utils.py
+++ b/_stbt/gst_utils.py
@@ -94,9 +94,6 @@ class Frame(numpy.ndarray):
         as number of seconds since the unix epoch (1970-01-01T00:00:00Z). This
         is the same format used by the Python standard library function
         `time.time`.
-
-    ``Frame`` was added in stb-tester v26.
-
     """
     def __new__(cls, array, dtype=None, order=None, time=None):
         obj = numpy.asarray(array, dtype=dtype, order=order).view(cls)

--- a/_stbt/gst_utils.py
+++ b/_stbt/gst_utils.py
@@ -90,9 +90,10 @@ class Frame(numpy.ndarray):
     In addition to the members inherited from `numpy.ndarray`, ``Frame``
     defines the following attributes:
 
-    * ``time`` (float) - the wall-clock time that this video-frame was captured
-      as number of seconds since the unix epoch (1970-01-01T00:00:00Z). This is
-      the same format used by the Python standard library function `time.time`.
+    :ivar float time: The wall-clock time when this video-frame was captured,
+        as number of seconds since the unix epoch (1970-01-01T00:00:00Z). This
+        is the same format used by the Python standard library function
+        `time.time`.
 
     ``Frame`` was added in stb-tester v26.
 

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -65,8 +65,8 @@ def press_and_wait(
         * **press_time** (*float*) – When the key-press completed.
         * **animation_start_time** (*float*) – When animation started after the
           key-press (or ``None`` if timed out).
-        * **end_time** (*float*): When animation completed (or ``None`` if
-            timed out).
+        * **end_time** (*float*) – When animation completed (or ``None`` if
+          timed out).
         * **duration** (*float*) – Time from ``press_time`` to ``end_time`` (or
           ``None`` if timed out).
         * **animation_duration** (*float*) – Time from ``animation_start_time``

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -59,7 +59,7 @@ def press_and_wait(
 
         * **frame** (`stbt.Frame`) – If successful, the first video frame when
           the transition completed; if timed out, the last frame seen.
-        * **status** (`TransitionResult`) – Either ``START_TIMEOUT``,
+        * **status** (`TransitionStatus`) – Either ``START_TIMEOUT``,
           ``STABLE_TIMEOUT``, or ``COMPLETE``. If it's ``COMPLETE``, the whole
           object will evaluate as true.
         * **press_time** (*float*) – When the key-press completed.
@@ -166,7 +166,7 @@ class _Transition(object):
                     "Transition didn't start within %s seconds of pressing %s",
                     f, self.timeout_secs, key)
                 return _TransitionResult(
-                    f, TransitionResult.START_TIMEOUT,
+                    f, TransitionStatus.START_TIMEOUT,
                     press_time, None, None)
 
         end_result = self.wait_for_transition_to_end(f)  # pylint:disable=undefined-loop-variable
@@ -194,13 +194,13 @@ class _Transition(object):
                        first_stable_frame, self.stable_secs,
                        first_stable_frame.time)
                 return _TransitionResult(
-                    first_stable_frame, TransitionResult.COMPLETE,
+                    first_stable_frame, TransitionStatus.COMPLETE,
                     None, initial_frame.time, first_stable_frame.time)
             if f.time >= self.expiry_time:
                 _debug("Transition didn't end within %s seconds",
                        f, self.timeout_secs)
                 return _TransitionResult(
-                    f, TransitionResult.STABLE_TIMEOUT,
+                    f, TransitionStatus.STABLE_TIMEOUT,
                     None, initial_frame.time, None)
 
 
@@ -254,7 +254,7 @@ class _TransitionResult(object):
                 self.animation_duration))
 
     def __nonzero__(self):
-        return self.status == TransitionResult.COMPLETE
+        return self.status == TransitionStatus.COMPLETE
 
     @property
     def duration(self):
@@ -269,7 +269,7 @@ class _TransitionResult(object):
         return self.end_time - self.animation_start_time
 
 
-class TransitionResult(enum.Enum):
+class TransitionStatus(enum.Enum):
     START_TIMEOUT = 0
     STABLE_TIMEOUT = 1
     COMPLETE = 2

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -49,11 +49,12 @@ open-source project, or update [test_pack.stbt_version] if you're using the
 * Added `stbt.pressing`: A context manager that will hold a key down for as
   long as the code in the `with` block is executing.
 
-* `stbt.is_screen_black` returns an `IsScreenBlackResult` instead of bool.
-  This evaluates to True or False so this change is backwards compatible,
-  unless you were explicitly comparing the result with `== True` or `is True`.
-  This change was made so that you can get the exact frame that was analysed,
-  for more precise performance measurements.
+* `stbt.is_screen_black` returns an object with `black` and `frame` attributes,
+  instead of a bool. This evaluates to True or False so this change is
+  backwards compatible, unless you were explicitly comparing the result with
+  `== True` or `is True`. This change was made so that you can get the exact
+  frame that changed to (or from) black, for more precise performance
+  measurements.
 
 * `stbt.is_screen_black` logs the result of its analysis, similar to
   `stbt.match`, `stbt.ocr`, etc.

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -41,7 +41,7 @@ from _stbt.core import \
     wait_until
 from _stbt.transition import \
     press_and_wait, \
-    TransitionResult, \
+    TransitionStatus, \
     wait_for_transition_to_end
 
 __all__ = [
@@ -79,7 +79,7 @@ __all__ = [
     "Region",
     "save_frame",
     "TextMatchResult",
-    "TransitionResult",
+    "TransitionStatus",
     "UITestError",
     "UITestFailure",
     "wait_for_match",

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -22,7 +22,6 @@ from _stbt.core import \
     debug, \
     Frame, \
     get_config, \
-    IsScreenBlackResult, \
     load_image, \
     MatchParameters, \
     MatchResult, \
@@ -58,7 +57,6 @@ __all__ = [
     "get_config",
     "get_frame",
     "is_screen_black",
-    "IsScreenBlackResult",
     "load_image",
     "match",
     "match_all",
@@ -579,11 +577,15 @@ def is_screen_black(frame=None, mask=None, threshold=None, region=Region.ALL):
         If you specify both ``region`` and ``mask``, the mask must be the same
         size as the region.
 
-    :returns: An `IsScreenBlackResult`, which will evaluate to True if the
-        frame was black.
+    :returns:
+        An object that will evaluate to true if the frame was black, or false
+        if not black. The object has the following attributes:
 
-    Added in v28: The ``region`` parameter.
-    Added in v29: Return `IsScreenBlackResult` instead of bool.
+        * **black** (*bool*) – True if the frame was black.
+        * **frame** (`stbt.Frame`) – The video frame that was analysed.
+
+    | Added in v28: The ``region`` parameter.
+    | Added in v29: Return an object with a frame attribute, instead of bool.
     """
     return _dut.is_screen_black(frame, mask, threshold, region)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -104,7 +104,7 @@ def test_is_screen_black(frame, mask, threshold, region, expected):
         stbt.is_screen_black(frame, mask, threshold, region))
 
 
-def test_IsScreenBlackResult():
+def test_is_screen_black_result():
     frame = stbt.load_image("almost-black.png")
     result = stbt.is_screen_black(frame)
     assert result

--- a/tests/test_transition.py
+++ b/tests/test_transition.py
@@ -57,7 +57,7 @@ def test_press_and_wait():
     transition = stbt.press_and_wait("white", stable_secs=0.1, _dut=_stbt)
     print transition
     assert transition
-    assert transition.status == stbt.TransitionResult.COMPLETE
+    assert transition.status == stbt.TransitionStatus.COMPLETE
     assert transition.press_time < transition.animation_start_time
     assert transition.animation_start_time == transition.end_time
     assert transition.duration < 0.01  # excludes stable period
@@ -67,7 +67,7 @@ def test_press_and_wait():
                                      _dut=_stbt)
     print transition
     assert transition
-    assert transition.status == stbt.TransitionResult.COMPLETE
+    assert transition.status == stbt.TransitionStatus.COMPLETE
     assert transition.animation_start_time < transition.end_time
     assert transition.frame.max() == 0
 
@@ -77,7 +77,7 @@ def test_press_and_wait_start_timeout():
                                      _dut=FakeDeviceUnderTest())
     print transition
     assert not transition
-    assert transition.status == stbt.TransitionResult.START_TIMEOUT
+    assert transition.status == stbt.TransitionStatus.START_TIMEOUT
 
 
 def test_press_and_wait_stable_timeout():
@@ -85,23 +85,23 @@ def test_press_and_wait_stable_timeout():
                                      _dut=FakeDeviceUnderTest())
     print transition
     assert not transition
-    assert transition.status == stbt.TransitionResult.STABLE_TIMEOUT
+    assert transition.status == stbt.TransitionStatus.STABLE_TIMEOUT
 
     transition = stbt.press_and_wait("ball", stable_secs=0,
                                      _dut=FakeDeviceUnderTest())
     print transition
     assert transition
-    assert transition.status == stbt.TransitionResult.COMPLETE
+    assert transition.status == stbt.TransitionStatus.COMPLETE
 
 
 @pytest.mark.parametrize("mask,region,expected", [
-    (None, stbt.Region.ALL, stbt.TransitionResult.STABLE_TIMEOUT),
+    (None, stbt.Region.ALL, stbt.TransitionStatus.STABLE_TIMEOUT),
     ("mask-out-left-half-720p.png", stbt.Region.ALL,
-     stbt.TransitionResult.START_TIMEOUT),
+     stbt.TransitionStatus.START_TIMEOUT),
     (None, stbt.Region(x=640, y=0, right=1280, bottom=720),
-     stbt.TransitionResult.START_TIMEOUT),
+     stbt.TransitionStatus.START_TIMEOUT),
     (None, stbt.Region(x=0, y=0, right=1280, bottom=360),
-     stbt.TransitionResult.STABLE_TIMEOUT),
+     stbt.TransitionStatus.STABLE_TIMEOUT),
 ])
 def test_press_and_wait_with_mask_or_region(mask, region, expected):
     transition = stbt.press_and_wait(
@@ -122,7 +122,7 @@ def test_wait_for_transition_to_end():
         timeout_secs=0.2, stable_secs=0.1, _dut=_stbt)
     print transition
     assert not transition
-    assert transition.status == stbt.TransitionResult.STABLE_TIMEOUT
+    assert transition.status == stbt.TransitionStatus.STABLE_TIMEOUT
 
 
 def test_press_and_wait_timestamps():


### PR DESCRIPTION
`IsScreenBlackResult` hasn't been released yet (it was added after v28). Users don't need to construct these, and its name is horrible.

I've had to move its documentation into `is_screen_black`, where I've mimicked the formatting that Sphinx's `:ivar:` generates.

Also rename `TransitionResult` -> `TransitionStatus` -- I was a bit hasty in merging the final post-review changes of #445.