### PR TITLE
stbt.match: Add structure_weighting

### DIFF
--- a/_stbt/stbt.conf
+++ b/_stbt/stbt.conf
@@ -39,6 +39,7 @@ match_threshold=0.80
 confirm_method=normed-absdiff
 confirm_threshold=0.30
 erode_passes=1
+structure_weighting=1
 
 # Downsample the video frame and the template image before matching, as a
 # performance optimisation. Once found, the match is always confirmed against

--- a/stbt-match
+++ b/stbt-match
@@ -55,6 +55,8 @@ try:
             mp.confirm_threshold = float(value)
         elif name == "erode_passes":
             mp.erode_passes = int(value)
+        elif name == "structure_weighting":
+            mp.structure_weighting = float(value)
         else:
             raise Exception("Unknown match_parameter argument '%s'" % p)
 except Exception:  # pylint: disable=W0703

--- a/tests/stbt.conf
+++ b/tests/stbt.conf
@@ -27,6 +27,7 @@ confirm_method=normed-absdiff
 confirm_threshold=0.30
 erode_passes=1
 pyramid_levels = 3
+structure_weighting=1
 
 [ocr]
 lang = eng


### PR DESCRIPTION
We use Sobel edge detection to improve the matching.  This is then
taken into account when constructing the heatmap.  This more closely
matches human expectations at the cost of being slower to run.

The weighting is done by raising the values to a power before
multiplying them together.  This is inspired by SSIM where seperate
brightness, contrast and structure terms are combined with the same
technique.

TODO:

- [ ] Include example in tests where it makes a difference
- [ ] Update debug HTML output 