### PR TITLE
stbt auto-selftest: Pre-import stbt & dependencies for better performance

### DIFF
--- a/stbt_auto_selftest.py
+++ b/stbt_auto_selftest.py
@@ -194,6 +194,11 @@ def _progress_line(width, n, total):
 def generate_into_tmpdir(source_files=None):
     start_time = time.time()
 
+    # Importing stbt + gstreamer bindings + opencv is slow.
+    # multiprocessing.Pool uses `fork` so by importing here, these modules
+    # won't be imported from scratch in each subprocess.
+    import stbt  # pylint:disable=unused-variable
+
     selftest_dir = "%s/selftest" % os.curdir
     mkdir_p(selftest_dir)
     # We use this process pool for sandboxing rather than concurrency:


### PR DESCRIPTION
Importing stbt + gstreamer bindings + opencv is slow. On Unix systems
`multiprocessing.Pool` uses `fork` so by importing stbt first, these
modules won't be imported from scratch in each subprocess. We use a
different subprocess for each Python file that we analyse.

This saves about 1 second on `tests/auto-selftest-example-test-pack`.
The improvement will be even larger on test-packs with more Python
files.

This should also make `test_auto_selftest_caching` more reliable.