### PR TITLE
RokuHttpControl: Enforce 3 second timeout on all HTTP requests 

### DIFF
--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -513,15 +513,17 @@ class RokuHttpControl(object):
         "KEY_VOLUMEUP": "VolumeUp",
     }
 
-    def __init__(self, hostname):
+    def __init__(self, hostname, timeout_secs=3):
         self.hostname = hostname
+        self.timeout_secs = timeout_secs
 
     def press(self, key):
         import requests
 
         roku_keyname = self._KEYNAMES.get(key, key)
-        response = requests.post("http://%s:8060/keypress/%s"
-                                 % (self.hostname, roku_keyname))
+        response = requests.post(
+            "http://%s:8060/keypress/%s" % (self.hostname, roku_keyname),
+            timeout=self.timeout_secs)
         response.raise_for_status()
         debug("Pressed " + key)
 
@@ -529,8 +531,9 @@ class RokuHttpControl(object):
         import requests
 
         roku_keyname = self._KEYNAMES.get(key, key)
-        response = requests.post("http://%s:8060/keydown/%s"
-                                 % (self.hostname, roku_keyname))
+        response = requests.post(
+            "http://%s:8060/keydown/%s" % (self.hostname, roku_keyname),
+            timeout=self.timeout_secs)
         response.raise_for_status()
         debug("Holding " + key)
 
@@ -538,8 +541,9 @@ class RokuHttpControl(object):
         import requests
 
         roku_keyname = self._KEYNAMES.get(key, key)
-        response = requests.post("http://%s:8060/keyup/%s"
-                                 % (self.hostname, roku_keyname))
+        response = requests.post(
+            "http://%s:8060/keyup/%s" % (self.hostname, roku_keyname),
+            timeout=self.timeout_secs)
         response.raise_for_status()
         debug("Released " + key)
 

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -71,6 +71,8 @@ def crop(frame, region):
     :returns: An OpenCV image (`numpy.ndarray`) containing the specified region
       of the source frame. This is a view onto the original data, so if you
       want to modify the cropped image call its ``copy()`` method first.
+
+    Added in v28.
     """
     if not _image_region(frame).contains(region):
         raise ValueError("frame with dimensions %r doesn't contain %r"


### PR DESCRIPTION
The [python-requests documentation][1] says:

> Nearly all production code should use this parameter in nearly all
> requests. Failure to do so can cause your program to hang
> indefinitely.

[1]: http://docs.python-requests.org/en/master/user/quickstart/#timeouts