### PR TITLE
stbt.match: Don't relax threshold at smaller pyramid levels

### DIFF
--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -547,13 +547,13 @@ def _find_candidate_matches(image, template, mask, match_parameters, imglog):
             image_pyramid[level], template_pyramid[level], mask_pyramid[level],
             method, roi_mask, level, imwrite)
 
-        # Relax the threshold slightly for scaled-down pyramid levels to
-        # compensate for scaling artifacts.
-        if level == 0:
+        if level == 0 or match_parameters.match_method == MatchMethod.SQDIFF:
             relax = 0
-        elif match_parameters.match_method == MatchMethod.SQDIFF:
-            relax = 0.01
         else:
+            # We used to think that we needed to relax the threshold for
+            # scaled-down pyramid levels to compensate for scaling artifacts.
+            # Keep it for the older match-methods, for (paranoid) backwards
+            # compatibility.
             relax = 0.2
         threshold = max(0, match_parameters.match_threshold - relax)
 


### PR DESCRIPTION
I tested 69 reference images (ranging in size from 40x1 to 1280x720)
against 22 screenshots (720p): 1,518 comparisons in total.
Of these 1,518 pairs, 221 matched (15%).

* There were a quite a few cases where the certainty at smaller levels
  was much higher than the certainty at the final level (where it didn't
  match): Up to 0.24 higher.

* There were only 13 cases (0.9%) where the certainty at the smallest
  level was *lower* than the certainty at the final level. All of these
  were matches at the final level (that's to be expected, because if it
  were much lower at the smaller level it wouldn't get past that level).
  The biggest difference was by 0.00183: the absolute certainties were
  0.99550 (level 2), 0.99745 (level 1), 0.99734 (final level).

* There were no cases where either of the smaller pyramid levels was
  <0.98 but the final level was >=0.98.

TODO:

- [ ] Repeat these measurements but allowing the calculations to proceed
  even if the earlier pyramid levels fall well below the threshold
  (the measurements above are with sqdiff @ 0.98, relax=0.01).