### PR TITLE
Add `frames` parameter to `wait_for_motion` and `detect_motion`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ INSTALL_PYLIB_FILES = \
     _stbt/lmdb/__init__.py \
     _stbt/lmdb/cpython.so \
     _stbt/lmdb/LICENSE \
+    _stbt/motion.py \
     _stbt/logging.py \
     _stbt/power.py \
     _stbt/pylint_plugin.py \

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ INSTALL_PYLIB_FILES = \
     _stbt/stbt-power.sh \
     _stbt/stbt.conf \
     _stbt/transition.py \
+    _stbt/types.py \
     _stbt/utils.py \
     _stbt/x-key-mapping.conf \
     _stbt/x11.py \

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ INSTALL_PYLIB_FILES = \
     _stbt/gst_hacks.py \
     _stbt/gst_utils.py \
     _stbt/imgproc_cache.py \
+    _stbt/imgutils.py \
     _stbt/irnetbox.py \
     _stbt/libxxhash.so \
     _stbt/lmdb/__init__.py \

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -34,7 +34,6 @@ import gi
 import numpy
 from enum import IntEnum
 from kitchen.text.converters import to_bytes
-from numpy import inf
 
 import _stbt.cv2_compat as cv2_compat
 from _stbt import imgproc_cache, logging, utils
@@ -42,6 +41,7 @@ from _stbt.config import ConfigurationError, get_config
 from _stbt.gst_utils import (array_from_sample, Frame, gst_iterate,
                              gst_sample_make_writable, sample_shape)
 from _stbt.logging import ddebug, debug, draw_on, warn
+from _stbt.types import Region, UITestError, UITestFailure
 
 gi.require_version("Gst", "1.0")
 from gi.repository import GLib, GObject, Gst  # isort:skip pylint: disable=E0611
@@ -176,277 +176,6 @@ class Position(namedtuple('Position', 'x y')):
     top left corner of the video frame.
     """
     pass
-
-
-class Region(namedtuple('Region', 'x y right bottom')):
-    u"""
-    ``Region(x, y, width=width, height=height)`` or
-    ``Region(x, y, right=right, bottom=bottom)``
-
-    Rectangular region within the video frame.
-
-    For example, given the following regions a, b, and c::
-
-        - 01234567890123
-        0 ░░░░░░░░
-        1 ░a░░░░░░
-        2 ░░░░░░░░
-        3 ░░░░░░░░
-        4 ░░░░▓▓▓▓░░▓c▓
-        5 ░░░░▓▓▓▓░░▓▓▓
-        6 ░░░░▓▓▓▓░░░░░
-        7 ░░░░▓▓▓▓░░░░░
-        8     ░░░░░░b░░
-        9     ░░░░░░░░░
-
-    >>> a = Region(0, 0, width=8, height=8)
-    >>> b = Region(4, 4, right=13, bottom=10)
-    >>> c = Region(10, 4, width=3, height=2)
-    >>> a.right
-    8
-    >>> b.bottom
-    10
-    >>> b.contains(c), a.contains(b), c.contains(b)
-    (True, False, False)
-    >>> b.extend(x=6, bottom=-4) == c
-    True
-    >>> a.extend(right=5).contains(c)
-    True
-    >>> a.width, a.extend(x=3).width, a.extend(right=-3).width
-    (8, 5, 5)
-    >>> c.replace(bottom=10)
-    Region(x=10, y=4, right=13, bottom=10)
-    >>> Region.intersect(a, b)
-    Region(x=4, y=4, right=8, bottom=8)
-    >>> Region.intersect(a, b) == Region.intersect(b, a)
-    True
-    >>> Region.intersect(c, b) == c
-    True
-    >>> print Region.intersect(a, c)
-    None
-    >>> print Region.intersect(None, a)
-    None
-    >>> quadrant = Region(x=float("-inf"), y=float("-inf"), right=0, bottom=0)
-    >>> quadrant.translate(2, 2)
-    Region(x=-inf, y=-inf, right=2, bottom=2)
-    >>> c.translate(x=-9, y=-3)
-    Region(x=1, y=1, right=4, bottom=3)
-    >>> Region.intersect(Region.ALL, c) == c
-    True
-    >>> Region.ALL
-    Region.ALL
-    >>> print Region.ALL
-    Region.ALL
-    >>> c.above()
-    Region(x=10, y=-inf, right=13, bottom=4)
-    >>> c.below()
-    Region(x=10, y=6, right=13, bottom=inf)
-    >>> a.right_of()
-    Region(x=8, y=0, right=inf, bottom=8)
-    >>> a.right_of(width=2)
-    Region(x=8, y=0, right=10, bottom=8)
-    >>> c.left_of()
-    Region(x=-inf, y=4, right=10, bottom=6)
-
-    .. py:attribute:: x
-
-        The x coordinate of the left edge of the region, measured in pixels
-        from the left of the video frame (inclusive).
-
-    .. py:attribute:: y
-
-        The y coordinate of the top edge of the region, measured in pixels from
-        the top of the video frame (inclusive).
-
-    .. py:attribute:: right
-
-        The x coordinate of the right edge of the region, measured in pixels
-        from the left of the video frame (exclusive).
-
-    .. py:attribute:: bottom
-
-        The y coordinate of the bottom edge of the region, measured in pixels
-        from the top of the video frame (exclusive).
-
-    ``x``, ``y``, ``right``, and ``bottom`` can be infinite -- that is,
-    ``float("inf")`` or ``-float("inf")``.
-    """
-    def __new__(cls, x, y, width=None, height=None, right=None, bottom=None):
-        if (width is None) == (right is None):
-            raise ValueError("You must specify either 'width' or 'right'")
-        if (height is None) == (bottom is None):
-            raise ValueError("You must specify either 'height' or 'bottom'")
-        if right is None:
-            right = x + width
-        if bottom is None:
-            bottom = y + height
-        if right <= x:
-            raise ValueError("'right' must be greater than 'x'")
-        if bottom <= y:
-            raise ValueError("'bottom' must be greater than 'y'")
-        return super(Region, cls).__new__(cls, x, y, right, bottom)
-
-    def __repr__(self):
-        if self == Region.ALL:
-            return 'Region.ALL'
-        else:
-            return 'Region(x=%r, y=%r, right=%r, bottom=%r)' \
-                % (self.x, self.y, self.right, self.bottom)
-
-    @property
-    def width(self):
-        """The width of the region, measured in pixels."""
-        return self.right - self.x
-
-    @property
-    def height(self):
-        """The height of the region, measured in pixels."""
-        return self.bottom - self.y
-
-    @staticmethod
-    def from_extents(x, y, right, bottom):
-        """Create a Region using right and bottom extents rather than width and
-        height.
-
-        Typically you'd use the ``right`` and ``bottom`` parameters of the
-        ``Region`` constructor instead, but this factory function is useful
-        if you need to create a ``Region`` from a tuple.
-
-        >>> extents = (4, 4, 13, 10)
-        >>> Region.from_extents(*extents)
-        Region(x=4, y=4, right=13, bottom=10)
-        """
-        return Region(x, y, right=right, bottom=bottom)
-
-    @staticmethod
-    def intersect(a, b):
-        """
-        :returns: The intersection of regions ``a`` and ``b``, or ``None`` if
-            the regions don't intersect.
-
-        Either ``a`` or ``b`` can be ``None`` so intersect is commutative and
-        associative.
-        """
-        if a is None or b is None:
-            return None
-        else:
-            extents = (max(a.x, b.x), max(a.y, b.y),
-                       min(a.right, b.right), min(a.bottom, b.bottom))
-            if extents[0] < extents[2] and extents[1] < extents[3]:
-                return Region.from_extents(*extents)
-            else:
-                return None
-
-    def contains(self, other):
-        """:returns: True if ``other`` is entirely contained within self."""
-        return (other and self.x <= other.x and self.y <= other.y and
-                self.right >= other.right and self.bottom >= other.bottom)
-
-    def extend(self, x=0, y=0, right=0, bottom=0):
-        """
-        :returns: A new region with the edges of the region adjusted by the
-            given amounts.
-        """
-        return Region.from_extents(
-            self.x + x, self.y + y, self.right + right, self.bottom + bottom)
-
-    def replace(self, x=None, y=None, width=None, height=None, right=None,
-                bottom=None):
-        """
-        :returns: A new region with the edges of the region set to the given
-            coordinates.
-
-        This is similar to `extend`, but it takes absolute coordinates within
-        the image instead of adjusting by a relative number of pixels.
-        """
-        def norm_coords(name_x, name_width, name_right,
-                        x, width, right,  # or y, height, bottom
-                        default_x, _default_width, default_right):
-            if all(z is not None for z in (x, width, right)):
-                raise ValueError(
-                    "Region.replace: Argument conflict: you may only specify "
-                    "two of %s, %s and %s.  You specified %s=%s, %s=%s and "
-                    "%s=%s" % (name_x, name_width, name_right,
-                               name_x, x, name_width, width, name_right, right))
-            if x is None:
-                if width is not None and right is not None:
-                    x = right - width
-                else:
-                    x = default_x
-            if right is None:
-                right = x + width if width is not None else default_right
-            return x, right
-
-        x, right = norm_coords('x', 'width', 'right', x, width, right,
-                               self.x, self.width, self.right)
-        y, bottom = norm_coords('y', 'height', 'bottom', y, height, bottom,
-                                self.y, self.height, self.bottom)
-
-        return Region(x=x, y=y, right=right, bottom=bottom)
-
-    def translate(self, x=0, y=0):
-        """
-        :returns: A new region with the position of the region adjusted by the
-            given amounts.
-        """
-        return Region.from_extents(self.x + x, self.y + y,
-                                   self.right + x, self.bottom + y)
-
-    def above(self, height=inf):
-        """
-        :returns: A new region above the current region, extending to the top
-            of the frame (or to the specified height).
-        """
-        return self.replace(y=self.y - height, bottom=self.y)
-
-    def below(self, height=inf):
-        """
-        :returns: A new region below the current region, extending to the bottom
-            of the frame (or to the specified height).
-        """
-        return self.replace(y=self.bottom, bottom=self.bottom + height)
-
-    def right_of(self, width=inf):
-        """
-        :returns: A new region to the right of the current region, extending to
-            the right edge of the frame (or to the specified width).
-        """
-        return self.replace(x=self.right, right=self.right + width)
-
-    def left_of(self, width=inf):
-        """
-        :returns: A new region to the left of the current region, extending to
-            the left edge of the frame (or to the specified width).
-        """
-        return self.replace(x=self.x - width, right=self.x)
-
-
-Region.ALL = Region(x=-inf, y=-inf, right=inf, bottom=inf)
-
-
-def _bounding_box(a, b):
-    """Find the bounding box of two regions.  Returns the smallest region which
-    contains both regions a and b.
-
-    >>> print _bounding_box(Region(50, 20, 10, 20), Region(20, 30, 10, 20))
-    Region(x=20, y=20, right=60, bottom=50)
-    >>> print _bounding_box(Region(20, 30, 10, 20), Region(20, 30, 10, 20))
-    Region(x=20, y=30, right=30, bottom=50)
-    >>> print _bounding_box(None, Region(20, 30, 10, 20))
-    Region(x=20, y=30, right=30, bottom=50)
-    >>> print _bounding_box(Region(20, 30, 10, 20), None)
-    Region(x=20, y=30, right=30, bottom=50)
-    >>> print _bounding_box(Region(20, 30, 10, 20), Region.ALL)
-    Region.ALL
-    >>> print _bounding_box(None, None)
-    None
-    """
-    if a is None:
-        return b
-    if b is None:
-        return a
-    return Region.from_extents(min(a.x, b.x), min(a.y, b.y),
-                               max(a.right, b.right), max(a.bottom, b.bottom))
 
 
 class MatchResult(object):
@@ -1267,7 +996,7 @@ class DeviceUnderTest(object):
                 # Find bounding box
                 box = None
                 for _, elem in p:
-                    box = _bounding_box(box, _hocr_elem_region(elem))
+                    box = Region.bounding_box(box, _hocr_elem_region(elem))
                 # _tesseract crops to region and scales up by a factor of 3 so
                 # we must undo this transformation here.
                 n = 3 if upsample else 1
@@ -1582,19 +1311,6 @@ def as_precondition(message):
         if hasattr(e, 'screenshot'):
             exc.screenshot = e.screenshot  # pylint: disable=attribute-defined-outside-init,no-member
         raise exc
-
-
-class UITestError(Exception):
-    """The test script had an unrecoverable error."""
-    pass
-
-
-class UITestFailure(Exception):
-    """The test failed because the device under test didn't behave as expected.
-
-    Inherit from this if you need to define your own test-failure exceptions.
-    """
-    pass
 
 
 class NoVideo(Exception):

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -38,8 +38,10 @@ from kitchen.text.converters import to_bytes
 import _stbt.cv2_compat as cv2_compat
 from _stbt import imgproc_cache, logging, utils
 from _stbt.config import ConfigurationError, get_config
-from _stbt.gst_utils import (array_from_sample, Frame, gst_iterate,
-                             gst_sample_make_writable, sample_shape)
+from _stbt.gst_utils import (array_from_sample, gst_iterate,
+                             gst_sample_make_writable)
+from _stbt.imgutils import (_frame_repr, _image_region, _ImageFromUser,
+                            _load_image, crop, find_user_file, Frame)
 from _stbt.logging import ddebug, debug, draw_on, warn
 from _stbt.types import Region, UITestError, UITestFailure
 
@@ -241,45 +243,6 @@ class MatchResult(object):
             return int(self.time * 1e9)
 
 
-def _frame_repr(frame):
-    if frame is None:
-        return "None"
-    if isinstance(frame, Frame):
-        return repr(frame)
-    if len(frame.shape) == 3:
-        return "<%dx%dx%d>" % (frame.shape[1], frame.shape[0], frame.shape[2])
-    else:
-        return "<%dx%d>" % (frame.shape[1], frame.shape[0])
-
-
-class _ImageFromUser(namedtuple(
-        '_ImageFromUser',
-        'image relative_filename absolute_filename')):
-
-    @property
-    def friendly_name(self):
-        if self.image is None:
-            return None
-        return self.relative_filename or '<Custom Image>'
-
-
-def _load_image(image, flags=cv2.IMREAD_COLOR):
-    if isinstance(image, _ImageFromUser):
-        return image
-    if isinstance(image, numpy.ndarray):
-        return _ImageFromUser(image, None, None)
-    else:
-        relative_filename = image
-        absolute_filename = _find_user_file(relative_filename)
-        if not absolute_filename:
-            raise IOError("No such file: %s" % relative_filename)
-        numpy_image = cv2.imread(absolute_filename, flags)
-        if numpy_image is None:
-            raise IOError("Failed to load image: %s" %
-                          absolute_filename)
-        return _ImageFromUser(numpy_image, relative_filename, absolute_filename)
-
-
 def load_image(filename, flags=cv2.IMREAD_COLOR):
     """Find & read an image from disk.
 
@@ -309,38 +272,13 @@ def load_image(filename, flags=cv2.IMREAD_COLOR):
     Added in v28.
     """
 
-    absolute_filename = _find_user_file(filename)
+    absolute_filename = find_user_file(filename)
     if not absolute_filename:
         raise IOError("No such file: %s" % filename)
     image = cv2.imread(absolute_filename, flags)
     if image is None:
         raise IOError("Failed to load image: %s" % absolute_filename)
     return image
-
-
-def crop(frame, region):
-    """Returns an image containing the specified region of ``frame``.
-
-    :type frame: `stbt.Frame` or `numpy.ndarray`
-    :param frame: An image in OpenCV format (for example as returned by
-      `frames`, `get_frame` and `load_image`, or the ``frame`` parameter of
-      `MatchResult`).
-
-    :type Region region: The region to crop.
-
-    :returns: An OpenCV image (`numpy.ndarray`) containing the specified region
-      of the source frame. This is a view onto the original data, so if you
-      want to modify the cropped image call its ``copy()`` method first.
-    """
-    if not _image_region(frame).contains(region):
-        raise ValueError("frame with dimensions %r doesn't contain %r"
-                         % (frame.shape, region))
-    return frame[region.y:region.bottom, region.x:region.right]
-
-
-def _image_region(image):
-    s = sample_shape(image)
-    return Region(0, 0, s[1], s[0])
 
 
 class MotionResult(object):
@@ -2518,60 +2456,6 @@ def _log_match_image_debug(imglog):
                 x._first_pass_matched for x in imglog.data["matches"]),  # pylint:disable=protected-access
             template_name=imglog.data["template_name"],
         ))
-
-
-def _iter_frames(depth=1):
-    frame = inspect.currentframe(depth + 1)
-    while frame:
-        yield frame
-        frame = frame.f_back
-
-
-def _find_user_file(filename):
-    """Searches for the given filename and returns the full path.
-
-    Searches in the directory of the script that called `load_image` (or
-    `match`, etc), then in the directory of that script's caller, etc.
-    Falls back to searching the current working directory.
-
-    :returns: Absolute filename, or None if it can't find the file.
-    """
-
-    if isinstance(filename, unicode):
-        filename = filename.encode("utf-8")
-
-    if os.path.isabs(filename) and os.path.isfile(filename):
-        return filename
-
-    # Start searching from the first parent stack-frame that is outside of
-    # the _stbt installation directory (this file's directory). We can ignore
-    # the first 2 stack-frames:
-    #
-    # * stack()[0] is _find_user_file;
-    # * stack()[1] is _find_user_file's caller: load_image or _load_image;
-    # * stack()[2] is load_image's caller (the user script). It could also be
-    #   _load_image's caller (e.g. `match`) so we still need to check until
-    #   we're outside of the _stbt directory.
-
-    _stbt_dir = os.path.abspath(os.path.dirname(__file__))
-    for caller in _iter_frames(depth=2):
-        caller_dir = os.path.abspath(
-            os.path.dirname(inspect.getframeinfo(caller).filename))
-        if caller_dir.startswith(_stbt_dir):
-            continue
-        caller_path = os.path.join(caller_dir, filename)
-        if os.path.isfile(caller_path):
-            ddebug("Resolved relative path %r to %r" % (filename, caller_path))
-            return caller_path
-
-    # Fall back to image from cwd, to allow loading an image saved previously
-    # during the same test-run.
-    if os.path.isfile(filename):
-        abspath = os.path.abspath(filename)
-        ddebug("Resolved relative path %r to %r" % (filename, abspath))
-        return abspath
-
-    return None
 
 
 # Tesseract sometimes has a hard job distinguishing certain glyphs such as

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -281,50 +281,6 @@ def load_image(filename, flags=cv2.IMREAD_COLOR):
     return image
 
 
-class MotionResult(object):
-    """The result from `detect_motion` and `wait_for_motion`.
-
-    :ivar float time: The time at which the video-frame was captured, in
-        seconds since 1970-01-01T00:00Z. This timestamp can be compared with
-        system time (``time.time()``).
-
-    :ivar bool motion: True if motion was found. This is the same as evaluating
-        ``MotionResult`` as a bool. That is, ``if result:`` will behave the
-        same as ``if result.motion:``.
-
-    :ivar Region region: Bounding box where the motion was found, or ``None``
-        if no motion was found.
-
-    :ivar Frame frame: The video frame in which motion was (or wasn't) found.
-
-    :ivar int timestamp: DEPRECATED. Timestamp in nanoseconds. Use ``time``
-        instead.
-
-    Added in v28: The ``frame`` attribute.
-    """
-    def __init__(self, time, motion, region, frame):
-        self.time = time
-        self.motion = motion
-        self.region = region
-        self.frame = frame
-
-    def __nonzero__(self):
-        return self.motion
-
-    def __repr__(self):
-        return (
-            "MotionResult(time=%s, motion=%r, region=%r, frame=%s)" % (
-                "None" if self.time is None else "%.3f" % self.time,
-                self.motion, self.region, _frame_repr(self.frame)))
-
-    @property
-    def timestamp(self):
-        if self.time is None:
-            return None
-        else:
-            return int(self.time * 1e9)
-
-
 class _IsScreenBlackResult(object):
     def __init__(self, black, frame):
         self.black = black
@@ -478,47 +434,6 @@ def new_device_under_test_from_config(
         display=display[0], control=uri_to_control(args.control, display[0]),
         sink_pipeline=sink_pipeline, mainloop=mainloop,
         use_old_threading_behaviour=use_old_threading_behaviour)
-
-
-def _pixel_bounding_box(img):
-    """
-    Find the smallest region that contains all the non-zero pixels in an image.
-
-    >>> _pixel_bounding_box(numpy.array([[0]], dtype=numpy.uint8))
-    >>> _pixel_bounding_box(numpy.array([[1]], dtype=numpy.uint8))
-    Region(x=0, y=0, right=1, bottom=1)
-    >>> _pixel_bounding_box(numpy.array([
-    ...     [0, 0, 0, 0],
-    ...     [0, 1, 1, 1],
-    ...     [0, 1, 1, 1],
-    ...     [0, 0, 0, 0],
-    ... ], dtype=numpy.uint8))
-    Region(x=1, y=1, right=4, bottom=3)
-    >>> _pixel_bounding_box(numpy.array([
-    ...     [0, 0, 0, 0, 0, 0],
-    ...     [0, 0, 0, 1, 0, 0],
-    ...     [0, 1, 0, 0, 0, 0],
-    ...     [0, 0, 0, 0, 1, 0],
-    ...     [0, 0, 1, 0, 0, 0],
-    ...     [0, 0, 0, 0, 0, 0]
-    ... ], dtype=numpy.uint8))
-    Region(x=1, y=1, right=5, bottom=5)
-    """
-    if len(img.shape) != 2:
-        raise ValueError("Single-channel image required.  Provided image has "
-                         "shape %r" % (img.shape,))
-
-    out = [None, None, None, None]
-
-    for axis in (0, 1):
-        flat = numpy.any(img, axis=axis)
-        indices = numpy.where(flat)[0]
-        if len(indices) == 0:
-            return None
-        out[axis] = indices[0]
-        out[axis + 2] = indices[-1] + 1
-
-    return Region.from_extents(*out)
 
 
 class DeviceUnderTest(object):
@@ -698,76 +613,6 @@ class DeviceUnderTest(object):
                     os.path.basename(template.friendly_name))
             yield result
 
-    def detect_motion(self, timeout_secs=10, noise_threshold=None, mask=None,
-                      region=Region.ALL):
-
-        if noise_threshold is None:
-            noise_threshold = get_config(
-                'motion', 'noise_threshold', type_=float)
-
-        debug("Searching for motion")
-
-        if mask is None:
-            mask = _ImageFromUser(None, None, None)
-        else:
-            mask = _load_image(mask, cv2.IMREAD_GRAYSCALE)
-            debug("Using mask %s" % mask.friendly_name)
-
-        frames = self.frames(timeout_secs)
-        frame, _ = next(frames)
-
-        region = Region.intersect(_image_region(frame), region)
-
-        previous_frame_gray = cv2.cvtColor(crop(frame, region),
-                                           cv2.COLOR_BGR2GRAY)
-        if (mask.image is not None and
-                mask.image.shape[:2] != previous_frame_gray.shape[:2]):
-            raise ValueError(
-                "The dimensions of the mask '%s' %s don't match the "
-                "video frame %s" % (
-                    mask.friendly_name, mask.image.shape,
-                    previous_frame_gray.shape))
-
-        for frame, _ in frames:
-            frame_gray = cv2.cvtColor(crop(frame, region), cv2.COLOR_BGR2GRAY)
-
-            imglog = logging.ImageLogger("detect_motion")
-            imglog.imwrite("source", frame_gray)
-
-            absdiff = cv2.absdiff(frame_gray, previous_frame_gray)
-            previous_frame_gray = frame_gray
-            imglog.imwrite("absdiff", absdiff)
-
-            if mask.image is not None:
-                absdiff = cv2.bitwise_and(absdiff, mask.image)
-                imglog.imwrite("mask", mask.image)
-                imglog.imwrite("absdiff_masked", absdiff)
-
-            _, thresholded = cv2.threshold(
-                absdiff, int((1 - noise_threshold) * 255), 255,
-                cv2.THRESH_BINARY)
-            eroded = cv2.erode(
-                thresholded,
-                cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (3, 3)))
-            imglog.imwrite("absdiff_threshold", thresholded)
-            imglog.imwrite("absdiff_threshold_erode", eroded)
-
-            out_region = _pixel_bounding_box(eroded)
-            if out_region:
-                # Undo cv2.erode above:
-                out_region = out_region.extend(x=-1, y=-1)
-                # Undo crop:
-                out_region = out_region.translate(region.x, region.y)
-
-            motion = bool(out_region)
-
-            result = MotionResult(getattr(frame, "time", None), motion,
-                                  out_region, frame)
-            draw_on(frame, result, label="detect_motion()")
-            debug("%s found: %s" % (
-                "Motion" if motion else "No motion", str(result)))
-            yield result
-
     def wait_for_match(self, image, timeout_secs=10, consecutive_matches=1,
                        match_parameters=None, region=Region.ALL):
 
@@ -824,55 +669,6 @@ class DeviceUnderTest(object):
                     i += 1
                 else:
                     raise
-
-    def wait_for_motion(
-            self, timeout_secs=10, consecutive_frames=None,
-            noise_threshold=None, mask=None, region=Region.ALL):
-
-        if consecutive_frames is None:
-            consecutive_frames = get_config('motion', 'consecutive_frames')
-
-        consecutive_frames = str(consecutive_frames)
-        if '/' in consecutive_frames:
-            motion_frames = int(consecutive_frames.split('/')[0])
-            considered_frames = int(consecutive_frames.split('/')[1])
-        else:
-            motion_frames = int(consecutive_frames)
-            considered_frames = int(consecutive_frames)
-
-        if motion_frames > considered_frames:
-            raise ConfigurationError(
-                "`motion_frames` exceeds `considered_frames`")
-
-        debug("Waiting for %d out of %d frames with motion" % (
-            motion_frames, considered_frames))
-
-        if mask is None:
-            mask = _ImageFromUser(None, None, None)
-        else:
-            mask = _load_image(mask, cv2.IMREAD_GRAYSCALE)
-            debug("Using mask %s" % mask.friendly_name)
-
-        matches = deque(maxlen=considered_frames)
-        motion_count = 0
-        for res in self.detect_motion(timeout_secs, noise_threshold, mask,
-                                      region):
-            motion_count += bool(res)
-            if len(matches) == matches.maxlen:
-                motion_count -= bool(matches.popleft())
-            matches.append(res)
-            if motion_count >= motion_frames:
-                debug("Motion detected.")
-                # We want to return the first True motion result as this is when
-                # the motion actually started.
-                for result in matches:
-                    if result:
-                        return result
-                assert False, ("Logic error in wait_for_motion: This code "
-                               "should never be reached")
-
-        screenshot = self.get_frame()
-        raise MotionTimeout(screenshot, mask.friendly_name, timeout_secs)
 
     def ocr(self, frame=None, region=Region.ALL,
             mode=OcrMode.PAGE_SEGMENTATION_WITHOUT_OSD,
@@ -1276,30 +1072,6 @@ class MatchTimeout(UITestFailure):
     def __str__(self):
         return "Didn't find match for '%s' within %g seconds." % (
             self.expected, self.timeout_secs)
-
-
-class MotionTimeout(UITestFailure):
-    """Exception raised by `wait_for_motion`.
-
-    :ivar Frame screenshot: The last video frame that `wait_for_motion` checked
-        before timing out.
-
-    :vartype mask: str or None
-    :ivar mask: Filename of the mask that was used, if any.
-
-    :vartype timeout_secs: int or float
-    :ivar timeout_secs: Number of seconds that motion was searched for.
-    """
-    def __init__(self, screenshot, mask, timeout_secs):
-        super(MotionTimeout, self).__init__()
-        self.screenshot = screenshot
-        self.mask = mask
-        self.timeout_secs = timeout_secs
-
-    def __str__(self):
-        return "Didn't find motion%s within %g seconds." % (
-            " (with mask '%s')" % self.mask if self.mask else "",
-            self.timeout_secs)
 
 
 class PreconditionError(UITestError):

--- a/_stbt/gst_utils.py
+++ b/_stbt/gst_utils.py
@@ -95,15 +95,17 @@ class Frame(numpy.ndarray):
         is the same format used by the Python standard library function
         `time.time`.
     """
-    def __new__(cls, array, dtype=None, order=None, time=None):
+    def __new__(cls, array, dtype=None, order=None, time=None, _draw_sink=None):
         obj = numpy.asarray(array, dtype=dtype, order=order).view(cls)
         obj.time = time
+        obj._draw_sink = _draw_sink
         return obj
 
     def __array_finalize__(self, obj):
         if obj is None:
             return
         self.time = getattr(obj, 'time', None)  # pylint: disable=attribute-defined-outside-init
+        self._draw_sink = getattr(obj, '_draw_sink', None)  # pylint: disable=attribute-defined-outside-init
 
     def __repr__(self):
         if len(self.shape) == 3:

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -1,0 +1,164 @@
+import inspect
+import os
+from collections import namedtuple
+
+import cv2
+import numpy
+
+from .logging import ddebug
+from .types import Region
+
+
+class Frame(numpy.ndarray):
+    """A frame of video.
+
+    A ``Frame`` is what you get from `stbt.get_frame` and `stbt.frames`. It is
+    a subclass of `numpy.ndarray`, which is the type that OpenCV uses to
+    represent images. Data is stored in 8-bit, 3 channel BGR format.
+
+    In addition to the members inherited from `numpy.ndarray`, ``Frame``
+    defines the following attributes:
+
+    :ivar float time: The wall-clock time when this video-frame was captured,
+        as number of seconds since the unix epoch (1970-01-01T00:00:00Z). This
+        is the same format used by the Python standard library function
+        `time.time`.
+    """
+    def __new__(cls, array, dtype=None, order=None, time=None, _draw_sink=None):
+        obj = numpy.asarray(array, dtype=dtype, order=order).view(cls)
+        obj.time = time
+        obj._draw_sink = _draw_sink  # pylint: disable=protected-access
+        return obj
+
+    def __array_finalize__(self, obj):
+        if obj is None:
+            return
+        self.time = getattr(obj, 'time', None)  # pylint: disable=attribute-defined-outside-init
+        self._draw_sink = getattr(obj, '_draw_sink', None)  # pylint: disable=attribute-defined-outside-init
+
+    def __repr__(self):
+        if len(self.shape) == 3:
+            dimensions = "%dx%dx%d" % (
+                self.shape[1], self.shape[0], self.shape[2])
+        else:
+            dimensions = "%dx%d" % (self.shape[1], self.shape[0])
+        return "<stbt.Frame(time=%s, dimensions=%s)>" % (
+            "None" if self.time is None else "%.3f" % self.time,
+            dimensions)
+
+
+def _frame_repr(frame):
+    if frame is None:
+        return "None"
+    if isinstance(frame, Frame):
+        return repr(frame)
+    if len(frame.shape) == 3:
+        return "<%dx%dx%d>" % (frame.shape[1], frame.shape[0], frame.shape[2])
+    else:
+        return "<%dx%d>" % (frame.shape[1], frame.shape[0])
+
+
+def crop(frame, region):
+    """Returns an image containing the specified region of ``frame``.
+
+    :type frame: `stbt.Frame` or `numpy.ndarray`
+    :param frame: An image in OpenCV format (for example as returned by
+      `frames`, `get_frame` and `load_image`, or the ``frame`` parameter of
+      `MatchResult`).
+
+    :type Region region: The region to crop.
+
+    :returns: An OpenCV image (`numpy.ndarray`) containing the specified region
+      of the source frame. This is a view onto the original data, so if you
+      want to modify the cropped image call its ``copy()`` method first.
+    """
+    if not _image_region(frame).contains(region):
+        raise ValueError("frame with dimensions %r doesn't contain %r"
+                         % (frame.shape, region))
+    return frame[region.y:region.bottom, region.x:region.right]
+
+
+def _image_region(image):
+    s = image.shape
+    return Region(0, 0, s[1], s[0])
+
+
+class _ImageFromUser(namedtuple(
+        '_ImageFromUser',
+        'image relative_filename absolute_filename')):
+
+    @property
+    def friendly_name(self):
+        if self.image is None:
+            return None
+        return self.relative_filename or '<Custom Image>'
+
+
+def _load_image(image, flags=cv2.IMREAD_COLOR):
+    if isinstance(image, _ImageFromUser):
+        return image
+    if isinstance(image, numpy.ndarray):
+        return _ImageFromUser(image, None, None)
+    else:
+        relative_filename = image
+        absolute_filename = find_user_file(relative_filename)
+        if not absolute_filename:
+            raise IOError("No such file: %s" % relative_filename)
+        numpy_image = cv2.imread(absolute_filename, flags)
+        if numpy_image is None:
+            raise IOError("Failed to load image: %s" %
+                          absolute_filename)
+        return _ImageFromUser(numpy_image, relative_filename, absolute_filename)
+
+
+def find_user_file(filename):
+    """Searches for the given filename and returns the full path.
+
+    Searches in the directory of the script that called `load_image` (or
+    `match`, etc), then in the directory of that script's caller, etc.
+    Falls back to searching the current working directory.
+
+    :returns: Absolute filename, or None if it can't find the file.
+    """
+    if isinstance(filename, unicode):
+        filename = filename.encode("utf-8")
+
+    if os.path.isabs(filename) and os.path.isfile(filename):
+        return filename
+
+    # Start searching from the first parent stack-frame that is outside of
+    # the _stbt installation directory (this file's directory). We can ignore
+    # the first 2 stack-frames:
+    #
+    # * stack()[0] is _find_user_file;
+    # * stack()[1] is _find_user_file's caller: load_image or _load_image;
+    # * stack()[2] is load_image's caller (the user script). It could also be
+    #   _load_image's caller (e.g. `match`) so we still need to check until
+    #   we're outside of the _stbt directory.
+
+    _stbt_dir = os.path.abspath(os.path.dirname(__file__))
+    for caller in _iter_frames(depth=2):
+        caller_dir = os.path.abspath(
+            os.path.dirname(inspect.getframeinfo(caller).filename))
+        if caller_dir.startswith(_stbt_dir):
+            continue
+        caller_path = os.path.join(caller_dir, filename)
+        if os.path.isfile(caller_path):
+            ddebug("Resolved relative path %r to %r" % (filename, caller_path))
+            return caller_path
+
+    # Fall back to image from cwd, to allow loading an image saved previously
+    # during the same test-run.
+    if os.path.isfile(filename):
+        abspath = os.path.abspath(filename)
+        ddebug("Resolved relative path %r to %r" % (filename, abspath))
+        return abspath
+
+    return None
+
+
+def _iter_frames(depth=1):
+    frame = inspect.currentframe(depth + 1)
+    while frame:
+        yield frame
+        frame = frame.f_back

--- a/_stbt/logging.py
+++ b/_stbt/logging.py
@@ -142,3 +142,13 @@ def test_that_debug_can_write_unicode_strings():
             ddebug(u'Prüfungs Debug-Unicode')
     for level in [0, 1, 2]:
         yield (test, level)
+
+
+def draw_on(frame, *args, **kwargs):
+    draw_sink_ref = getattr(frame, '_draw_sink', None)
+    if not draw_sink_ref:
+        return
+    draw_sink = draw_sink_ref()
+    if not draw_sink:
+        return
+    draw_sink.draw(*args, **kwargs)

--- a/_stbt/motion.py
+++ b/_stbt/motion.py
@@ -1,0 +1,348 @@
+from collections import deque
+
+import cv2
+import numpy
+
+from .config import ConfigurationError, get_config
+from .imgutils import (_frame_repr, _image_region, _ImageFromUser, _load_image,
+                       crop)
+from .logging import debug, draw_on, ImageLogger
+from .types import Region, UITestFailure
+
+
+def detect_motion(timeout_secs=10, noise_threshold=None, mask=None,
+                  region=Region.ALL, frames=None):
+    """Generator that yields a sequence of one `MotionResult` for each frame
+    processed from the device-under-test's video stream.
+
+    The `MotionResult` indicates whether any motion was detected -- that is,
+    any difference between two consecutive frames.
+
+    :type timeout_secs: int or float or None
+    :param timeout_secs:
+        A timeout in seconds. After this timeout the iterator will be exhausted.
+        Thas is, a ``for`` loop like ``for m in detect_motion(timeout_secs=10)``
+        will terminate after 10 seconds. If ``timeout_secs`` is ``None`` then
+        the iterator will yield frames forever. Note that you can stop
+        iterating (for example with ``break``) at any time.
+
+    :param float noise_threshold:
+        The amount of noise to ignore. This is only useful with noisy analogue
+        video sources. Valid values range from 0 (all differences are
+        considered noise; a value of 0 will never report motion) to 1.0 (any
+        difference is considered motion).
+
+        This defaults to 0.84. You can override the global default value by
+        setting ``noise_threshold`` in the ``[motion]`` section of
+        :ref:`.stbt.conf`.
+
+    :type mask: str or `numpy.ndarray`
+    :param mask:
+        A black & white image that specifies which part of the image to search
+        for motion. White pixels select the area to analyse; black pixels select
+        the area to ignore. The mask must be the same size as the video frame.
+
+        This can be a string (a filename that will be resolved as per
+        `load_image`) or a single-channel image in OpenCV format.
+
+    :type region: `Region`
+    :param region:
+        Only analyze the specified region of the video frame.
+
+        If you specify both ``region`` and ``mask``, the mask must be the same
+        size as the region.
+
+    :type frames: Iterator[(stbt.Frame, int)]
+    :param frames: An iterable of Frames to analyse.  Defaults to
+        `stbt.frames()`
+
+    Added in v28: The ``region`` parameter.
+    Added in v29: The ``frames`` parameter.
+    """
+    if frames is None:
+        import stbt
+        frames = stbt.frames()
+
+    frames = limit_time(frames, timeout_secs)  # pylint: disable=redefined-variable-type
+
+    if noise_threshold is None:
+        noise_threshold = get_config(
+            'motion', 'noise_threshold', type_=float)
+
+    debug("Searching for motion")
+
+    if mask is None:
+        mask = _ImageFromUser(None, None, None)
+    else:
+        mask = _load_image(mask, cv2.IMREAD_GRAYSCALE)
+        debug("Using mask %s" % mask.friendly_name)
+
+    frame, _ = next(frames)
+
+    region = Region.intersect(_image_region(frame), region)
+
+    previous_frame_gray = cv2.cvtColor(crop(frame, region),
+                                       cv2.COLOR_BGR2GRAY)
+    if (mask.image is not None and
+            mask.image.shape[:2] != previous_frame_gray.shape[:2]):
+        raise ValueError(
+            "The dimensions of the mask '%s' %s don't match the "
+            "video frame %s" % (
+                mask.friendly_name, mask.image.shape,
+                previous_frame_gray.shape))
+
+    for frame, _ in frames:
+        frame_gray = cv2.cvtColor(crop(frame, region), cv2.COLOR_BGR2GRAY)
+
+        imglog = ImageLogger("detect_motion")
+        imglog.imwrite("source", frame_gray)
+
+        absdiff = cv2.absdiff(frame_gray, previous_frame_gray)
+        previous_frame_gray = frame_gray
+        imglog.imwrite("absdiff", absdiff)
+
+        if mask.image is not None:
+            absdiff = cv2.bitwise_and(absdiff, mask.image)
+            imglog.imwrite("mask", mask.image)
+            imglog.imwrite("absdiff_masked", absdiff)
+
+        _, thresholded = cv2.threshold(
+            absdiff, int((1 - noise_threshold) * 255), 255,
+            cv2.THRESH_BINARY)
+        eroded = cv2.erode(
+            thresholded,
+            cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (3, 3)))
+        imglog.imwrite("absdiff_threshold", thresholded)
+        imglog.imwrite("absdiff_threshold_erode", eroded)
+
+        out_region = _pixel_bounding_box(eroded)
+        if out_region:
+            # Undo cv2.erode above:
+            out_region = out_region.extend(x=-1, y=-1)
+            # Undo crop:
+            out_region = out_region.translate(region.x, region.y)
+
+        motion = bool(out_region)
+
+        result = MotionResult(getattr(frame, "time", None), motion,
+                              out_region, frame)
+        draw_on(frame, result, label="detect_motion()")
+        debug("%s found: %s" % (
+            "Motion" if motion else "No motion", str(result)))
+        yield result
+
+
+def _pixel_bounding_box(img):
+    """
+    Find the smallest region that contains all the non-zero pixels in an image.
+
+    >>> _pixel_bounding_box(numpy.array([[0]], dtype=numpy.uint8))
+    >>> _pixel_bounding_box(numpy.array([[1]], dtype=numpy.uint8))
+    Region(x=0, y=0, right=1, bottom=1)
+    >>> _pixel_bounding_box(numpy.array([
+    ...     [0, 0, 0, 0],
+    ...     [0, 1, 1, 1],
+    ...     [0, 1, 1, 1],
+    ...     [0, 0, 0, 0],
+    ... ], dtype=numpy.uint8))
+    Region(x=1, y=1, right=4, bottom=3)
+    >>> _pixel_bounding_box(numpy.array([
+    ...     [0, 0, 0, 0, 0, 0],
+    ...     [0, 0, 0, 1, 0, 0],
+    ...     [0, 1, 0, 0, 0, 0],
+    ...     [0, 0, 0, 0, 1, 0],
+    ...     [0, 0, 1, 0, 0, 0],
+    ...     [0, 0, 0, 0, 0, 0]
+    ... ], dtype=numpy.uint8))
+    Region(x=1, y=1, right=5, bottom=5)
+    """
+    if len(img.shape) != 2:
+        raise ValueError("Single-channel image required.  Provided image has "
+                         "shape %r" % (img.shape,))
+
+    out = [None, None, None, None]
+
+    for axis in (0, 1):
+        flat = numpy.any(img, axis=axis)
+        indices = numpy.where(flat)[0]
+        if len(indices) == 0:
+            return None
+        out[axis] = indices[0]
+        out[axis + 2] = indices[-1] + 1
+
+    return Region.from_extents(*out)
+
+
+def limit_time(frames, duration_secs):
+    """
+    Adapts a frame iterator such that it will return EOS after `duration_secs`
+    worth of video has been read.
+    """
+    import time
+    end_time = time.time() + duration_secs
+    for frame, ts in frames:
+        if frame.time > end_time:
+            debug("timed out: %.3f > %.3f" % (frame.time, end_time))
+            break
+        else:
+            yield frame, ts
+
+
+def wait_for_motion(
+        timeout_secs=10, consecutive_frames=None,
+        noise_threshold=None, mask=None, region=Region.ALL, frames=None):
+    """Search for motion in the device-under-test's video stream.
+
+    "Motion" is difference in pixel values between two consecutive frames.
+
+    :type timeout_secs: int or float or None
+    :param timeout_secs:
+        A timeout in seconds. This function will raise `MotionTimeout` if no
+        motion is detected within this time.
+
+    :type consecutive_frames: int or str
+    :param consecutive_frames:
+        Considers the video stream to have motion if there were differences
+        between the specified number of consecutive frames. This can be:
+
+        * a positive integer value, or
+        * a string in the form "x/y", where "x" is the number of frames with
+          motion detected out of a sliding window of "y" frames.
+
+        This defaults to "10/20". You can override the global default value by
+        setting ``consecutive_frames`` in the ``[motion]`` section of
+        :ref:`.stbt.conf`.
+
+    :param float noise_threshold: See `detect_motion`.
+
+    :param mask: See `detect_motion`.
+
+    :param region: See `detect_motion`.
+
+    :param frames: See `detect_motion`.
+
+    :returns: `MotionResult` when motion is detected. The MotionResult's
+        ``time`` and ``frame`` attributes correspond to the first frame in
+        which motion was detected.
+    :raises: `MotionTimeout` if no motion is detected after ``timeout_secs``
+        seconds.
+
+    Added in v28: The ``region`` parameter.
+    """
+    if frames is None:
+        import stbt
+        frames = stbt.frames()
+
+    if consecutive_frames is None:
+        consecutive_frames = get_config('motion', 'consecutive_frames')
+
+    consecutive_frames = str(consecutive_frames)
+    if '/' in consecutive_frames:
+        motion_frames = int(consecutive_frames.split('/')[0])
+        considered_frames = int(consecutive_frames.split('/')[1])
+    else:
+        motion_frames = int(consecutive_frames)
+        considered_frames = int(consecutive_frames)
+
+    if motion_frames > considered_frames:
+        raise ConfigurationError(
+            "`motion_frames` exceeds `considered_frames`")
+
+    debug("Waiting for %d out of %d frames with motion" % (
+        motion_frames, considered_frames))
+
+    if mask is None:
+        mask = _ImageFromUser(None, None, None)
+    else:
+        mask = _load_image(mask, cv2.IMREAD_GRAYSCALE)
+        debug("Using mask %s" % mask.friendly_name)
+
+    matches = deque(maxlen=considered_frames)
+    motion_count = 0
+    last_frame = None
+    for res in detect_motion(
+            timeout_secs, noise_threshold, mask, region, frames):
+        motion_count += bool(res)
+        if len(matches) == matches.maxlen:
+            motion_count -= bool(matches.popleft())
+        matches.append(res)
+        if motion_count >= motion_frames:
+            debug("Motion detected.")
+            # We want to return the first True motion result as this is when
+            # the motion actually started.
+            for result in matches:
+                if result:
+                    return result
+            assert False, ("Logic error in wait_for_motion: This code "
+                           "should never be reached")
+        last_frame = res.frame
+
+    raise MotionTimeout(last_frame, mask.friendly_name, timeout_secs)
+
+
+class MotionResult(object):
+    """The result from `detect_motion` and `wait_for_motion`.
+
+    :ivar float time: The time at which the video-frame was captured, in
+        seconds since 1970-01-01T00:00Z. This timestamp can be compared with
+        system time (``time.time()``).
+
+    :ivar bool motion: True if motion was found. This is the same as evaluating
+        ``MotionResult`` as a bool. That is, ``if result:`` will behave the
+        same as ``if result.motion:``.
+
+    :ivar Region region: Bounding box where the motion was found, or ``None``
+        if no motion was found.
+
+    :ivar Frame frame: The video frame in which motion was (or wasn't) found.
+
+    :ivar int timestamp: DEPRECATED. Timestamp in nanoseconds. Use ``time``
+        instead.
+
+    Added in v28: The ``frame`` attribute.
+    """
+    def __init__(self, time, motion, region, frame):
+        self.time = time
+        self.motion = motion
+        self.region = region
+        self.frame = frame
+
+    def __nonzero__(self):
+        return self.motion
+
+    def __repr__(self):
+        return (
+            "MotionResult(time=%s, motion=%r, region=%r, frame=%s)" % (
+                "None" if self.time is None else "%.3f" % self.time,
+                self.motion, self.region, _frame_repr(self.frame)))
+
+    @property
+    def timestamp(self):
+        if self.time is None:
+            return None
+        else:
+            return int(self.time * 1e9)
+
+
+class MotionTimeout(UITestFailure):
+    """Exception raised by `wait_for_motion`.
+
+    :ivar Frame screenshot: The last video frame that `wait_for_motion` checked
+        before timing out.
+
+    :vartype mask: str or None
+    :ivar mask: Filename of the mask that was used, if any.
+
+    :vartype timeout_secs: int or float
+    :ivar timeout_secs: Number of seconds that motion was searched for.
+    """
+    def __init__(self, screenshot, mask, timeout_secs):
+        super(MotionTimeout, self).__init__()
+        self.screenshot = screenshot
+        self.mask = mask
+        self.timeout_secs = timeout_secs
+
+    def __str__(self):
+        return "Didn't find motion%s within %g seconds." % (
+            " (with mask '%s')" % self.mask if self.mask else "",
+            self.timeout_secs)

--- a/_stbt/types.py
+++ b/_stbt/types.py
@@ -1,0 +1,290 @@
+# coding: utf-8
+# Don't import anything not in the Python standard library from this file
+
+from collections import namedtuple
+
+
+class Region(namedtuple('Region', 'x y right bottom')):
+    u"""
+    ``Region(x, y, width=width, height=height)`` or
+    ``Region(x, y, right=right, bottom=bottom)``
+
+    Rectangular region within the video frame.
+
+    For example, given the following regions a, b, and c::
+
+        - 01234567890123
+        0 ░░░░░░░░
+        1 ░a░░░░░░
+        2 ░░░░░░░░
+        3 ░░░░░░░░
+        4 ░░░░▓▓▓▓░░▓c▓
+        5 ░░░░▓▓▓▓░░▓▓▓
+        6 ░░░░▓▓▓▓░░░░░
+        7 ░░░░▓▓▓▓░░░░░
+        8     ░░░░░░b░░
+        9     ░░░░░░░░░
+
+    >>> a = Region(0, 0, width=8, height=8)
+    >>> b = Region(4, 4, right=13, bottom=10)
+    >>> c = Region(10, 4, width=3, height=2)
+    >>> a.right
+    8
+    >>> b.bottom
+    10
+    >>> b.contains(c), a.contains(b), c.contains(b)
+    (True, False, False)
+    >>> b.extend(x=6, bottom=-4) == c
+    True
+    >>> a.extend(right=5).contains(c)
+    True
+    >>> a.width, a.extend(x=3).width, a.extend(right=-3).width
+    (8, 5, 5)
+    >>> c.replace(bottom=10)
+    Region(x=10, y=4, right=13, bottom=10)
+    >>> Region.intersect(a, b)
+    Region(x=4, y=4, right=8, bottom=8)
+    >>> Region.intersect(a, b) == Region.intersect(b, a)
+    True
+    >>> Region.intersect(c, b) == c
+    True
+    >>> print Region.intersect(a, c)
+    None
+    >>> print Region.intersect(None, a)
+    None
+    >>> quadrant = Region(x=float("-inf"), y=float("-inf"), right=0, bottom=0)
+    >>> quadrant.translate(2, 2)
+    Region(x=-inf, y=-inf, right=2, bottom=2)
+    >>> c.translate(x=-9, y=-3)
+    Region(x=1, y=1, right=4, bottom=3)
+    >>> Region.intersect(Region.ALL, c) == c
+    True
+    >>> Region.ALL
+    Region.ALL
+    >>> print Region.ALL
+    Region.ALL
+    >>> c.above()
+    Region(x=10, y=-inf, right=13, bottom=4)
+    >>> c.below()
+    Region(x=10, y=6, right=13, bottom=inf)
+    >>> a.right_of()
+    Region(x=8, y=0, right=inf, bottom=8)
+    >>> a.right_of(width=2)
+    Region(x=8, y=0, right=10, bottom=8)
+    >>> c.left_of()
+    Region(x=-inf, y=4, right=10, bottom=6)
+
+    .. py:attribute:: x
+
+        The x coordinate of the left edge of the region, measured in pixels
+        from the left of the video frame (inclusive).
+
+    .. py:attribute:: y
+
+        The y coordinate of the top edge of the region, measured in pixels from
+        the top of the video frame (inclusive).
+
+    .. py:attribute:: right
+
+        The x coordinate of the right edge of the region, measured in pixels
+        from the left of the video frame (exclusive).
+
+    .. py:attribute:: bottom
+
+        The y coordinate of the bottom edge of the region, measured in pixels
+        from the top of the video frame (exclusive).
+
+    ``x``, ``y``, ``right``, and ``bottom`` can be infinite -- that is,
+    ``float("inf")`` or ``-float("inf")``.
+    """
+    def __new__(cls, x, y, width=None, height=None, right=None, bottom=None):
+        if (width is None) == (right is None):
+            raise ValueError("You must specify either 'width' or 'right'")
+        if (height is None) == (bottom is None):
+            raise ValueError("You must specify either 'height' or 'bottom'")
+        if right is None:
+            right = x + width
+        if bottom is None:
+            bottom = y + height
+        if right <= x:
+            raise ValueError("'right' must be greater than 'x'")
+        if bottom <= y:
+            raise ValueError("'bottom' must be greater than 'y'")
+        return super(Region, cls).__new__(cls, x, y, right, bottom)
+
+    def __repr__(self):
+        if self == Region.ALL:
+            return 'Region.ALL'
+        else:
+            return 'Region(x=%r, y=%r, right=%r, bottom=%r)' \
+                % (self.x, self.y, self.right, self.bottom)
+
+    @property
+    def width(self):
+        """The width of the region, measured in pixels."""
+        return self.right - self.x
+
+    @property
+    def height(self):
+        """The height of the region, measured in pixels."""
+        return self.bottom - self.y
+
+    @staticmethod
+    def from_extents(x, y, right, bottom):
+        """Create a Region using right and bottom extents rather than width and
+        height.
+
+        Typically you'd use the ``right`` and ``bottom`` parameters of the
+        ``Region`` constructor instead, but this factory function is useful
+        if you need to create a ``Region`` from a tuple.
+
+        >>> extents = (4, 4, 13, 10)
+        >>> Region.from_extents(*extents)
+        Region(x=4, y=4, right=13, bottom=10)
+        """
+        return Region(x, y, right=right, bottom=bottom)
+
+    @staticmethod
+    def intersect(a, b):
+        """
+        :returns: The intersection of regions ``a`` and ``b``, or ``None`` if
+            the regions don't intersect.
+
+        Either ``a`` or ``b`` can be ``None`` so intersect is commutative and
+        associative.
+        """
+        if a is None or b is None:
+            return None
+        else:
+            extents = (max(a.x, b.x), max(a.y, b.y),
+                       min(a.right, b.right), min(a.bottom, b.bottom))
+            if extents[0] < extents[2] and extents[1] < extents[3]:
+                return Region.from_extents(*extents)
+            else:
+                return None
+
+    def contains(self, other):
+        """:returns: True if ``other`` is entirely contained within self."""
+        return (other and self.x <= other.x and self.y <= other.y and
+                self.right >= other.right and self.bottom >= other.bottom)
+
+    def extend(self, x=0, y=0, right=0, bottom=0):
+        """
+        :returns: A new region with the edges of the region adjusted by the
+            given amounts.
+        """
+        return Region.from_extents(
+            self.x + x, self.y + y, self.right + right, self.bottom + bottom)
+
+    def replace(self, x=None, y=None, width=None, height=None, right=None,
+                bottom=None):
+        """
+        :returns: A new region with the edges of the region set to the given
+            coordinates.
+
+        This is similar to `extend`, but it takes absolute coordinates within
+        the image instead of adjusting by a relative number of pixels.
+        """
+        def norm_coords(name_x, name_width, name_right,
+                        x, width, right,  # or y, height, bottom
+                        default_x, _default_width, default_right):
+            if all(z is not None for z in (x, width, right)):
+                raise ValueError(
+                    "Region.replace: Argument conflict: you may only specify "
+                    "two of %s, %s and %s.  You specified %s=%s, %s=%s and "
+                    "%s=%s" % (name_x, name_width, name_right,
+                               name_x, x, name_width, width, name_right, right))
+            if x is None:
+                if width is not None and right is not None:
+                    x = right - width
+                else:
+                    x = default_x
+            if right is None:
+                right = x + width if width is not None else default_right
+            return x, right
+
+        x, right = norm_coords('x', 'width', 'right', x, width, right,
+                               self.x, self.width, self.right)
+        y, bottom = norm_coords('y', 'height', 'bottom', y, height, bottom,
+                                self.y, self.height, self.bottom)
+
+        return Region(x=x, y=y, right=right, bottom=bottom)
+
+    def translate(self, x=0, y=0):
+        """
+        :returns: A new region with the position of the region adjusted by the
+            given amounts.
+        """
+        return Region.from_extents(self.x + x, self.y + y,
+                                   self.right + x, self.bottom + y)
+
+    def above(self, height=float('inf')):
+        """
+        :returns: A new region above the current region, extending to the top
+            of the frame (or to the specified height).
+        """
+        return self.replace(y=self.y - height, bottom=self.y)
+
+    def below(self, height=float('inf')):
+        """
+        :returns: A new region below the current region, extending to the bottom
+            of the frame (or to the specified height).
+        """
+        return self.replace(y=self.bottom, bottom=self.bottom + height)
+
+    def right_of(self, width=float('inf')):
+        """
+        :returns: A new region to the right of the current region, extending to
+            the right edge of the frame (or to the specified width).
+        """
+        return self.replace(x=self.right, right=self.right + width)
+
+    def left_of(self, width=float('inf')):
+        """
+        :returns: A new region to the left of the current region, extending to
+            the left edge of the frame (or to the specified width).
+        """
+        return self.replace(x=self.x - width, right=self.x)
+
+    @staticmethod
+    def bounding_box(a, b):
+        """Find the bounding box of two regions.  Returns the smallest region
+        which contains both regions a and b.
+
+        >>> Region.bounding_box(Region(50, 20, 10, 20), Region(20, 30, 10, 20))
+        Region(x=20, y=20, right=60, bottom=50)
+        >>> Region.bounding_box(Region(20, 30, 10, 20), Region(20, 30, 10, 20))
+        Region(x=20, y=30, right=30, bottom=50)
+        >>> Region.bounding_box(None, Region(20, 30, 10, 20))
+        Region(x=20, y=30, right=30, bottom=50)
+        >>> Region.bounding_box(Region(20, 30, 10, 20), None)
+        Region(x=20, y=30, right=30, bottom=50)
+        >>> Region.bounding_box(Region(20, 30, 10, 20), Region.ALL)
+        Region.ALL
+        >>> print Region.bounding_box(None, None)
+        None
+        """
+        if a is None:
+            return b
+        if b is None:
+            return a
+        return Region.from_extents(min(a.x, b.x), min(a.y, b.y),
+                                   max(a.right, b.right),
+                                   max(a.bottom, b.bottom))
+
+
+Region.ALL = Region(x=-float('inf'), y=-float('inf'),
+                    right=float('inf'), bottom=float('inf'))
+
+
+class UITestError(Exception):
+    """The test script had an unrecoverable error."""
+    pass
+
+
+class UITestFailure(Exception):
+    """The test failed because the device under test didn't behave as expected.
+
+    Inherit from this if you need to define your own test-failure exceptions.
+    """
+    pass

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -26,8 +26,6 @@ from _stbt.core import \
     MatchParameters, \
     MatchResult, \
     MatchTimeout, \
-    MotionResult, \
-    MotionTimeout, \
     NoVideo, \
     OcrMode, \
     Position, \
@@ -38,6 +36,11 @@ from _stbt.core import \
     UITestError, \
     UITestFailure, \
     wait_until
+from _stbt.motion import (
+    detect_motion,
+    MotionResult,
+    MotionTimeout,
+    wait_for_motion)
 from _stbt.transition import \
     press_and_wait, \
     TransitionStatus, \
@@ -237,53 +240,6 @@ def detect_match(image, timeout_secs=10, match_parameters=None,
     return _dut.detect_match(image, timeout_secs, match_parameters, region)
 
 
-def detect_motion(timeout_secs=10, noise_threshold=None, mask=None,
-                  region=Region.ALL):
-    """Generator that yields a sequence of one `MotionResult` for each frame
-    processed from the device-under-test's video stream.
-
-    The `MotionResult` indicates whether any motion was detected -- that is,
-    any difference between two consecutive frames.
-
-    :type timeout_secs: int or float or None
-    :param timeout_secs:
-        A timeout in seconds. After this timeout the iterator will be exhausted.
-        Thas is, a ``for`` loop like ``for m in detect_motion(timeout_secs=10)``
-        will terminate after 10 seconds. If ``timeout_secs`` is ``None`` then
-        the iterator will yield frames forever. Note that you can stop
-        iterating (for example with ``break``) at any time.
-
-    :param float noise_threshold:
-        The amount of noise to ignore. This is only useful with noisy analogue
-        video sources. Valid values range from 0 (all differences are
-        considered noise; a value of 0 will never report motion) to 1.0 (any
-        difference is considered motion).
-
-        This defaults to 0.84. You can override the global default value by
-        setting ``noise_threshold`` in the ``[motion]`` section of
-        :ref:`.stbt.conf`.
-
-    :type mask: str or `numpy.ndarray`
-    :param mask:
-        A black & white image that specifies which part of the image to search
-        for motion. White pixels select the area to analyse; black pixels select
-        the area to ignore. The mask must be the same size as the video frame.
-
-        This can be a string (a filename that will be resolved as per
-        `load_image`) or a single-channel image in OpenCV format.
-
-    :type region: `Region`
-    :param region:
-        Only analyze the specified region of the video frame.
-
-        If you specify both ``region`` and ``mask``, the mask must be the same
-        size as the region.
-
-    Added in v28: The ``region`` parameter.
-    """
-    return _dut.detect_motion(timeout_secs, noise_threshold, mask, region)
-
-
 def wait_for_match(image, timeout_secs=10, consecutive_matches=1,
                    match_parameters=None, region=Region.ALL):
     """Search for an image in the device-under-test's video stream.
@@ -349,49 +305,6 @@ def press_until_match(
     """
     return _dut.press_until_match(
         key, image, interval_secs, max_presses, match_parameters, region)
-
-
-def wait_for_motion(
-        timeout_secs=10, consecutive_frames=None,
-        noise_threshold=None, mask=None, region=Region.ALL):
-    """Search for motion in the device-under-test's video stream.
-
-    "Motion" is difference in pixel values between two consecutive frames.
-
-    :type timeout_secs: int or float or None
-    :param timeout_secs:
-        A timeout in seconds. This function will raise `MotionTimeout` if no
-        motion is detected within this time.
-
-    :type consecutive_frames: int or str
-    :param consecutive_frames:
-        Considers the video stream to have motion if there were differences
-        between the specified number of consecutive frames. This can be:
-
-        * a positive integer value, or
-        * a string in the form "x/y", where "x" is the number of frames with
-          motion detected out of a sliding window of "y" frames.
-
-        This defaults to "10/20". You can override the global default value by
-        setting ``consecutive_frames`` in the ``[motion]`` section of
-        :ref:`.stbt.conf`.
-
-    :param float noise_threshold: See `detect_motion`.
-
-    :param mask: See `detect_motion`.
-
-    :param region: See `detect_motion`.
-
-    :returns: `MotionResult` when motion is detected. The MotionResult's
-        ``time`` and ``frame`` attributes correspond to the first frame in
-        which motion was detected.
-    :raises: `MotionTimeout` if no motion is detected after ``timeout_secs``
-        seconds.
-
-    Added in v28: The ``region`` parameter.
-    """
-    return _dut.wait_for_motion(
-        timeout_secs, consecutive_frames, noise_threshold, mask, region)
 
 
 def ocr(frame=None, region=Region.ALL,

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -1,6 +1,8 @@
+import time
 from contextlib import contextmanager
 
 import numpy
+import pytest
 
 import stbt
 
@@ -18,51 +20,48 @@ def test_motionresult_repr():
 
 
 def test_wait_for_motion_half_motion_str_2of4():
-    with _fake_frames_at_half_motion() as dut:
-        res = dut.wait_for_motion(consecutive_frames='2/4')
-        print res
-        assert res.time == 1466084606.
+    with MockTime().patch():
+        res = stbt.wait_for_motion(
+            consecutive_frames='2/4', frames=fake_frames())
+    print res
+    assert res.time == 1466084606.
 
 
 def test_wait_for_motion_half_motion_str_2of3():
-    with _fake_frames_at_half_motion() as dut:
-        res = dut.wait_for_motion(consecutive_frames='2/3')
-        print res
-        assert res.time == 1466084606.
+    with MockTime().patch():
+        res = stbt.wait_for_motion(
+            consecutive_frames='2/3', frames=fake_frames())
+    print res
+    assert res.time == 1466084606.
 
 
 def test_wait_for_motion_half_motion_str_4of10():
-    with _fake_frames_at_half_motion() as dut:
+    with MockTime().patch():
         # Time is not affected by consecutive_frames parameter
-        res = dut.wait_for_motion(consecutive_frames='4/10', timeout_secs=20)
-        assert res.time == 1466084606.
+        res = stbt.wait_for_motion(
+            consecutive_frames='4/10', timeout_secs=20, frames=fake_frames())
+    assert res.time == 1466084606.
 
 
 def test_wait_for_motion_half_motion_str_3of4():
-    with _fake_frames_at_half_motion() as dut:
-        try:
-            dut.wait_for_motion(consecutive_frames='3/4')
-            assert False, "wait_for_motion succeeded unexpectedly"
-        except stbt.MotionTimeout:
-            pass
+    try:
+        with MockTime().patch():
+            stbt.wait_for_motion(consecutive_frames='3/4', frames=fake_frames())
+        assert False, "wait_for_motion succeeded unexpectedly"
+    except stbt.MotionTimeout:
+        pass
 
 
 def test_wait_for_motion_half_motion_int():
-    with _fake_frames_at_half_motion() as dut:
-        try:
-            dut.wait_for_motion(consecutive_frames=2)
-            assert False, "wait_for_motion succeeded unexpectedly"
-        except stbt.MotionTimeout:
-            pass
+    with pytest.raises(stbt.MotionTimeout), MockTime().patch():
+        stbt.wait_for_motion(consecutive_frames=2, frames=fake_frames())
 
 
-@contextmanager
-def _fake_frames_at_half_motion():
-    from _stbt.core import DeviceUnderTest, NoSinkPipeline
-
-    FRAMES = []
+def fake_frames():
     a = numpy.zeros((2, 2, 3), dtype=numpy.uint8)
+    a.flags.writeable = False
     b = numpy.ones((2, 2, 3), dtype=numpy.uint8) * 255
+    b.flags.writeable = False
 
     # Motion:                 v     v     v     v     v     v     v     v     v
     data = [a, a, a, a, a, a, b, b, a, a, b, b, a, a, b, b, a, a, b, b, a, a, b]
@@ -70,27 +69,47 @@ def _fake_frames_at_half_motion():
     #       |                 L Motion starts here at timestamp 1466084606.
     #       L Video starts here at timestamp 1466084600
 
-    FRAMES = [stbt.Frame(x, time=1466084600. + n) for n, x in enumerate(data)]
+    start_time = time.time()
+    for n, x in enumerate(data):
+        t = start_time + n
+        time.sleep(t - time.time())
+        yield stbt.Frame(x, time=t), t * 1e9
 
-    class FakeDisplay(object):
-        def get_frame(self, timeout_secs=10, since=0):  # pylint: disable=unused-argument
-            for f in FRAMES:
-                if f.time > since:
-                    return f
-            f = FRAMES[-1].copy()
-            f.time = since + 1
-            return f
 
-    class FakeTime(object):
-        def __init__(self, now):
-            self._now = now
+class MockTime(object):
+    def __init__(self, start_time=1466084600.):
+        self._time = start_time
+        self._functions = []
 
-        def time(self):
-            return self._now
+    def time(self):
+        t = self._time
+        return t
 
-        def sleep(self, duration):
-            self._now += duration
+    def sleep(self, seconds):
+        while self._functions and self._functions[0][0] <= self._time + seconds:
+            _, fn = self._functions.pop(0)
+            fn()
 
-    dut = DeviceUnderTest(display=FakeDisplay(), sink_pipeline=NoSinkPipeline(),
-                          _time=FakeTime(FRAMES[0].time))
-    yield dut
+        self._time += seconds
+
+    def interrupt(self, exception):
+        def raise_exception():
+            raise exception
+        self.at(0, raise_exception)
+
+    def at(self, offset, function):
+        self._functions.append((self._time + offset, function))
+        self._functions.sort()
+
+    @contextmanager
+    def assert_duration(self, seconds):
+        start_time = self._time
+        yield self
+        assert self._time - start_time == seconds
+
+    @contextmanager
+    def patch(self):
+        from mock import patch
+        with patch("time.time", self.time), \
+                patch("time.sleep", self.sleep):
+            yield self


### PR DESCRIPTION
They are no longer members of `DeviceUnderTest` so we no-longer need to
have forwarding implementations in `stbt/__init__.py`.

I think this general model makes some sense.  The different image
processing bits are no longer bound so tightly together.  But we make a
concession to convenience - frames defaults to `stbt.frames()`.  By
introducing this impurity we maintain the convenience of the existing API.
It makes the tests cleaner too.