### PR TITLE
stbt.match: Performance optimisation: Don't threshold last matchTemplate heatmap

### DIFF
--- a/_stbt/imgproc_cache.py
+++ b/_stbt/imgproc_cache.py
@@ -352,7 +352,7 @@ def test_that_cache_speeds_up_match_all():
     cached_time, uncached_time, cached_result, uncached_result = (
         _check_cache_behaviour(match_all))
 
-    assert uncached_time > (cached_time * 4)
+    assert uncached_time > (cached_time * 2)
     assert len(uncached_result) == 6
     for cached, uncached in itertools.izip_longest(cached_result,
                                                    uncached_result):

--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -565,13 +565,14 @@ def _find_candidate_matches(image, template, mask, match_parameters, imglog):
         if not matched:
             break
 
-        _, roi_mask = cv2.threshold(
-            heatmap,
-            (1 - threshold) * heatmap_scale,
-            255,
-            cv2.THRESH_BINARY_INV)
-        roi_mask = roi_mask.astype(numpy.uint8)
-        imwrite("source_matchtemplate_threshold", roi_mask)
+        if level > 0 or imglog.enabled:
+            _, roi_mask = cv2.threshold(
+                heatmap,
+                (1 - threshold) * heatmap_scale,
+                255,
+                cv2.THRESH_BINARY_INV)
+            roi_mask = roi_mask.astype(numpy.uint8)
+            imwrite("source_matchtemplate_threshold", roi_mask)
 
     # pylint:disable=undefined-loop-variable
     region = Region(*_upsample(best_match_position, level),


### PR DESCRIPTION
Here we create `roi_mask` which is used in the next iteration of the
`for` loop. In the last iteration we don't need to create a new
`roi_mask`, because it isn't used after the `for` loop.

This saves up to 1ms on my laptop.