### PR TITLE
stbt.detect_motion docstring: Clarify that you need to use it in a `for` loop

### DIFF
--- a/_stbt/motion.py
+++ b/_stbt/motion.py
@@ -18,6 +18,13 @@ def detect_motion(timeout_secs=10, noise_threshold=None, mask=None,
     The `MotionResult` indicates whether any motion was detected -- that is,
     any difference between two consecutive frames.
 
+    Use it in a ``for`` loop like this::
+
+        for motionresult in stbt.detect_motion():
+            ...
+
+    In most cases you should use `wait_for_motion` instead.
+
     :type timeout_secs: int or float or None
     :param timeout_secs:
         A timeout in seconds. After this timeout the iterator will be exhausted.


### PR DESCRIPTION
A common mistake is to use it directly in an `if` statement
(`if stbt.detect_motion():`) which is always true because it's a
generator object.