### PR TITLE
stbt.frames: Change return type to Iterator[Frame]

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -201,9 +201,6 @@ class MatchResult(object):
     :ivar Frame frame: The video frame that was searched, as given to `match`.
 
     :ivar image: The reference image that was searched for, as given to `match`.
-
-    :ivar int timestamp: DEPRECATED. Timestamp in nanoseconds. Use ``time``
-        instead.
     """
     def __init__(
             self, time, match, region, first_pass_result, frame, image,
@@ -234,13 +231,6 @@ class MatchResult(object):
     @property
     def position(self):
         return Position(self.region.x, self.region.y)
-
-    @property
-    def timestamp(self):
-        if self.time is None:
-            return None
-        else:
-            return int(self.time * 1e9)
 
 
 def load_image(filename, flags=cv2.IMREAD_COLOR):
@@ -338,9 +328,6 @@ class TextMatchResult(object):
 
     :ivar unicode text: The text that was searched for, as given to
         `match_text`.
-
-    :ivar int timestamp: DEPRECATED. Timestamp in nanoseconds. Use ``time``
-        instead.
     """
     def __init__(self, time, match, region, frame, text):
         self.time = time
@@ -362,13 +349,6 @@ class TextMatchResult(object):
                 self.region,
                 _frame_repr(self.frame),
                 self.text))
-
-    @property
-    def timestamp(self):
-        if self.time is None:
-            return None
-        else:
-            return int(self.time * 1e9)
 
 
 def new_device_under_test_from_config(

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -605,11 +605,11 @@ class DeviceUnderTest(object):
 
         debug("Searching for " + template.friendly_name)
 
-        for sample, _ in self.frames(timeout_secs):
+        for frame in self.frames(timeout_secs):
             result = self.match(
-                template, frame=sample, match_parameters=match_parameters,
+                template, frame=frame, match_parameters=match_parameters,
                 region=region)
-            draw_on(sample, result, label="match(%r)" %
+            draw_on(frame, result, label="match(%r)" %
                     os.path.basename(template.friendly_name))
             yield result
 
@@ -771,7 +771,7 @@ class DeviceUnderTest(object):
                 debug("timed out: %.3f > %.3f" % (timestamp, end_time))
                 return
 
-            yield frame, int(frame.time * 1e9)
+            yield frame
             first = False
 
     def get_frame(self):

--- a/_stbt/motion.py
+++ b/_stbt/motion.py
@@ -56,8 +56,8 @@ def detect_motion(timeout_secs=10, noise_threshold=None, mask=None,
     :param frames: An iterable of video-frames to analyse. Defaults to
         ``stbt.frames()``.
 
-    Added in v28: The ``region`` parameter.
-    Added in v29: The ``frames`` parameter.
+    | Added in v28: The ``region`` parameter.
+    | Added in v29: The ``frames`` parameter.
     """
     if frames is None:
         import stbt

--- a/_stbt/motion.py
+++ b/_stbt/motion.py
@@ -52,9 +52,9 @@ def detect_motion(timeout_secs=10, noise_threshold=None, mask=None,
         If you specify both ``region`` and ``mask``, the mask must be the same
         size as the region.
 
-    :type frames: Iterator[(stbt.Frame, int)]
-    :param frames: An iterable of Frames to analyse.  Defaults to
-        `stbt.frames()`
+    :type frames: Iterator[stbt.Frame]
+    :param frames: An iterable of video-frames to analyse. Defaults to
+        ``stbt.frames()``.
 
     Added in v28: The ``region`` parameter.
     Added in v29: The ``frames`` parameter.
@@ -77,7 +77,7 @@ def detect_motion(timeout_secs=10, noise_threshold=None, mask=None,
         mask = _load_image(mask, cv2.IMREAD_GRAYSCALE)
         debug("Using mask %s" % mask.friendly_name)
 
-    frame, _ = next(frames)
+    frame = next(frames)
 
     region = Region.intersect(_image_region(frame), region)
 
@@ -91,7 +91,7 @@ def detect_motion(timeout_secs=10, noise_threshold=None, mask=None,
                 mask.friendly_name, mask.image.shape,
                 previous_frame_gray.shape))
 
-    for frame, _ in frames:
+    for frame in frames:
         frame_gray = cv2.cvtColor(crop(frame, region), cv2.COLOR_BGR2GRAY)
 
         imglog = ImageLogger("detect_motion")
@@ -180,12 +180,12 @@ def limit_time(frames, duration_secs):
     """
     import time
     end_time = time.time() + duration_secs
-    for frame, ts in frames:
+    for frame in frames:
         if frame.time > end_time:
             debug("timed out: %.3f > %.3f" % (frame.time, end_time))
             break
         else:
-            yield frame, ts
+            yield frame
 
 
 def wait_for_motion(

--- a/_stbt/motion.py
+++ b/_stbt/motion.py
@@ -296,9 +296,6 @@ class MotionResult(object):
 
     :ivar Frame frame: The video frame in which motion was (or wasn't) found.
 
-    :ivar int timestamp: DEPRECATED. Timestamp in nanoseconds. Use ``time``
-        instead.
-
     Added in v28: The ``frame`` attribute.
     """
     def __init__(self, time, motion, region, frame):
@@ -315,13 +312,6 @@ class MotionResult(object):
             "MotionResult(time=%s, motion=%r, region=%r, frame=%s)" % (
                 "None" if self.time is None else "%.3f" % self.time,
                 self.motion, self.region, _frame_repr(self.frame)))
-
-    @property
-    def timestamp(self):
-        if self.time is None:
-            return None
-        else:
-            return int(self.time * 1e9)
 
 
 class MotionTimeout(UITestFailure):

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -145,14 +145,14 @@ class _Transition(object):
         self.expiry_time = None
 
     def press_and_wait(self, key):
-        original_frame, _ = next(self.frames)
+        original_frame = next(self.frames)
         self.dut.press(key)
         press_time = time.time()
         stbt.debug("transition: %.3f: Pressed %s" % (press_time, key))
         self.expiry_time = press_time + self.timeout_secs
 
         # Wait for animation to start
-        for f, _ in self.frames:
+        for f in self.frames:
             if f.time < press_time:
                 # Discard frame to work around latency in video-capture pipeline
                 continue
@@ -176,14 +176,14 @@ class _Transition(object):
 
     def wait_for_transition_to_end(self, initial_frame):
         if initial_frame is None:
-            initial_frame, _ = next(self.frames)
+            initial_frame = next(self.frames)
         if self.expiry_time is None:
             self.expiry_time = initial_frame.time + self.timeout_secs
 
         f = first_stable_frame = initial_frame
         while True:
             prev = f
-            f, _ = next(self.frames)
+            f = next(self.frames)
             if self.diff(prev, f, self.region, self.mask_image):
                 _debug("Animation in progress", f)
                 first_stable_frame = f

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -40,6 +40,10 @@ open-source project, or update [test_pack.stbt_version] if you're using the
 
         for frame in stbt.frames():
 
+* Similarly, removed the deprecated `timestamp` attribute (nanoseconds) from
+  `stbt.MatchResult`, `stbt.TextMatchResult`, and `stbt.MotionResult`. Use the
+  `time` attribute instead (seconds).
+
 * `stbt.is_screen_black` returns an object with `black` and `frame` attributes,
   instead of a bool. This evaluates to truthy or falsey so this change is
   backwards compatible, unless you were explicitly comparing the result with

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -29,6 +29,17 @@ open-source project, or update [test_pack.stbt_version] if you're using the
 
 ##### Breaking changes since v28
 
+* `stbt.frames()` returns an iterator of `stbt.Frame` objects, instead of an
+  iterator of tuples `(stbt.Frame, int)`. The second field of the tuple was a
+  timestamp in nanoseconds; this has been deprecated since we added
+  `stbt.Frame.time` in v26, 2 years ago. If you were calling it like this:
+
+        for frame, _ in stbt.frames():
+
+  then you should change it to this:
+
+        for frame in stbt.frames():
+
 * `stbt.is_screen_black` returns an object with `black` and `frame` attributes,
   instead of a bool. This evaluates to truthy or falsey so this change is
   backwards compatible, unless you were explicitly comparing the result with
@@ -46,7 +57,7 @@ open-source project, or update [test_pack.stbt_version] if you're using the
 * `stbt run` will no longer show an output video window by default. This is a
   better default for headless environments like stbt-docker.  You can re-enable
   this by setting `global.sink_pipeline = xvimagesink sync=false` in your
-  `$HOME/.config/stbt/stbt.conf`.
+  stbt.conf file.
 
 * Remove tracing infrastructure (which would report the current test & line
   number to a file specified via the `--save-trace` argument or to a socket
@@ -70,6 +81,10 @@ open-source project, or update [test_pack.stbt_version] if you're using the
 
 * `stbt.android.AdbDevice.press` will convert some standard Stb-tester key
   names like "KEY_OK" to the equivalent Android KeyEvent keycodes.
+
+* `stbt.wait_for_motion` and `stbt.detect_motion` take a new optional `frames`
+  parameter. This defaults to `stbt.frames()` which preserves the existing
+  behaviour.
 
 * If your test-pack is a Python module (that is, it contains an `__init__.py`
   in each directory under `tests/`) then `stbt run` will automatically add the

--- a/stbt-camera.d/stbt_camera_calibrate.py
+++ b/stbt-camera.d/stbt_camera_calibrate.py
@@ -197,7 +197,7 @@ def analyse_colours_video(dut, number=None):
     errors_in_a_row = 0
     n = 0
     qrscanner = QRScanner()
-    for frame, _ in dut.frames():
+    for frame in dut.frames():
         if number is not None and n >= number:
             return
         n = n + 1
@@ -446,14 +446,14 @@ def _create_reference_png(dut, filename):
     average = None
     for frame in pop_with_progress(dut.frames(), FRAME_AVERAGE_COUNT):
         if average is None:
-            average = numpy.zeros(shape=frame[0].shape, dtype=numpy.uint16)
-        average += frame[0]
+            average = numpy.zeros(shape=frame.shape, dtype=numpy.uint16)
+        average += frame
     average /= FRAME_AVERAGE_COUNT
     cv2.imwrite(filename, numpy.array(average, dtype=numpy.uint8))
 
 
 def await_blank(dut, brightness):
-    for frame, _ in dut.frames(10):
+    for frame in dut.frames(10):
         grayscale = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
         min_, max_, _, _ = cv2.minMaxLoc(grayscale)
         contrast = max_ - min_

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -432,17 +432,14 @@ def frames(timeout_secs=None):
     :type timeout_secs: int or float or None
     :param timeout_secs:
       A timeout in seconds. After this timeout the iterator will be exhausted.
-      That is, a ``for`` loop like ``for f, t in frames(timeout_secs=10)`` will
+      That is, a ``for`` loop like ``for f in frames(timeout_secs=10)`` will
       terminate after 10 seconds. If ``timeout_secs`` is ``None`` (the default)
       then the iterator will yield frames forever. Note that you can stop
       iterating (for example with ``break``) at any time.
 
+    :rtype: Iterator[stbt.Frame]
     :returns:
-      A ``(frame, timestamp)`` tuple for each video frame:
-
-      * ``frame`` is a `stbt.Frame` (that is, an OpenCV image).
-      * ``timestamp`` (int): DEPRECATED. Timestamp in nanoseconds. Use
-        ``frame.time`` instead.
+      An iterator of frames in OpenCV format (`stbt.Frame`).
     """
     return _dut.frames(timeout_secs)
 

--- a/tests/run-performance-test.sh
+++ b/tests/run-performance-test.sh
@@ -14,7 +14,7 @@ cat > script.$$ <<-EOF
 	start = datetime.datetime.now()
 	for m in stbt.detect_match("videotestsrc-redblue.png", timeout_secs=10):
 	    frames += 1
-	    print "%s %s %s" % (m.timestamp, bool(m), m.position)
+	    print "%.3f %s %s" % (m.time, bool(m), m.position)
 	    # if not m:
 	    #     break
 	duration = (datetime.datetime.now() - start).total_seconds()

--- a/tests/test-soak.sh
+++ b/tests/test-soak.sh
@@ -23,12 +23,12 @@ test_long_running_stbt_run_process_for_memory_leaks() {
 	print "Testing short stbt.frames"
 	end_time = time.time() + 600  # 10 minutes
 	while time.time() < end_time:
-	    for frame, _ in stbt.frames(timeout_secs=10):
+	    for frame in stbt.frames(timeout_secs=10):
 	        stbt.match("$testdir/videotestsrc-redblue-flipped.png", frame)
 	    assert get_rss() < initial_rss * 1.1
 	
 	print "Testing long stbt.frames"
-	for frame, _ in stbt.frames(timeout_secs=600):  # 10 minutes
+	for frame in stbt.frames(timeout_secs=600):  # 10 minutes
 	    stbt.match("$testdir/videotestsrc-redblue-flipped.png", frame)
 	    if int(frame.time) % 10 == 0:
 	        assert get_rss() < initial_rss * 1.1

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -113,15 +113,15 @@ test_using_frames_to_measure_black_screen() {
 	threading.Thread(target=presser).start()
 	
 	frames = stbt.frames(timeout_secs=10)
-	for frame, timestamp in frames:
+	for frame in frames:
 	    black = stbt.is_screen_black(frame)
-	    print "%s: %s" % (timestamp, black)
+	    print "%s: %s" % (frame.time, black)
 	    if black:
 	        break
 	assert black, "Failed to find black screen"
-	for frame, timestamp in frames:
+	for frame in frames:
 	    black = stbt.is_screen_black(frame)
-	    print "%s: %s" % (timestamp, black)
+	    print "%s: %s" % (frame.time, black)
 	    if not black:
 	        break
 	assert not black, "Failed to find non-black screen"
@@ -132,11 +132,11 @@ test_using_frames_to_measure_black_screen() {
 test_that_frames_doesnt_deadlock() {
     cat > test.py <<-EOF &&
 	import stbt
-	for frame, timestamp in stbt.frames():
-	    print timestamp
+	for frame in stbt.frames():
+	    print frame.time
 	    break
-	for frame, timestamp in stbt.frames():
-	    print timestamp
+	for frame in stbt.frames():
+	    print frame.time
 	    break
 	frames = stbt.frames()
 	frame1 = frames.next()
@@ -400,7 +400,7 @@ test_that_frames_are_read_only() {
 	    # Different versions of numpy raise different exceptions
 	    pass
 	
-	for f, _ in stbt.frames():
+	for f in stbt.frames():
 	    try:
 	        f[0,0,0] = 0
 	        assert False, "frame from stbt.frames is writeable"
@@ -655,7 +655,7 @@ test_global_use_old_threading_behaviour_frames() {
 	import itertools
 	sa = set()
 	sb = set()
-	for (a, _), (b, _) in itertools.izip(stbt.frames(), stbt.frames()):
+	for a, b in itertools.izip(stbt.frames(), stbt.frames()):
 	    if len(sa) >= 10:
 	        break
 	    sa.add(a.time)
@@ -676,7 +676,7 @@ test_global_use_old_threading_behaviour_frames() {
 	import itertools
 	sa = set()
 	sb = set()
-	for (a, _), (b, _) in itertools.izip(stbt.frames(), stbt.frames()):
+	for a, b in itertools.izip(stbt.frames(), stbt.frames()):
 	    if len(sa) >= 10:
 	        break
 	    sa.add(a.time)

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -73,7 +73,7 @@ def fake_frames():
     for n, x in enumerate(data):
         t = start_time + n
         time.sleep(t - time.time())
-        yield stbt.Frame(x, time=t), t * 1e9
+        yield stbt.Frame(x, time=t)
 
 
 class MockTime(object):

--- a/tests/test_transition.py
+++ b/tests/test_transition.py
@@ -22,7 +22,7 @@ class FakeDeviceUnderTest(object):
             t = time.time()
             for state in self._frames:
                 array = F(state, t)
-                yield stbt.Frame(array, time=t), int(t * 1e9)
+                yield stbt.Frame(array, time=t)
                 t += 0.04  # 25fps
 
         else:
@@ -33,7 +33,7 @@ class FakeDeviceUnderTest(object):
                     self.state = "black"
                 elif self.state == "fade-to-white":
                     self.state = "white"
-                yield stbt.Frame(array, time=t), int(t * 1e9)
+                yield stbt.Frame(array, time=t)
 
 
 def F(state, t):


### PR DESCRIPTION
...from Iterator[(Frame, int)].

This is a breaking change, but the error will happen immediately and the
error message will be somewhat obvious: "ValueError: too many values to
unpack". Also, there should be very few uses of `stbt.frames()` in any
given test-pack.

The second field of the yielded tuple was a timestamp in
nanoseconds (GStreamer format). This has been deprecated since we added
`stbt.Frame.time` in v26, 2 years ago.

Now seems like a good time to do this because we've just added a
`frames` parameter to `detect_motion` and `wait_for_motion`. This API is
much more convenient.
