### PR TITLE
stbt.load_image: Change `flags` default value to BGR[A]

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -30,7 +30,7 @@ from _stbt import logging
 from _stbt.config import get_config
 from _stbt.gst_utils import (array_from_sample, gst_iterate,
                              gst_sample_make_writable)
-from _stbt.imgutils import find_user_file, Frame
+from _stbt.imgutils import find_user_file, Frame, imread
 from _stbt.logging import ddebug, debug, warn
 from _stbt.types import Region, UITestError, UITestFailure
 
@@ -47,7 +47,7 @@ warnings.filterwarnings(
 # ===========================================================================
 
 
-def load_image(filename, flags=cv2.IMREAD_COLOR):
+def load_image(filename, flags=None):
     """Find & read an image from disk.
 
     If given a relative filename, this will search in the directory of the
@@ -68,18 +68,20 @@ def load_image(filename, flags=cv2.IMREAD_COLOR):
 
     :param flags: Flags to pass to :ocv:pyfunc:`cv2.imread`.
 
-    :returns: An image in OpenCV format (a `numpy.ndarray` of 8-bit values, 3
-        channel BGR).
+    :returns: An image in OpenCV format — that is, a `numpy.ndarray` of 8-bit
+        values. With the default flags this will be 3 channels BGR, or 4
+        channels BGRA if the file has an alpha (transparency) channel.
     :raises: `IOError` if the specified path doesn't exist or isn't a valid
         image file.
 
-    Added in v28.
+    | Added in v28.
+    | Changed in v30: Include alpha (transparency) channel if the file has one.
     """
 
     absolute_filename = find_user_file(filename)
     if not absolute_filename:
         raise IOError("No such file: %s" % filename)
-    image = cv2.imread(absolute_filename, flags)
+    image = imread(absolute_filename, flags)
     if image is None:
         raise IOError("Failed to load image: %s" % absolute_filename)
     return image

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -69,13 +69,14 @@ def load_image(filename, flags=None):
     :param flags: Flags to pass to :ocv:pyfunc:`cv2.imread`.
 
     :returns: An image in OpenCV format — that is, a `numpy.ndarray` of 8-bit
-        values. With the default flags this will be 3 channels BGR, or 4
-        channels BGRA if the file has an alpha (transparency) channel.
+        values. With the default ``flags`` parameter this will be 3 channels
+        BGR, or 4 channels BGRA if the file has transparent pixels.
     :raises: `IOError` if the specified path doesn't exist or isn't a valid
         image file.
 
-    | Added in v28.
-    | Changed in v30: Include alpha (transparency) channel if the file has one.
+    * Added in v28.
+    * Changed in v30: Include alpha (transparency) channel if the file has
+      transparent pixels.
     """
 
     absolute_filename = find_user_file(filename)

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -146,6 +146,10 @@ def imread(filename, flags=None):
         if len(img.shape) == 2 or img.shape[2] == 1:
             img = cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
 
+        # Remove alpha channel if it's 100% opaque
+        if img.shape[2] == 4 and numpy.all(img[:, :, 3] == 255):
+            img = img[:, :, :3]
+
     return img
 
 

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -65,6 +65,7 @@ def test_matching_greyscale_array_with_greyscale_frame(match_method):
 ])
 def test_that_match_converts_greyscale_reference_image(filename):
     stbt.match(filename, frame=black())  # Doesn't raise
+    stbt.match(stbt.load_image(filename), frame=black())
 
 
 @pytest.mark.parametrize("match_method", [


### PR DESCRIPTION
This makes transparency work when you call `stbt.load_image` and pass the result to `stbt.match`, instead of passing the filename to `stbt.match`.

TODO:

- [x] Merge #542 & rebase.
- [x] Remove `cv2` from top-level code for the sake of (future) pylint-stubs generation.
- [x] ~~Provide config value for backwards compatibility?~~ I've found a way to provide backward compatibility (see #548).
- [x] Strip alpha channel if all pixels == 255? We use `frame=load_image(...)` a lot in our unit tests, and many of our screenshots have an alpha channel (albeit 100% opaque).
