### PR TITLE
RokuHttpControl: Cleanup: Inherit from RemoteControl

### DIFF
--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -480,7 +480,7 @@ class IRNetBoxControl(RemoteControl):
             raise
 
 
-class RokuHttpControl(object):
+class RokuHttpControl(RemoteControl):
     """Send a key-press via Roku remote control protocol.
 
     See https://sdkdocs.roku.com/display/sdkdoc/External+Control+API


### PR DESCRIPTION
No user-visible change, just fixing an inconsistency from the other
RemoteControl implementations.