### PR TITLE
match: Change sqdiff normalisation

### DIFF
--- a/_stbt/stbt.conf
+++ b/_stbt/stbt.conf
@@ -34,7 +34,7 @@ video_format = mp4
 
 [match]
 match_method=sqdiff
-match_threshold=0.98
+match_threshold=0.85
 confirm_method=normed-absdiff
 confirm_threshold=0.30
 erode_passes=1

--- a/tests/stbt.conf
+++ b/tests/stbt.conf
@@ -21,7 +21,7 @@ video_format = mp4
 
 [match]
 match_method=sqdiff
-match_threshold=0.98
+match_threshold=0.85
 confirm_method=normed-absdiff
 confirm_threshold=0.30
 erode_passes=1


### PR DESCRIPTION
Previously we'd normalise SQDIFF matching such that a certainty of 1 is
perfect match and a certainty of 0 is the match of a white template against
a black image (or vice-versa).  This normalisation has some strange
properties:

* You can't get a certainty of zero if your template is not extreme
* You can't get a certainty of zero if your frame is not extreme
* For a mid-grey template (128, 128, 128) the *minimum* certainty possible
  is 75%!
* For a mid-grey template comparing against a random noise (i.e. completely
  decorrelated with the template) you expect a certainty of 92%!
* For a black/white template compared against noise you expect a certainty
  of 66%!

This commit changes the normalisation such that:

* Comparing *any* template against noise should give a certainty of ~0.
* The normalisation only depends on the template and not the frame (unlike
  sqdiff-normed).

We do this by calculating the average sqdiff of the template against all
possible frames.  This works out to be:

    ²⁵⁵₀∫(v-k)²dk
    -------------
         255

    = v² - 255v + 255²/3

Summed over the whole template where v is a single pixel/channel value
between 0 - 255.

With this normalisation method we get negative certainties too, but I clamp
them away to avoid confusing users.

TODO:

- [ ] Choose appropriate defaults
- [ ] Check debug html