### PR TITLE
make check: Don't run virtual-stb tests by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,8 +104,8 @@ install:
      rm -Rf parallel-20140522/ &&
      mkdir $HOME/.parallel &&
      touch $HOME/.parallel/will-cite  # Silence citation warning
- - make enable_stbt_camera=yes
+ - make enable_stbt_camera=yes enable_virtual_stb=yes
 
 script:
  - tesseract --version
- - make enable_stbt_camera=no check
+ - make enable_stbt_camera=no enable_virtual_stb=yes check

--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -865,9 +865,12 @@ def test_samsung_tcp_control():
 
 def test_x11_control():
     from unittest import SkipTest
-    from .x11 import x_server
+    if os.environ.get('enable_virtual_stb') != 'yes':
+        raise SkipTest('Set $enable_virtual_stb=yes to run this test')
     if not find_executable('Xorg') or not find_executable('xterm'):
         raise SkipTest("Testing X11Control requires X11 and xterm")
+
+    from .x11 import x_server
 
     with utils.named_temporary_directory() as tmp, \
             x_server(320, 240) as display:

--- a/stbt-camera.d/stbt_camera_calibrate.py
+++ b/stbt-camera.d/stbt_camera_calibrate.py
@@ -342,8 +342,8 @@ def fit_fn(ideals, measureds):
     """
     >>> f = fit_fn([120, 240, 150, 18, 200],
     ...            [120, 240, 150, 18, 200])
-    >>> print f(0), f(56)
-    0.0 56.0
+    >>> print "%.2f %.2f" % (f(0), f(56))
+    0.00 56.00
     """
     from scipy.optimize import curve_fit  # pylint: disable=E0611
     from scipy.interpolate import interp1d  # pylint: disable=E0611


### PR DESCRIPTION
You need to do `make check enable_virtual_stb=yes`.

This is because the tests screw up my X11 display when I run them
locally. Note that stbt-virtual-stb is already a separate debian
package because of all its dependencies on X11.