### PR TITLE
stbt-lint: stbt-frame-object-missing-frame checker: Also check class constructors

### DIFF
--- a/_stbt/pylint_plugin.py
+++ b/_stbt/pylint_plugin.py
@@ -81,9 +81,9 @@ class StbtChecker(BaseChecker):
 
         if _in_frameobject(node) and _in_property(node):
             for funcdef in _infer(node.func):
-                if (isinstance(funcdef, FunctionDef) and
-                        "frame" in funcdef.argnames()):
-                    index = funcdef.argnames().index("frame")
+                argnames = _get_argnames(funcdef)
+                if "frame" in argnames:
+                    index = argnames.index("frame")
                     args = [a for a in node.args if not isinstance(a, Keyword)]
                     if hasattr(node, "keywords"):  # astroid >= 1.4
                         keywords = node.keywords or []
@@ -126,6 +126,16 @@ def _in_property(node):
                 return True
         node = node.parent
     return False
+
+
+def _get_argnames(node):
+    if isinstance(node, FunctionDef):
+        return node.argnames()
+    if isinstance(node, ClassDef) and node.newstyle:
+        for method in node.methods():
+            if method.name == "__init__":
+                return method.argnames()[1:]
+    return []
 
 
 def _is_uri(filename):

--- a/_stbt/pylint_plugin.py
+++ b/_stbt/pylint_plugin.py
@@ -86,7 +86,6 @@ class StbtChecker(BaseChecker):
         if _in_frameobject(node) and _in_property(node):
             for funcdef in _infer(node.func):
                 if (isinstance(funcdef, FunctionDef) and
-                        funcdef != YES and
                         "frame" in funcdef.argnames()):
                     index = funcdef.argnames().index("frame")
                     args = [a for a in node.args if not isinstance(a, Keyword)]

--- a/_stbt/pylint_plugin.py
+++ b/_stbt/pylint_plugin.py
@@ -1,10 +1,6 @@
 """pylint plugin to do static analysis on stbt scripts
 
-* Identifies broken image links in parameters to `stbt.wait_for_match` etc.
-* Identifies calls to `wait_until` whose return value isn't used (probably
-  missing an `assert`).
-
-Intended to be used by "stbt lint".
+Used by "stbt lint".
 
 Documentation on Abstract Syntax Tree traversal with python/pylint:
 

--- a/tests/test-stbt-lint.sh
+++ b/tests/test-stbt-lint.sh
@@ -153,10 +153,13 @@ test_that_stbt_lint_checks_frame_parameter_in_frameobject_methods() {
 	def find_boxes(frame=None):
 	    pass
 	
+	class Button(FrameObject):
+	    pass
+	
 	class ModalDialog(FrameObject):
 	    @property
 	    def is_visible(self):
-	        return bool(find_boxes())
+	        return find_boxes() and Button()
 	
 	class ErrorDialog(ModalDialog):
 	    @property
@@ -173,7 +176,7 @@ test_that_stbt_lint_checks_frame_parameter_in_frameobject_methods() {
 	class Good(FrameObject):
 	    @property
 	    def is_visible(self):
-	        return bool(find_boxes(self._frame))
+	        return find_boxes(self._frame) and Button(self._frame)
 	
 	    @property
 	    def property1(self):
@@ -194,11 +197,12 @@ test_that_stbt_lint_checks_frame_parameter_in_frameobject_methods() {
 
     cat > lint.expected <<-'EOF'
 	************* Module test
-	E:  9,20: "find_boxes()" missing "frame" argument (stbt-frame-object-missing-frame)
-	E: 15,12: "match('videotestsrc-redblue.png')" missing "frame" argument (stbt-frame-object-missing-frame)
-	E: 16,12: "match_text('Error')" missing "frame" argument (stbt-frame-object-missing-frame)
-	E: 17,16: "is_screen_black()" missing "frame" argument (stbt-frame-object-missing-frame)
-	E: 21,15: "ocr()" missing "frame" argument (stbt-frame-object-missing-frame)
+	E: 12,15: "find_boxes()" missing "frame" argument (stbt-frame-object-missing-frame)
+	E: 12,32: "Button()" missing "frame" argument (stbt-frame-object-missing-frame)
+	E: 18,12: "match('videotestsrc-redblue.png')" missing "frame" argument (stbt-frame-object-missing-frame)
+	E: 19,12: "match_text('Error')" missing "frame" argument (stbt-frame-object-missing-frame)
+	E: 20,16: "is_screen_black()" missing "frame" argument (stbt-frame-object-missing-frame)
+	E: 24,15: "ocr()" missing "frame" argument (stbt-frame-object-missing-frame)
 	EOF
     diff -u lint.expected lint.log
 }


### PR DESCRIPTION
Inside a FrameObject property, if you do `stbt.match("image.png")`
instead of `stbt.match("image.png", frame=self._frame)`, stbt-lint will
warn you. However it wasn't warning if you were instantiating a **class**
that takes a `frame` parameter. This is a common use-case because
sometimes we want to return a FrameObject as the result of a different
FrameObject's property. For example, a FrameObject called `Dialog`
might have a property called `button` that returns an instance of a
`Button` FrameObject class.