### PR TITLE
Add new `stbt.timeout` API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ INSTALL_PYLIB_FILES = \
     _stbt/stbt_run.py \
     _stbt/stbt-power.sh \
     _stbt/stbt.conf \
+    _stbt/timeout.py \
     _stbt/transition.py \
     _stbt/types.py \
     _stbt/utils.py \

--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -514,34 +514,30 @@ class RokuHttpControl(object):
     }
 
     def __init__(self, hostname, timeout_secs=3):
+        import requests
         self.hostname = hostname
+        self.requests = requests.Session()
         self.timeout_secs = timeout_secs
 
     def press(self, key):
-        import requests
-
         roku_keyname = self._KEYNAMES.get(key, key)
-        response = requests.post(
+        response = self.requests.post(
             "http://%s:8060/keypress/%s" % (self.hostname, roku_keyname),
             timeout=self.timeout_secs)
         response.raise_for_status()
         debug("Pressed " + key)
 
     def keydown(self, key):
-        import requests
-
         roku_keyname = self._KEYNAMES.get(key, key)
-        response = requests.post(
+        response = self.requests.post(
             "http://%s:8060/keydown/%s" % (self.hostname, roku_keyname),
             timeout=self.timeout_secs)
         response.raise_for_status()
         debug("Holding " + key)
 
     def keyup(self, key):
-        import requests
-
         roku_keyname = self._KEYNAMES.get(key, key)
-        response = requests.post(
+        response = self.requests.post(
             "http://%s:8060/keyup/%s" % (self.hostname, roku_keyname),
             timeout=self.timeout_secs)
         response.raise_for_status()

--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -480,6 +480,16 @@ class IRNetBoxControl(RemoteControl):
             raise
 
 
+def post(requests, *args, **kwargs):
+    try:
+        kwargs['timeout'] = min(timeout.check_timeout(),
+                                kwargs.get('timeout', float('inf')))
+        response = requests.post(*args, **kwargs)
+    except requests.exceptions.Timeout:
+        timeout.check_timeout()
+        raise
+
+
 class RokuHttpControl(object):
     """Send a key-press via Roku remote control protocol.
 
@@ -521,7 +531,8 @@ class RokuHttpControl(object):
 
     def press(self, key):
         roku_keyname = self._KEYNAMES.get(key, key)
-        response = self.requests.post(
+        response = post(
+            requests,
             "http://%s:8060/keypress/%s" % (self.hostname, roku_keyname),
             timeout=self.timeout_secs)
         response.raise_for_status()
@@ -529,7 +540,8 @@ class RokuHttpControl(object):
 
     def keydown(self, key):
         roku_keyname = self._KEYNAMES.get(key, key)
-        response = self.requests.post(
+        response = post(
+            requests,
             "http://%s:8060/keydown/%s" % (self.hostname, roku_keyname),
             timeout=self.timeout_secs)
         response.raise_for_status()
@@ -537,7 +549,8 @@ class RokuHttpControl(object):
 
     def keyup(self, key):
         roku_keyname = self._KEYNAMES.get(key, key)
-        response = self.requests.post(
+        response = post(
+            requests,
             "http://%s:8060/keyup/%s" % (self.hostname, roku_keyname),
             timeout=self.timeout_secs)
         response.raise_for_status()

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -33,7 +33,7 @@ from _stbt.gst_utils import (array_from_sample, gst_iterate,
                              gst_sample_make_writable)
 from _stbt.imgutils import find_user_file, Frame
 from _stbt.logging import ddebug, debug, warn
-from _stbt.timeout import sleep_until
+from _stbt.timeout import check_timeout, sleep_until
 from _stbt.types import Region, UITestError, UITestFailure
 
 gi.require_version("Gst", "1.0")
@@ -888,7 +888,8 @@ class Display(object):
                 t = time.time()
                 if t > end_time:
                     break
-                self._condition.wait(end_time - t)
+                self._condition.wait(min(check_timeout(), end_time - t))
+                check_timeout()
 
         pipeline = self.source_pipeline
         if pipeline:

--- a/_stbt/stbt.conf
+++ b/_stbt/stbt.conf
@@ -10,7 +10,6 @@ control=error
 verbose=0
 power_outlet=none
 v4l2_ctls=
-use_old_threading_behaviour = false
 
 # Handle loss of video (but without end-of-stream event) from the video capture
 # device. Set to "True" if you're using the Hauppauge HD PVR.

--- a/_stbt/stbt_run.py
+++ b/_stbt/stbt_run.py
@@ -96,10 +96,9 @@ def load_test_function(script, args):
         # For backwards compatibility. We want to encourage people to expli-
         # citly import stbt in their scripts, so don't add new APIs here.
         for x in '''press press_until_match wait_for_match wait_for_motion
-                    detect_match MatchResult Position detect_motion
-                    MotionResult save_frame get_frame MatchParameters
-                    debug UITestError UITestFailure MatchTimeout MotionTimeout
-                    ConfigurationError'''.split():
+                    MatchResult Position detect_motion MotionResult save_frame
+                    get_frame MatchParameters debug UITestError UITestFailure
+                    MatchTimeout MotionTimeout ConfigurationError'''.split():
             test_globals[x] = getattr(stbt, x)
 
         def fn():

--- a/_stbt/timeout.py
+++ b/_stbt/timeout.py
@@ -1,0 +1,129 @@
+import functools
+import threading
+import time
+
+
+def timeout(duration=None, raise_=True):
+    """Can be used as a decorator or a contextmanager."""
+    return _Timeout(duration, raise_)
+
+
+def sleep(duration):
+    """A timeout aware version of time.sleep."""
+    with Timeout(duration, raise_=False):
+        while True:
+            time.sleep(check_timeout())
+
+
+def check_timeout(now=None):
+    """Raises an exception on timeout, otherwise returns the amount of time left
+    until the next timeout."""
+    try:
+        stack = _TL.stack
+    except AttributeError:
+        return float('inf')
+    if now is None:
+        now = time.time()
+    stack_level = None
+    for n, t in enumerate(stack):
+        if t.end_time < now:
+            t._timed_out = True  # pylint: disable=protected-access
+            if stack_level is None:
+                stack_level = n
+    if stack_level is not None:
+        raise TimeoutRewind(stack_level, now)
+    else:
+        return min(stack).end_time - now
+
+
+class StillRunning(Exception):
+    pass
+
+
+class TimeoutRewind(BaseException):
+    """This should only be caught by the contextmanager that set up the
+    timeout so it derives from BaseException.  Think of it as equivalent to
+    GeneratorExit or similar."""
+    def __init__(self, stack_level, check_time):
+        super(TimeoutRewind, self).__init__()
+        self.stack_level = stack_level
+        self.check_time = check_time
+
+
+class Timeout(Exception):
+    def __init__(self, message, check_time):
+        super(Timeout, self).__init__(message)
+        self.check_time = check_time
+
+
+_TL = threading.local()
+
+
+class _Timeout(object):
+    def __init__(self, duration=None, message=None, raise_=True):
+        self.duration = duration
+        self.message = message
+        self.raise_ = raise_
+
+        # Only valid between __enter__ and __exit__:
+        self.end_time = None
+        self._stack_pos = None
+
+        # This is set in check_timeout:
+        self._timed_out = None
+
+    # Allow using as a decorator:
+    def __call__(self, func):
+        if self.message is None:
+            self.message = "during %s" % func.__name__
+        @functools.wraps(func)
+        def inner(*args, **kwargs):
+            with self:
+                func(*args, **kwargs)
+        return inner
+
+    def __cmp__(self, other):
+        return cmp(self.end_time, other.end_time)
+
+    def __enter__(self):
+        if self.duration is None:
+            self.end_time = float('inf')
+            return self
+
+        self.end_time = time.time() + duration
+
+        try:
+            stack = _TL.stack
+        except AttributeError:
+            stack = []
+            _TL.stack = stack
+
+        self._stack_pos = len(stack)
+        stack.append(self)
+        return self
+
+    def __exit__(self, _exc_type, exc_value, traceback):
+        if self.duration is None:
+            self._timed_out = False
+            return None
+
+        stack = _TL.stack
+        assert self._stack_pos == len(stack)
+        top_of_stack = stack.pop()
+        assert top_of_stack is self
+        if isinstance(exc_value, TimeoutRewind) and \
+                exc_value.stack_level == self._stack_pos:
+            if self.raise_:
+                raise Timeout, \
+                      Timeout("Timeout", exc_value.check_time), \
+                      traceback
+            else:
+                # Suppress the exception:
+                return True
+        else:
+            return None
+
+    def timed_out(self):
+        if self._timed_out is None:
+            raise StillRunning("Still running")
+        return self._timed_out

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -31,6 +31,11 @@ TODO: Date
   This was introduced in v28, but seems to be unused. See release notes for v28
   below for more information.
 
+* Removed API `stbt.detect_match`. This has been redundant since we introduced
+  `stbt.match` in 0.21 (Dec 2014). It is unlikely there are many uses of it in
+  the wild and it is easily replaced with a combination of `stbt.frames` and
+  `stbt.match`.
+
 ##### New features
 
 ##### Bug fixes & improvements

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -27,6 +27,10 @@ TODO: Date
 
 ##### Breaking changes since v29
 
+* Compatibility flag `global.use_old_threading_behaviour` has been removed.
+  This was introduced in v28, but seems to be unused. See release notes for v28
+  below for more information.
+
 ##### New features
 
 ##### Bug fixes & improvements

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -21,6 +21,16 @@ open-source project, or update [test_pack.stbt_version] if you're using the
 [test_pack.stbt_version]: https://stb-tester.com/manual/advanced-configuration#stbt-conf
 [Stb-tester hardware]: https://stb-tester.com/solutions
 
+#### v30
+
+TODO: Date
+
+##### Breaking changes since v29
+
+##### New features
+
+##### Bug fixes & improvements
+
 #### v29
 
 New APIs for measuring animations and transitions, and for sending infrared

--- a/stbt-batch.d/README.rst
+++ b/stbt-batch.d/README.rst
@@ -96,8 +96,7 @@ directory set to the directory containing the test run logs:
   * ``backtrace.log`` (if ``stbt run`` dumped core).
   * ``screenshot-clean.png`` (taken as soon as the test failed).
   * ``template.png`` (if the test failed due to a MatchTimeout; contains the
-    image that the ``wait_for_match`` or ``detect_match`` function failed to
-    find).
+    image that the ``wait_for_match`` function failed to find).
 
   The program can choose to leave the ``failure-reason`` file unchanged, or to
   overwrite the file with a new failure reason. The failure reason is an

--- a/stbt-camera.d/stbt_camera_validate.py
+++ b/stbt-camera.d/stbt_camera_validate.py
@@ -147,10 +147,9 @@ def validate(video, driver, validate_match=True):
     for square, char in zip(SQUARES, GLYPHS):
         pos = square_to_pos(square)
         template = pristine[pos.y:pos.y + 80, pos.x:pos.x + 80]
-        result = (stbt.detect_match(
+        result = stbt.match(
             template,
             match_parameters=stbt.MatchParameters(match_method="ccoeff-normed"))
-            .next())
         sys.stdout.write(
             "%s%s" % ([FAIL, WARNING, OKGREEN][rate(square, result)], char))
         if square.x == 15:

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -34,7 +34,6 @@ from _stbt.imgutils import (
 from _stbt.logging import (
     debug)
 from _stbt.match import (
-    detect_match,
     match,
     match_all,
     MatchParameters,
@@ -67,7 +66,6 @@ __all__ = [
     "ConfigurationError",
     "crop",
     "debug",
-    "detect_match",
     "detect_motion",
     "draw_text",
     "Frame",

--- a/tests/run-performance-test.sh
+++ b/tests/run-performance-test.sh
@@ -12,7 +12,8 @@ cat > script.$$ <<-EOF
 	frames = 0
 	stbt.frames().next()  # Don't count pipeline startup time
 	start = datetime.datetime.now()
-	for m in stbt.detect_match("videotestsrc-redblue.png", timeout_secs=10):
+	for frame in stbt.frames(timeout_secs=10):
+	    m = match("videotestsrc-redblue.png", frame=frame)
 	    frames += 1
 	    print "%.3f %s %s" % (m.time, bool(m), m.position)
 	    # if not m:

--- a/tests/stbt.conf
+++ b/tests/stbt.conf
@@ -9,7 +9,6 @@ verbose = 1
 power_outlet = none
 
 v4l2_device = /dev/null
-use_old_threading_behaviour = false
 
 test_key = this is a test value
 not_special = this is another test value

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -413,8 +413,7 @@ test_that_get_frame_time_is_wall_time() {
 test_template_annotation_labels() {
     cat > test.py <<-EOF &&
 	import stbt
-	for _ in stbt.detect_match("${testdir}/videotestsrc-checkers-8.png"):
-	    pass
+	stbt.wait_for_match("${testdir}/videotestsrc-checkers-8.png"):
 	EOF
     mkfifo fifo || fail "Initial test setup failed"
 
@@ -440,8 +439,7 @@ test_template_annotation_with_ndarray_template() {
 	template = np.ones(shape=(100, 100, 3), dtype=np.uint8)
 	template *= np.array([0, 255, 0], dtype=np.uint8)  # green
 	stbt.save_frame(template, 'template.png')
-	for _ in stbt.detect_match(template):
-	    pass
+	stbt.wait_for_match(template)
 	EOF
     mkfifo fifo || fail "Initial test setup failed"
 

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -584,22 +584,6 @@ test_multithreaded() {
 }
 
 test_global_use_old_threading_behaviour() {
-    set_config global.use_old_threading_behaviour true
-
-    cat > test.py <<-EOF &&
-	ts = set()
-	for _ in range(10):
-	    ts.add(stbt.get_frame().time)
-	print "Saw %i unique frames" % len(ts)
-	assert len(ts) == 10
-	EOF
-    stbt run test.py 2>stderr.log || fail "Incorrect get_frame() behaviour"
-
-    grep -q "stb-tester/stb-tester/pull/449" stderr.log \
-        || fail "use_old_threading_behaviour Warning not printed"
-
-    set_config global.use_old_threading_behaviour false
-
     cat > test.py <<-EOF &&
 	ts = set()
 	for _ in range(10):
@@ -613,29 +597,6 @@ test_global_use_old_threading_behaviour() {
 }
 
 test_global_use_old_threading_behaviour_frames() {
-    set_config global.use_old_threading_behaviour true
-
-    cat > test.py <<-EOF &&
-	import itertools
-	sa = set()
-	sb = set()
-	for a, b in itertools.izip(stbt.frames(), stbt.frames()):
-	    if len(sa) >= 10:
-	        break
-	    sa.add(a.time)
-	    sb.add(b.time)
-	print sorted(sa)
-	print sorted(sb)
-	assert len(sa) == 10
-	assert len(sb) == 10
-	# sa and sb contain unique frames:
-	assert sa.isdisjoint(sb)
-	EOF
-    stbt run -vv test.py ||
-        fail "Incorrect frames() behaviour (use_old_threading_behaviour=true)"
-
-    set_config global.use_old_threading_behaviour false
-
     cat > test.py <<-EOF &&
 	import itertools
 	sa = set()


### PR DESCRIPTION
You can now decorate a function with a timeout

```
@timeout(3)
def test_something():
    ...
```

or use it as a `contextmanager`:

```
with timeout(30):
    while True:
        ...
```

This greatly simplifies looping and retries in test-scripts.  It's inspired by [Timeouts and cancellation for humans](https://vorpus.org/blog/timeouts-and-cancellation-for-humans/)

**TODO:**

* [ ] We currently only cope with having a single stack.  Generators mean we can have more than one "stack" per thread which will confuse the timeouts.
* [ ] Consider how to attach additional information to a timeout.  It would be nice to get a `MatchTimeout` or similar if that's what we've been doing at the time of the timeout.
* [ ] Write tests
* [ ] Make it actually work