### PR TITLE
stbt lint: Report images that exist but aren't committed to git

### DIFF
--- a/_stbt/pylint_plugin.py
+++ b/_stbt/pylint_plugin.py
@@ -73,9 +73,10 @@ class StbtChecker(BaseChecker):
             path = _find_file(node.value, node)
             if path:
                 if _is_file_uncommitted(path):
-                    self.add_message('E7005', node=node, args=node.value)
+                    self.add_message('E7005', node=node,
+                                     args=os.path.relpath(path))
             else:
-                self.add_message('E7001', node=node, args=node.value)
+                self.add_message('E7001', node=node, args=os.path.relpath(path))
 
     def visit_callfunc(self, node):
         if re.search(r"\b(is_screen_black|match|match_text|ocr|wait_until)$",

--- a/stbt-lint
+++ b/stbt-lint
@@ -17,6 +17,9 @@
   a function or lambda expression).
 * E7004: FrameObject properties must always provide "self._frame" as the
   "frame" parameter to functions such as "stbt.match".
+* E7005: The image path given to "stbt.match" (and similar functions)
+  exists on disk, but isn't committed to git.
+
 """
 
 import argparse

--- a/tests/test-stbt-lint.sh
+++ b/tests/test-stbt-lint.sh
@@ -86,11 +86,15 @@ test_that_stbt_lint_reports_uncommitted_images() {
     stbt lint --errors-only tests/test.py &> lint.log
     cat > lint.expected <<-EOF
 	************* Module test
-	E:  2,18: Image "images/reference.png" not committed to git (stbt-uncommitted-image)
+	E:  2,18: Image "tests/images/reference.png" not committed to git (stbt-uncommitted-image)
 	EOF
     diff -u lint.expected lint.log || fail "(see diff above)"
 
     (cd tests && stbt lint --errors-only test.py) &> lint.log
+    cat > lint.expected <<-EOF
+	************* Module test
+	E:  2,18: Image "images/reference.png" not committed to git (stbt-uncommitted-image)
+	EOF
     diff -u lint.expected lint.log || fail "(see diff above)"
 
     git add tests/images/reference.png

--- a/tests/test-stbt-lint.sh
+++ b/tests/test-stbt-lint.sh
@@ -71,6 +71,35 @@ test_that_stbt_lint_ignores_image_urls() {
     stbt lint --errors-only test.py
 }
 
+test_that_stbt_lint_reports_uncommitted_images() {
+    mkdir -p repo/tests/images
+    touch repo/tests/images/reference.png
+    cat > repo/tests/test.py <<-EOF
+	import stbt
+	assert stbt.match("images/reference.png")
+	EOF
+    cd repo
+    stbt lint --errors-only tests/test.py ||
+        fail "checker should be disabled because we're not in a git repo"
+
+    git init .
+    stbt lint --errors-only tests/test.py &> lint.log
+    cat > lint.expected <<-EOF
+	************* Module test
+	E:  2,18: Image "images/reference.png" not committed to git (stbt-uncommitted-image)
+	EOF
+    diff -u lint.expected lint.log || fail "(see diff above)"
+
+    (cd tests && stbt lint --errors-only test.py) &> lint.log
+    diff -u lint.expected lint.log || fail "(see diff above)"
+
+    git add tests/images/reference.png
+    stbt lint --errors-only tests/test.py || fail "stbt-lint should succeed"
+
+    (cd tests && stbt lint --errors-only test.py) ||
+        fail "stbt-lint should succeed from subdirectory too"
+}
+
 test_pylint_plugin_on_itself() {
     # It should work on arbitrary python files, so that you can just enable it
     # as a pylint plugin across your entire project, not just for stbt scripts.


### PR DESCRIPTION
This is a common & annoying problem -- stbt-lint passes locally but
fails on your CI server (as do the actual tests!).

I've used `subprocess` instead of `dulwich` because the latter is hard
to use (the version on Ubuntu 16.04 doesn't have
`dulwich.porcelain.ls_files`) and its Apache 2.0 license isn't
compatible with LGPL v2.1.