### PR TITLE
debian: Fixes for publishing to PPA from Ubuntu 18.04 build machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,8 +161,7 @@ INSTALL_GPL_FILES = \
     _stbt/control_gpl.py
 
 install-gpl: $(INSTALL_GPL_FILES)
-	$(INSTALL) -m 0755 -d \
-	    $(patsubst %,$(DESTDIR)$(libexecdir)/stbt/%,$(sort $(dir $(INSTALL_GPL_FILES))))
+	$(INSTALL) -m 0755 -d $(DESTDIR)$(pythondir)/_stbt
 	for filename in $(INSTALL_GPL_FILES); do \
 	    [ -x "$$filename" ] && mode=0755 || mode=0644; \
 	    $(INSTALL) -m $$mode $$filename $(DESTDIR)$(pythondir)/$$filename; \

--- a/extra/debian/build-source-package.sh
+++ b/extra/debian/build-source-package.sh
@@ -71,5 +71,6 @@ mkdir -p $srcdir/debian-packages
 mv $builddir/stb-tester_$version.orig.tar.gz \
     $builddir/stb-tester_$version-$release.debian.tar.gz \
     $builddir/stb-tester_$version-$release.dsc \
+    $builddir/stb-tester_$version-${release}_source.buildinfo \
     $builddir/stb-tester_$version-${release}_source.changes \
     $srcdir/debian-packages


### PR DESCRIPTION
It turns out that we had forgotten to publish the PPA packages back in June.