### PR TITLE
Use CircleCI for Continuous Integration testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,8 @@ commands:
     steps:
       - run:
           name: make check
+          environment:
+            LANG: en_GB.UTF-8
           command: |
             tesseract --version
             pylint --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,44 @@
+version: 2.1
+
+jobs:
+  ubuntu1604-python2:
+    docker:
+      - image: stbtester/circleci:ubuntu1604-python2
+    environment:
+      PYTHON: /usr/bin/python2.7
+    steps:
+      - checkout
+      - test
+
+  ubuntu1804-python2:
+    docker:
+      - image: stbtester/circleci:ubuntu1804
+    environment:
+      PYTHON: /usr/bin/python2.7
+    steps:
+      - checkout
+      - test
+
+  ubuntu1804-python3:
+    docker:
+      - image: stbtester/circleci:ubuntu1804
+    environment:
+      PYTHON: /usr/bin/python3.6
+    steps:
+      - checkout
+      - test
+
+commands:
+  test:
+    steps:
+      - run:
+          name: make check
+          command: |
+            tesseract --version
+            pylint --version
+            make enable_stbt_camera=no enable_virtual_stb=yes check
+
+workflows:
+  test_all:
+    jobs:
+      - ubuntu1604-python2

--- a/.circleci/ubuntu1604-python2.dockerfile
+++ b/.circleci/ubuntu1604-python2.dockerfile
@@ -18,6 +18,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         gstreamer1.0-tools \
         gstreamer1.0-x \
         gzip \
+        language-pack-en \
         libgstreamer1.0-dev \
         libgstreamer-plugins-base1.0-dev \
         libopencv-dev \

--- a/.circleci/ubuntu1604-python2.dockerfile
+++ b/.circleci/ubuntu1604-python2.dockerfile
@@ -3,18 +3,21 @@ FROM ubuntu:16.04
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get install -y \
+        ca-certificates \
         chromium-browser \
         expect \
         expect-dev \
         gdb \
         gir1.2-gstreamer-1.0 \
         gir1.2-gudev-1.0 \
+        git \
         gstreamer1.0-libav \
         gstreamer1.0-plugins-bad \
         gstreamer1.0-plugins-base \
         gstreamer1.0-plugins-good \
         gstreamer1.0-tools \
         gstreamer1.0-x \
+        gzip \
         libgstreamer1.0-dev \
         libgstreamer-plugins-base1.0-dev \
         libopencv-dev \
@@ -46,6 +49,8 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         python-zbar \
         ratpoison \
         socat \
+        ssh \
+        tar \
         tesseract-ocr \
         tesseract-ocr-deu \
         tesseract-ocr-eng \

--- a/.circleci/ubuntu1604-python2.dockerfile
+++ b/.circleci/ubuntu1604-python2.dockerfile
@@ -4,7 +4,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get install -y \
         chromium-browser \
-        cmake \
         expect \
         expect-dev \
         gdb \
@@ -18,12 +17,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         gstreamer1.0-x \
         libgstreamer1.0-dev \
         libgstreamer-plugins-base1.0-dev \
-        liblockdev1-dev \
         libopencv-dev \
         liborc-0.4-dev \
         librsvg2-bin \
-        libudev-dev \
-        libxrandr-dev \
         lighttpd \
         moreutils \
         pep8 \
@@ -33,6 +29,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         python-gi \
         python-jinja2 \
         python-kitchen \
+        python-libcec \
         python-lxml \
         python-matplotlib \
         python-mock \
@@ -49,7 +46,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         python-zbar \
         ratpoison \
         socat \
-        swig \
         tesseract-ocr \
         tesseract-ocr-deu \
         tesseract-ocr-eng \
@@ -66,26 +62,6 @@ RUN pip install \
         pylint==1.6.4 \
         pytest==3.3.1 \
         responses==0.5.1
-
-RUN mkdir -p /src && \
-    cd /src && \
-    git clone -b libcec-3.1.0 https://github.com/Pulse-Eight/libcec.git && \
-    git clone -b p8-platform-2.0.1 https://github.com/Pulse-Eight/platform.git && \
-    mkdir platform/build && \
-    cd platform/build && \
-    cmake .. && \
-    make && \
-    sudo make install && \
-    cd ../.. && \
-    mkdir libcec/build && \
-    cd libcec/build && \
-    cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr \
-        -DPYTHON_INCLUDE_DIR:PATH=/usr/include/python2.7 \
-        -DPYTHON_LIBRARY:FILEPATH=/usr/lib/x86_64-linux-gnu/libpython2.7.so \
-        -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python2.7 \
-        .. && \
-    make && \
-    sudo make install
 
 # Ubuntu parallel package conflicts with moreutils, so we have to build it
 # ourselves.

--- a/.circleci/ubuntu1604-python2.dockerfile
+++ b/.circleci/ubuntu1604-python2.dockerfile
@@ -1,0 +1,105 @@
+FROM ubuntu:16.04
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install -y \
+        chromium-browser \
+        cmake \
+        expect \
+        expect-dev \
+        gdb \
+        gir1.2-gstreamer-1.0 \
+        gir1.2-gudev-1.0 \
+        gstreamer1.0-libav \
+        gstreamer1.0-plugins-bad \
+        gstreamer1.0-plugins-base \
+        gstreamer1.0-plugins-good \
+        gstreamer1.0-tools \
+        gstreamer1.0-x \
+        libgstreamer1.0-dev \
+        libgstreamer-plugins-base1.0-dev \
+        liblockdev1-dev \
+        libopencv-dev \
+        liborc-0.4-dev \
+        librsvg2-bin \
+        libudev-dev \
+        libxrandr-dev \
+        lighttpd \
+        moreutils \
+        pep8 \
+        python-dev \
+        python-docutils \
+        python-flask \
+        python-gi \
+        python-jinja2 \
+        python-kitchen \
+        python-lxml \
+        python-matplotlib \
+        python-mock \
+        python-nose \
+        python-numpy \
+        python-opencv \
+        python-pip \
+        python-pysnmp4 \
+        python-qrcode \
+        python-requests \
+        python-scipy \
+        python-serial \
+        python-yaml \
+        python-zbar \
+        ratpoison \
+        socat \
+        swig \
+        tesseract-ocr \
+        tesseract-ocr-deu \
+        tesseract-ocr-eng \
+        v4l-utils \
+        wget \
+        xdotool \
+        xserver-xorg-video-dummy \
+        xterm && \
+    apt-get clean
+
+RUN pip install \
+        astroid==1.4.8 \
+        isort==3.9.0 \
+        pylint==1.6.4 \
+        pytest==3.3.1 \
+        responses==0.5.1
+
+RUN mkdir -p /src && \
+    cd /src && \
+    git clone -b libcec-3.1.0 https://github.com/Pulse-Eight/libcec.git && \
+    git clone -b p8-platform-2.0.1 https://github.com/Pulse-Eight/platform.git && \
+    mkdir platform/build && \
+    cd platform/build && \
+    cmake .. && \
+    make && \
+    sudo make install && \
+    cd ../.. && \
+    mkdir libcec/build && \
+    cd libcec/build && \
+    cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+        -DPYTHON_INCLUDE_DIR:PATH=/usr/include/python2.7 \
+        -DPYTHON_LIBRARY:FILEPATH=/usr/lib/x86_64-linux-gnu/libpython2.7.so \
+        -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python2.7 \
+        .. && \
+    make && \
+    sudo make install
+
+# Ubuntu parallel package conflicts with moreutils, so we have to build it
+# ourselves.
+RUN mkdir -p /src && \
+    cd /src && \
+    { wget http://ftpmirror.gnu.org/parallel/parallel-20140522.tar.bz2 || \
+      wget http://ftp.gnu.org/gnu/parallel/parallel-20140522.tar.bz2 || \
+      exit 0; } && \
+    tar -xvf parallel-20140522.tar.bz2 && \
+    cd parallel-20140522/ && \
+    ./configure --prefix=/usr/local && \
+    make && \
+    make install && \
+    cd && \
+    rm -rf /src && \
+    mkdir -p $HOME/.parallel && \
+    touch $HOME/.parallel/will-cite  # Silence citation warning

--- a/.circleci/ubuntu1604-python2.dockerfile
+++ b/.circleci/ubuntu1604-python2.dockerfile
@@ -5,6 +5,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get install -y \
         ca-certificates \
         chromium-browser \
+        curl \
         expect \
         expect-dev \
         gdb \
@@ -51,10 +52,12 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         ratpoison \
         socat \
         ssh \
+        sudo \
         tar \
         tesseract-ocr \
         tesseract-ocr-deu \
         tesseract-ocr-eng \
+        time \
         v4l-utils \
         wget \
         xdotool \

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *_orc.c
 *_orc.h
 .cache
+.circleci/.*.built
 .DS_Store
 .stbt-cflags
 .stbt-ldflags

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,4 +107,6 @@ install:
 
 script:
  - tesseract --version
+ - pylint --version
+ - env
  - make enable_stbt_camera=no enable_virtual_stb=yes check

--- a/Makefile
+++ b/Makefile
@@ -378,6 +378,22 @@ install-docs: docs/stbt.1
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(man1dir)
 	$(INSTALL) -m 0644 docs/stbt.1 $(DESTDIR)$(man1dir)
 
+### Docker images for CI #####################################################
+
+CI_DOCKER_IMAGES = ubuntu1604-python2 ubuntu1804-python2
+
+$(CI_DOCKER_IMAGES:%=.circleci/.%.built): .circleci/.%.built: .circleci/%.dockerfile
+	docker build -t stbtester/circleci:$* -f .circleci/$*.dockerfile \
+	    .circleci/ && \
+	touch $@
+
+ci-docker-images: $(CI_DOCKER_IMAGES:%=.circleci/.%.built)
+publish-ci-docker-images: $(CI_DOCKER_IMAGES:%=.circleci/.%.built)
+	set -x && \
+	for x in $(CI_DOCKER_IMAGES); do \
+	    docker push stbtester/circleci:$$x; \
+	done
+
 ### Debian Packaging #########################################################
 
 ubuntu_releases ?= trusty xenial artful

--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -451,7 +451,7 @@ class IRNetBoxControl(RemoteControl):
 
     """
 
-    def __init__(self, hostname, port, output, config):  # pylint: disable=W0621
+    def __init__(self, hostname, port, output, config):  # pylint:disable=redefined-outer-name
         self.hostname = hostname
         self.port = int(port or 10001)
         self.output = int(output)
@@ -756,7 +756,7 @@ class FileToSocket(object):
     def __init__(self, f):
         self.file = f
 
-    def recv(self, bufsize, flags=0):  # pylint: disable=W0613
+    def recv(self, bufsize, flags=0):  # pylint:disable=unused-argument
         return self.file.read(bufsize)
 
 
@@ -898,10 +898,10 @@ def test_x11_control():
 
 
 def test_uri_to_control():
-    global IRNetBoxControl  # pylint: disable=W0601
+    global IRNetBoxControl  # pylint:disable=global-variable-undefined
     orig_IRNetBoxControl = IRNetBoxControl
     try:
-        # pylint: disable=W0621
+        # pylint:disable=redefined-outer-name
         def IRNetBoxControl(hostname, port, output, config):
             return ":".join([hostname, str(port or '10001'), output, config])
         out = uri_to_control("irnetbox:localhost:1234:1:conf")

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -37,7 +37,7 @@ from _stbt.logging import ddebug, debug, warn
 from _stbt.types import Region, UITestError, UITestFailure
 
 gi.require_version("Gst", "1.0")
-from gi.repository import GLib, GObject, Gst  # isort:skip pylint: disable=E0611
+from gi.repository import GLib, GObject, Gst  # isort:skip pylint:disable=no-name-in-module
 
 Gst.init(None)
 

--- a/_stbt/gst_hacks.py
+++ b/_stbt/gst_hacks.py
@@ -6,7 +6,7 @@ from os.path import dirname
 import gi
 
 gi.require_version("Gst", "1.0")
-from gi.repository import Gst  # isort:skip pylint: disable=E0611
+from gi.repository import Gst  # isort:skip pylint:disable=no-name-in-module
 
 # Here we are using ctypes to call `gst_buffer_map` and `gst_buffer_unmap`
 # because PyGObject does not properly expose struct GstMapInfo (see
@@ -125,7 +125,7 @@ def test_map_sample_without_buffer():
 
     sample = Gst.Sample.new(None, None, None, None)
     try:
-        # pylint: disable=E1120
+        # pylint:disable=no-value-for-parameter
         with map_gst_sample(sample, Gst.MapFlags.READ):
             assert False
     except ValueError:

--- a/_stbt/gst_utils.py
+++ b/_stbt/gst_utils.py
@@ -7,7 +7,7 @@ from .gst_hacks import map_gst_sample, sample_get_size
 from .imgutils import Frame
 
 gi.require_version("Gst", "1.0")
-from gi.repository import GObject, Gst  # isort:skip pylint: disable=E0611
+from gi.repository import GObject, Gst  # isort:skip pylint:disable=no-name-in-module
 
 Gst.init([])
 
@@ -176,7 +176,7 @@ def frames_to_video(outfilename, frames, caps="image/svg",
 
     if t == 0:
         raise ValueError("Sequence argument frames must not be empty")
-    _appsrc_push_data(vsrc, data, t, 0)  # pylint: disable=W0631
+    _appsrc_push_data(vsrc, data, t, 0)  # pylint:disable=undefined-loop-variable
 
     vsrc.emit("end-of-stream")
     asrc.emit('end-of-stream')

--- a/_stbt/irnetbox.py
+++ b/_stbt/irnetbox.py
@@ -326,7 +326,7 @@ def test_that_read_responses_doesnt_hang_on_incomplete_data():
 def test_that_parse_config_understands_redrat_format():
     import StringIO
 
-    # pylint: disable=C0301
+    # pylint:disable=line-too-long
     f = StringIO.StringIO(
         re.sub(
             "^ +", "", flags=re.MULTILINE, string=""
@@ -363,5 +363,5 @@ class _FileToSocket(object):
     def __init__(self, f):
         self.file = f
 
-    def recv(self, bufsize, flags=0):  # pylint: disable=W0613
+    def recv(self, bufsize, flags=0):  # pylint:disable=unused-argument
         return self.file.read(bufsize)

--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -408,7 +408,7 @@ def wait_for_match(image, timeout_secs=10, consecutive_matches=1,
             debug("Matched " + image.friendly_name)
             return res
 
-    raise MatchTimeout(res.frame, image.friendly_name, timeout_secs)  # pylint:disable=undefined-loop-variable,line-too-long
+    raise MatchTimeout(res.frame, image.friendly_name, timeout_secs)  # pylint:disable=undefined-loop-variable
 
 
 class MatchTimeout(UITestFailure):

--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -408,7 +408,7 @@ def wait_for_match(image, timeout_secs=10, consecutive_matches=1,
             debug("Matched " + image.friendly_name)
             return res
 
-    raise MatchTimeout(res.frame, image.friendly_name, timeout_secs)  # pylint: disable=W0631,C0301
+    raise MatchTimeout(res.frame, image.friendly_name, timeout_secs)  # pylint:disable=undefined-loop-variable,line-too-long
 
 
 class MatchTimeout(UITestFailure):

--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -100,7 +100,7 @@ class TextMatchResult(object):
         self.frame = frame
         self.text = text
 
-    # pylint: disable=E1101
+    # pylint:disable=no-member
     def __nonzero__(self):
         return self.match
 

--- a/_stbt/stbt_run.py
+++ b/_stbt/stbt_run.py
@@ -124,7 +124,7 @@ def sane_unicode_and_exception_handling(script):
 
     try:
         yield
-    except Exception as e:  # pylint: disable=W0703
+    except Exception as e:  # pylint:disable=broad-except
         error_message = exception_to_bytes(e)
         if not error_message and isinstance(e, AssertionError):
             error_message = traceback.extract_tb(sys.exc_info()[2])[-1][3]

--- a/_stbt/utils.py
+++ b/_stbt/utils.py
@@ -30,7 +30,7 @@ def rm_f(filename):
 
 @contextmanager
 def named_temporary_directory(
-        suffix='', prefix='tmp', dir=None):  # pylint: disable=W0622
+        suffix='', prefix='tmp', dir=None):  # pylint:disable=redefined-builtin
     dirname = tempfile.mkdtemp(suffix, prefix, dir)
     try:
         yield dirname

--- a/irnetbox-proxy
+++ b/irnetbox-proxy
@@ -153,7 +153,7 @@ class IRNetBoxProxy(object):
             sock, old_id = self.async_commands[new_id]
             data = self.replace_sequence_id(data, old_id)
             sock.sendall(header + data)
-        except Exception, e:  # pylint: disable=W0703
+        except Exception, e:  # pylint:disable=broad-except
             self.error(e, "Error sending async complete command", fatal=False)
         if new_id in self.async_commands:
             del self.async_commands[new_id]
@@ -176,13 +176,13 @@ class IRNetBoxProxy(object):
     def send_management_command(self, message_type):
         message = self.MESSAGE_HEADER.pack(self.MESSAGE_MARKER, 0, message_type)
         self.irnet_sock.sendall(message)
-        response_type, _, _ = self.get_message_from_irnet(True)  # pylint: disable=W0633,C0301
+        response_type, _, _ = self.get_message_from_irnet(True)  # pylint:disable=unpacking-non-sequence
         assert response_type == message_type
 
     def accept_client(self):
         new_client, (addr, _) = self.listen_sock.accept()
         self.info("Accepted connection from %s" % (addr,))
-        # pylint: disable=E1101
+        # pylint:disable=no-member
         self.read_sockets[new_client.fileno()] = new_client
 
     def read_client_command(self, sock):
@@ -193,9 +193,9 @@ class IRNetBoxProxy(object):
                 response = ""
             else:
                 self.irnet_sock.sendall(header + message)
-                _, response_header, response = self.get_message_from_irnet(True)  # pylint: disable=W0633,C0301
+                _, response_header, response = self.get_message_from_irnet(True)  # pylint:disable=unpacking-non-sequence,line-too-long
             sock.sendall(response_header + response)
-        except Exception, e:  # pylint: disable=W0703
+        except Exception, e:  # pylint:disable=broad-except
             del self.read_sockets[sock.fileno()]
             sock.close()
             if isinstance(e, SocketClosed) and e.socket is sock:  # pylint:disable=no-member
@@ -226,13 +226,13 @@ class IRNetBoxProxy(object):
                                         socket.SO_REUSEADDR, 1)
             self.listen_sock.bind(self.listen_addr)
             self.listen_sock.listen(5)
-        except Exception, e:  # pylint: disable=W0703
+        except Exception, e:  # pylint:disable=broad-except
             self.error(e, "Could not bind to local address")
 
         try:
             self.irnet_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.irnet_sock.connect(self.irnet_addr)
-        except Exception, e:  # pylint: disable=W0703
+        except Exception, e:  # pylint:disable=broad-except
             self.error(e, "Could not connect to irNetBox.")
         self.read_sockets = {
             self.listen_sock.fileno(): self.listen_sock,
@@ -243,7 +243,7 @@ class IRNetBoxProxy(object):
         self.connect()
         try:
             self.send_management_command(self.POWER_ON)
-        except Exception, e:  # pylint: disable=W0703
+        except Exception, e:  # pylint:disable=broad-except
             self.error(
                 e, "Connected to irNetBox, but could not send power on command")
 
@@ -263,12 +263,12 @@ class IRNetBoxProxy(object):
         finally:
             try:
                 self.send_management_command(self.POWER_OFF)
-            except Exception, e:  # pylint: disable=W0703
+            except Exception, e:  # pylint:disable=broad-except
                 self.error(e, "Could not turn irNetBox off", fatal=False)
             for sock in self.read_sockets.viewvalues():
                 try:
                     sock.close()
-                except:  # pylint: disable=W0702
+                except:  # pylint:disable=bare-except
                     pass
 
 
@@ -309,7 +309,7 @@ def main():
         proxy.run()
     except (KeyboardInterrupt, StopRunning), e:
         proxy.error(e, "Stopped")
-    except Exception, e:  # pylint:disable=W0703
+    except Exception, e:  # pylint:disable=broad-except
         proxy.error(e, "irNetProxy encountered an error")
 
 if __name__ == "__main__":

--- a/irnetbox-proxy
+++ b/irnetbox-proxy
@@ -193,7 +193,7 @@ class IRNetBoxProxy(object):
                 response = ""
             else:
                 self.irnet_sock.sendall(header + message)
-                _, response_header, response = self.get_message_from_irnet(True)  # pylint:disable=unpacking-non-sequence,line-too-long
+                _, response_header, response = self.get_message_from_irnet(True)  # pylint:disable=unpacking-non-sequence
             sock.sendall(response_header + response)
         except Exception, e:  # pylint:disable=broad-except
             del self.read_sockets[sock.fileno()]

--- a/stbt-camera.d/stbt_camera_calibrate.py
+++ b/stbt-camera.d/stbt_camera_calibrate.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python -u
 # Encoding: utf-8
-# pylint: disable=W0212
+# pylint:disable=protected-access
 
 import math
 import re
@@ -22,7 +22,7 @@ from _stbt import tv_driver
 from _stbt.config import set_config, xdg_config_dir
 
 gi.require_version("Gst", "1.0")
-from gi.repository import Gst  # isort:skip pylint: disable=E0611
+from gi.repository import Gst  # isort:skip pylint:disable=no-name-in-module
 
 COLOUR_SAMPLES = 50
 videos = {}
@@ -345,15 +345,15 @@ def fit_fn(ideals, measureds):
     >>> print "%.2f %.2f" % (f(0), f(56))
     0.00 56.00
     """
-    from scipy.optimize import curve_fit  # pylint: disable=E0611
-    from scipy.interpolate import interp1d  # pylint: disable=E0611
+    from scipy.optimize import curve_fit  # pylint:disable=no-name-in-module
+    from scipy.interpolate import interp1d  # pylint:disable=no-name-in-module
     POINTS = 5
     xs = [n * 255.0 / (POINTS + 1) for n in range(0, POINTS + 2)]
 
     def fn(x, ys):
         return interp1d(xs, numpy.array([0] + ys + [255]))(x)
 
-    ys, _ = curve_fit(  # pylint:disable=W0632
+    ys, _ = curve_fit(  # pylint:disable=unbalanced-tuple-unpacking
         lambda x, *args: fn(x, list(args)), ideals, measureds, [0.0] * POINTS)
     return interp1d(xs, numpy.array([0] + ys.tolist() + [255]))
 
@@ -406,10 +406,10 @@ def colour_graph(dut):
 
 def _can_show_graphs():
     try:
-        # pylint: disable=W0612
+        # pylint:disable=unused-variable
         from matplotlib import pyplot
-        from scipy.optimize import curve_fit  # pylint: disable=E0611
-        from scipy.interpolate import interp1d  # pylint: disable=E0611
+        from scipy.optimize import curve_fit  # pylint:disable=no-name-in-module
+        from scipy.interpolate import interp1d  # pylint:disable=no-name-in-module
         return True
     except ImportError:
         sys.stderr.write("Install matplotlib and scipy for graphical "
@@ -502,7 +502,7 @@ v4l2videosrc = 'v4l2src device=%(v4l2_device)s extra-controls=%(v4l2_ctls)s'
 
 def list_cameras():
     gi.require_version('GUdev', '1.0')
-    from gi.repository import GUdev  # pylint: disable=E0611
+    from gi.repository import GUdev  # pylint:disable=no-name-in-module
     client = GUdev.Client.new(['video4linux/usb_device'])
     devices = client.query_by_subsystem('video4linux')
     for d in devices:

--- a/stbt-camera.d/stbt_camera_validate.py
+++ b/stbt-camera.d/stbt_camera_validate.py
@@ -15,7 +15,7 @@ import numpy
 from _stbt import tv_driver
 
 gi.require_version("Gst", "1.0")
-from gi.repository import Gst  # isort:skip pylint: disable=E0611
+from gi.repository import Gst  # isort:skip pylint:disable=no-name-in-module
 
 DATA_DIR = dirname(abspath(__file__))
 

--- a/stbt-match
+++ b/stbt-match
@@ -57,7 +57,7 @@ try:
             mp.erode_passes = int(value)
         else:
             raise Exception("Unknown match_parameter argument '%s'" % p)
-except Exception:  # pylint: disable=W0703
+except Exception:  # pylint:disable=broad-except
     error("Invalid argument '%s'" % p)
 
 source_image = cv2.imread(args.source_file)

--- a/tests/test-stbt-auto-selftest.sh
+++ b/tests/test-stbt-auto-selftest.sh
@@ -111,6 +111,8 @@ test_auto_selftest_caching()
         stbt auto-selftest validate \
         || fail "auto-selftest failed"
 
+    tail without_cache.time cold_cache.time hot_cache.time
+
     python -c "assert ($(<hot_cache.time) * 2) < $(<without_cache.time)" \
         || fail "caching isn't fast"
 }

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -131,7 +131,7 @@ def test_that_setting_config_options_has_an_effect():
     r'\d\*.\d\*.\d\*.\d\*',
 ])
 def test_tesseract_user_patterns(patterns):
-    # pylint: disable=W0212
+    # pylint:disable=protected-access
     if _tesseract_version() < distutils.version.LooseVersion('3.03'):
         raise SkipTest('tesseract is too old')
 
@@ -143,7 +143,7 @@ def test_tesseract_user_patterns(patterns):
 
 
 def test_that_with_old_tesseract_ocr_raises_an_exception_with_patterns():
-    # pylint: disable=W0212
+    # pylint:disable=protected-access
     if _tesseract_version() >= distutils.version.LooseVersion('3.03'):
         raise SkipTest('tesseract is too new')
 
@@ -198,7 +198,7 @@ def test_that_text_location_is_recognised():
     def test(text, region, upsample):
         result = stbt.match_text(text, frame=frame, upsample=upsample)
         assert result
-        assert region.contains(result.region)  # pylint: disable=E1101
+        assert region.contains(result.region)  # pylint:disable=no-member
 
     for text, region, multiline in iterate_menu():
         # Don't currently support multi-line comments

--- a/tests/test_set_config.py
+++ b/tests/test_set_config.py
@@ -70,7 +70,7 @@ def test_that_set_config_creates_new_sections_if_required():
 
 
 def test_that_set_config_preserves_file_comments_and_formatting():
-    # pylint:disable=W0511,W0101
+    # pylint:disable=fixme,unreachable
     # FIXME: Preserve comments and formatting.  This is fairly tricky as
     # comments and whitespace are not currently stored in Python's internal
     # ConfigParser representation and multiline values makes just using regex


### PR DESCRIPTION
Unlike Travis, CircleCI makes it easy to run tests inside a docker
container. So we'll build docker images for Ubuntu 16.04 and Ubuntu
18.04 (the latter in a future commit), push them to Docker
Hub (manually, needs to be done by the Stb-tester project owners but
only when we need to install new dependencies), and then CircleCI will
pull the image from Docker Hub each time it runs the tests.