### PR TITLE
API: Add return value from `stbt.press`

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -30,7 +30,7 @@ from _stbt import logging
 from _stbt.config import get_config
 from _stbt.gst_utils import (array_from_sample, gst_iterate,
                              gst_sample_make_writable)
-from _stbt.imgutils import find_user_file, Frame, imread
+from _stbt.imgutils import _frame_repr, find_user_file, Frame, imread
 from _stbt.logging import ddebug, debug, warn
 from _stbt.types import Region, UITestError, UITestFailure
 
@@ -172,20 +172,24 @@ class DeviceUnderTest(object):
 
         if hold_secs is None:
             with self._interpress_delay(interpress_delay_secs):
+                out = _Keypress(key, self._time.time(), None, self.get_frame())
                 self._control.press(key)
+                out.end_time = self._time.time()
             self.draw_text(key, duration_secs=3)
-
+            return out
         else:
-            with self.pressing(key, interpress_delay_secs):
+            with self.pressing(key, interpress_delay_secs) as out:
                 self._time.sleep(hold_secs)
+            return out
 
     @contextmanager
     def pressing(self, key, interpress_delay_secs=None):
         with self._interpress_delay(interpress_delay_secs):
+            out = _Keypress(key, self._time.time(), None, self.get_frame())
             try:
                 self._control.keydown(key)
                 self.draw_text("Holding %s" % key, duration_secs=3)
-                yield
+                yield out
             except:  # pylint:disable=bare-except
                 exc_info = sys.exc_info()
                 try:
@@ -197,6 +201,7 @@ class DeviceUnderTest(object):
                 raise exc_info[0], exc_info[1], exc_info[2]
             else:
                 self._control.keyup(key)
+                out.end_time = self._time.time()
                 self.draw_text("Released %s" % key, duration_secs=3)
 
     @contextmanager
@@ -281,6 +286,20 @@ class DeviceUnderTest(object):
 
     def get_frame(self):
         return self._display.get_frame()
+
+
+class _Keypress(object):
+    def __init__(self, key, start_time, end_time, frame_before):
+        self.key = key
+        self.start_time = start_time
+        self.end_time = end_time
+        self.frame_before = frame_before
+
+    def __repr__(self):
+        return (
+            "_Keypress(key=%r, start_time=%r, end_time=%r, frame_before=%s)" % (
+                self.key, self.start_time, self.end_time,
+                _frame_repr(self.frame_before)))
 
 
 # Utility functions

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -147,6 +147,7 @@ class DeviceUnderTest(object):
         self._sink_pipeline = sink_pipeline
         self._mainloop = mainloop
         self._time = _time
+        self._last_keypress = None
 
     def __enter__(self):
         if self._display:
@@ -176,6 +177,7 @@ class DeviceUnderTest(object):
                 self._control.press(key)
                 out.end_time = self._time.time()
             self.draw_text(key, duration_secs=3)
+            self._last_keypress = out
             return out
         else:
             with self.pressing(key, interpress_delay_secs) as out:
@@ -189,6 +191,7 @@ class DeviceUnderTest(object):
             try:
                 self._control.keydown(key)
                 self.draw_text("Holding %s" % key, duration_secs=3)
+                self._last_keypress = out
                 yield out
             except:  # pylint:disable=bare-except
                 exc_info = sys.exc_info()

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -107,6 +107,9 @@ TODO: Date
 
 ##### Minor additions, bugfixes & improvements
 
+* `stbt.press` now returns a object containing timing information. This is
+  intended to help making performance measurements.
+
 * `stbt power`: Add support for Rittal 7955.310 PDUs.
 
 * `stbt lint` fixes:

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -143,7 +143,14 @@ def press(key, interpress_delay_secs=None, hold_secs=None):
         this is implemented for the infrared, HDMI CEC, and Roku controls.
         There is a maximum limit of 60 seconds.
 
+    :rtype: `_KeyPress`
+    :returns:
+        A result object with the properties `key`, `start_time`, `end_time` and
+        `frame_before`.
+
     Added in v29: The ``hold_secs`` parameter.
+
+    Added in v30: Returns a ``_Keypress``
     """
     return _dut.press(key, interpress_delay_secs, hold_secs)
 

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -614,3 +614,35 @@ test_that_two_frames_iterators_can_return_the_same_frames_as_each_other() {
 	EOF
     stbt run -vv test.py || fail "Incorrect frames() behaviour"
 }
+
+test_that_press_returns_a_pressresult() {
+    cat > test.py <<-EOF &&
+	import time
+	
+	before = time.time()
+	result = stbt.press("KEY_MENU")
+	after = time.time()
+
+	assert before < result.start_time < result.end_time < after
+	assert result.key == "KEY_MENU"
+	assert isinstance(result.frame_before, stbt.Frame)
+
+	before = time.time()
+	result = stbt.press("KEY_HOME", hold_secs=0.001)
+	after = time.time()
+
+	assert before < result.start_time < result.end_time < after
+	assert result.key == "KEY_HOME"
+	assert isinstance(result.frame_before, stbt.Frame)
+
+	before = time.time()
+	with stbt.pressing("KEY_VOLUMEUP") as result:
+	    assert before < result.start_time
+	    assert result.end_time is None
+	    assert result.key == "KEY_VOLUMEUP"
+	    assert isinstance(result.frame_before, stbt.Frame)
+	after = time.time()
+	assert result.start_time < result.end_time < after
+	EOF
+    stbt run -vv --control=none test.py || fail "Incorrect press() behaviour"
+}

--- a/tests/test_press.py
+++ b/tests/test_press.py
@@ -5,6 +5,7 @@ from _stbt.core import DeviceUnderTest, NoSinkPipeline
 
 def test_that_pressing_context_manager_raises_keyup_exceptions():
     dut = DeviceUnderTest(control=FakeControl(raises_on_keyup=True),
+                          display=_FakeDisplay(),
                           sink_pipeline=NoSinkPipeline())
     with pytest.raises(RuntimeError) as excinfo:
         with dut.pressing("KEY_MENU"):
@@ -15,7 +16,8 @@ def test_that_pressing_context_manager_raises_keyup_exceptions():
 def test_that_pressing_context_manager_suppresses_keyup_exceptions():
     # ...if doing so would hide an exception raised by the test script.
     control = FakeControl(raises_on_keyup=True)
-    dut = DeviceUnderTest(control=control, sink_pipeline=NoSinkPipeline())
+    dut = DeviceUnderTest(control=control, display=_FakeDisplay(),
+                          sink_pipeline=NoSinkPipeline())
     with pytest.raises(AssertionError):
         with dut.pressing("KEY_MENU"):
             assert False
@@ -40,3 +42,8 @@ class FakeControl(object):
         self.keyup_called += 1
         if self.raises_on_keyup:
             raise RuntimeError("keyup %s failed" % key)
+
+
+class _FakeDisplay(object):
+    def get_frame(self):
+        return None

--- a/tests/test_transition.py
+++ b/tests/test_transition.py
@@ -15,7 +15,10 @@ class FakeDeviceUnderTest(object):
         self._frames = frames
 
     def press(self, key):
+        from _stbt.core import _Keypress
+        frame_before = self.frames().next()
         self.state = key
+        return _Keypress(key, time.time(), time.time(), frame_before)
 
     def frames(self):
         if self._frames is not None:


### PR DESCRIPTION
A common pattern for benchmarking is:

    stbt.press('KEY_XXX')
    start_time = time.time()
    x = wait_until(xyz)
    duration = x.time - start_time

This moved the `time.time()` bits into `stbt.press` itself where it
can do a better job as it is `interpress_delay_secs` aware.

This was motivated by some changes I want to make to the transition
APIs.  When writing page objects you have to deal with transitions
between different pages.  For example a menu might know that it has
to press `'KEY_OK'` to launch the EPG, but only the EPG knows how
to wait until the EPG has finished loading.  In this case the `key`
argument to `press_and_wait` is defined by the `Menu` page object,
whereas the `mask` would be defined by `EPG`. This API is a step
towards being able to implement this as:

    r = stbt.press('KEY_OK')
    page = EPG.wait_until_loaded(r)

This motivates the `frame_before` member.

TODO:

- [x] Tests
- [x] How do we document return types?