### PR TITLE
stbt.ocr: Only binarize the image if text_color_threshold > 0

### DIFF
--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -213,9 +213,11 @@ def ocr(frame=None, region=Region.ALL,
         translucent overlay.
 
     :param int text_color_threshold:
-        The threshold to use with ``text_color``, between 0 and 255. Defaults
-        to 25. You can override the global default value by setting
-        ``text_color_threshold`` in the ``[ocr]`` section of :ref:`.stbt.conf`.
+        The threshold to use with ``text_color``, between 0 and 255. If 0, no
+        binarization is done (tesseract will choose its own binarization
+        threshold). If None, the default value will be read from
+        ``ocr.text_color_threshold`` in :ref:`.stbt.conf`, and if that's not
+        specified the default value is 25.
 
     :param engine:
         The OCR engine to use. Defaults to ``OcrEngine.TESSERACT``. You can
@@ -223,9 +225,11 @@ def ocr(frame=None, region=Region.ALL,
         section of :ref:`.stbt.conf`.
     :type engine: `OcrEngine`
 
-    | Added in v28: The ``upsample`` and ``text_color`` parameters.
-    | Added in v29: The ``text_color_threshold`` parameter.
-    | Added in v30: The ``engine`` parameter and support for Tesseract v4.
+    * Added in v28: The ``upsample`` and ``text_color`` parameters.
+    * Added in v29: The ``text_color_threshold`` parameter.
+    * Added in v30:
+        * The ``engine`` parameter and support for Tesseract v4.
+        * ``text_color_threshold`` of 0 means no binarization.
     """
     if frame is None:
         import stbt
@@ -287,9 +291,11 @@ def match_text(text, frame=None, region=Region.ALL,
         while not stbt.match('selected-button.png').region.contains(m.region):
             stbt.press('KEY_DOWN')
 
-    | Added in v28: The ``upsample`` and ``text_color`` parameters.
-    | Added in v29: The ``text_color_threshold`` parameter.
-    | Added in v30: The ``engine`` parameter and support for Tesseract v4.
+    * Added in v28: The ``upsample`` and ``text_color`` parameters.
+    * Added in v29: The ``text_color_threshold`` parameter.
+    * Added in v30:
+        * The ``engine`` parameter and support for Tesseract v4.
+        * ``text_color_threshold`` of 0 means no binarization.
     """
     import lxml.etree
     if frame is None:
@@ -447,8 +453,9 @@ def _tesseract_subprocess(
                             diff[:, :, 1] ** 2 +
                             diff[:, :, 2] ** 2) / 3) \
                      .astype(numpy.uint8)
-        _, frame = cv2.threshold(frame, text_color_threshold, 255,
-                                 cv2.THRESH_BINARY)
+        if text_color_threshold:
+            _, frame = cv2.threshold(frame, text_color_threshold, 255,
+                                     cv2.THRESH_BINARY)
 
     # $XDG_RUNTIME_DIR is likely to be on tmpfs:
     tmpdir = os.environ.get("XDG_RUNTIME_DIR", None)

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -289,11 +289,7 @@ def test_ocr_on_text_next_to_image_match():
      stbt.Region(0, 370, right=1280, bottom=410)),
 
     # This is a light "8" on a dark background. Without the context of any
-    # other surrounding text, OCR reads it as ":" or ";"! Presumably tesseract
-    # is reading the *holes* in the "8" instead of the letter itself, because
-    # it's assuming that it's seeing printed matter (a scanned book with black
-    # text on white background). Expanding the region to include other text
-    # would solve the problem, but so does specifying the text color.
+    # other surrounding text, OCR reads it as ":" or ";"!
     ("ocr/ch8.png", (252, 242, 255), "8", stbt.Region.ALL),
 ])
 def test_ocr_text_color(image, color, expected, region):


### PR DESCRIPTION
In v28 we added `text_color` which calculates each pixel's distance from
the desired color, and then also binarizes the resulting image before
passing it to tesseract. But why do we do the binarization at all --
maybe the color-distance alone is enough, and tesseract can choose its
own binarization. Getting the binarization threshold right has proven
to be a trial-and-error process on a case-by-case basis.

UPDATE: It turns out that (for white text at least) doing color-distance
without our own thresholding, gives exactly the same result as no
color-distance at all. Where "the same result" means identical output
from tesseract's binarizer. See [comment below](#issuecomment-442833424).

TODO:

- [ ] We saw that text_color=white + text_color_threshold=0 makes no difference. Does it help if the text color is not white -- specifically if it isn't close to 255 in any channel?
- [ ] Try implementing an adaptive thresholding ourselves.