### PR TITLE
stbt auto-selftest: Include full exception traceback

### DIFF
--- a/stbt_auto_selftest.py
+++ b/stbt_auto_selftest.py
@@ -486,7 +486,7 @@ def update_doctests(infilename, outfile):
             except Exception:  # pylint: disable=broad-except
                 did_print[0] = (io.tell() != 0)
                 result[0] = "exception"
-                traceback.print_exc(0, io)
+                traceback.print_exc(file=io)
             finally:
                 perf_log.append((cmd, time.time() - start_time))
 


### PR DESCRIPTION
Unfortunately the first parameter (`limit`) limits to the *outermost*
frames, i.e. the code in stbt_auto_selftest.py. Otherwise we could have
set limit to 1 or 2 or 3. Negative numbers don't work.