### PR TITLE
stbt.match: Invert the meaning of confirm_threshold

### DIFF
--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -106,20 +106,20 @@ class MatchParameters(object):
         are a single solid color without any lines or variation).
 
         This is the default method, with a default ``confirm_threshold`` of
-        0.30.
+        0.70.
 
     :param float confirm_threshold:
-      The maximum allowed difference between any given pixel from the reference
-      image and its counterpart from the candidate region in the source video
-      frame, as a fraction of the pixel's total luminance range.
+      The minimum allowed similarity between any given pixel in the reference
+      image and the corresponding pixel in the source video frame, as a
+      fraction of the pixel's total luminance range.
 
       Unlike ``match_threshold``, this threshold applies to each pixel
       individually: Any pixel that exceeds this threshold will cause the match
       to fail (but see ``erode_passes`` below).
 
-      Valid values range from 0 (more strict) to 1.0 (less strict). Useful
-      values tend to be around 0.16 for ``ABSDIFF``, and 0.30 for
-      ``NORMED_ABSDIFF``. Defaults to 0.30.
+      Valid values range from 0 (less strict) to 1.0 (more strict). Useful
+      values tend to be around 0.84 for ``ABSDIFF``, and 0.70 for
+      ``NORMED_ABSDIFF``. Defaults to 0.70.
 
     :param int erode_passes:
       After the ``ABSDIFF`` or ``NORMED_ABSDIFF`` absolute difference is taken,
@@ -794,7 +794,7 @@ def _confirm_match(image, region, template, mask, match_parameters, imwrite):
 
     absdiff = cv2.absdiff(image, template)
     _, thresholded = cv2.threshold(
-        absdiff, int(match_parameters.confirm_threshold * 255),
+        absdiff, int((1 - match_parameters.confirm_threshold) * 255),
         255, cv2.THRESH_BINARY)
     eroded = cv2.erode(
         thresholded,

--- a/_stbt/stbt.conf
+++ b/_stbt/stbt.conf
@@ -36,7 +36,7 @@ video_format = mp4
 match_method=sqdiff
 match_threshold=0.98
 confirm_method=normed-absdiff
-confirm_threshold=0.30
+confirm_threshold=0.70
 erode_passes=1
 
 # Downsample the video frame and the reference image before matching, as a

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -72,6 +72,14 @@ TODO: Date
   match_threshold=0.80
   ```
 
+* `stbt.match`: Inverted the meaning of `confirm_threshold`. Now numbers closer
+  to 0 mean "less strict" and numbers closer to 1 mean "more strict". This is
+  for consistency with `match_threshold`. The default value has changed
+  accordingly, from 0.3 to 0.7.
+
+  If you were overriding the default value, you need to set the new value to
+  (1 - previous_value), for example change 0.16 to 0.84.
+
 * `stbt.load_image` will now return a 4-channel image (BGRA, where the 4th
   channel is the alpha, or transparency, channel) if the file had any
   transparent pixels.

--- a/stbt-match
+++ b/stbt-match
@@ -40,7 +40,7 @@ parser.add_argument(
     "match_parameters", nargs="*",
     help="""Parameters for the image processing algorithm. See
         'MatchParameters' in the stbt API documentation. For example:
-        'confirm_threshold=0.20')""")
+        'confirm_threshold=0.70')""")
 args = parser.parse_args(sys.argv[1:])
 
 mp = {}

--- a/tests/stbt-debug-expected-output/match/00002/index.html
+++ b/tests/stbt-debug-expected-output/match/00002/index.html
@@ -201,7 +201,7 @@
               <th><b>Absolute differences</b></th>
               <th>
                 Differences <b>above confirm_threshold</b>
-                of 0.30
+                of 0.70
               </th>
               <th>
                 After <b>eroding</b>

--- a/tests/stbt-debug-expected-output/match/00003/index.html
+++ b/tests/stbt-debug-expected-output/match/00003/index.html
@@ -201,7 +201,7 @@
               <th><b>Absolute differences</b></th>
               <th>
                 Differences <b>above confirm_threshold</b>
-                of 0.30
+                of 0.70
               </th>
               <th>
                 After <b>eroding</b>

--- a/tests/stbt-debug-expected-output/match/00004/index.html
+++ b/tests/stbt-debug-expected-output/match/00004/index.html
@@ -198,7 +198,7 @@
               <th><b>Absolute differences</b></th>
               <th>
                 Differences <b>above confirm_threshold</b>
-                of 0.16
+                of 0.84
               </th>
               <th>
                 After <b>eroding</b>

--- a/tests/stbt.conf
+++ b/tests/stbt.conf
@@ -23,7 +23,7 @@ video_format = mp4
 match_method=sqdiff
 match_threshold=0.98
 confirm_method=normed-absdiff
-confirm_threshold=0.30
+confirm_threshold=0.70
 erode_passes=1
 pyramid_levels = 3
 

--- a/tests/test-camera.sh
+++ b/tests/test-camera.sh
@@ -77,7 +77,7 @@ test_that_stbtgeometriccorrection_flattens_pictures_of_TVs() {
 
     create_stb_tester_logo_template &&
     echo 'wait_for_match("stb-tester-350px.png",
-                         match_parameters=MatchParameters(confirm_threshold=0.3))' >test.py &&
+                         match_parameters=MatchParameters(confirm_threshold=0.7))' >test.py &&
     stbt run -v test.py
 }
 

--- a/tests/test-match.sh
+++ b/tests/test-match.sh
@@ -179,7 +179,7 @@ test_wait_for_match_confirm_threshold_affects_match() {
     cat > test.py <<-EOF
 	wait_for_match("$testdir/slight-variation-2.png", timeout_secs=1,
 	               match_parameters=MatchParameters(
-	                   confirm_method="absdiff", confirm_threshold=0.4))
+	                   confirm_method="absdiff", confirm_threshold=0.6))
 	EOF
     ! stbt run -v --source-pipeline="$source_pipeline" --control=none test.py
 }

--- a/tests/test-stbt-match.sh
+++ b/tests/test-stbt-match.sh
@@ -27,11 +27,11 @@ test_that_stbt_match_applies_confirm_threshold_parameter() {
     ! stbt match \
         "$testdir"/videotestsrc-full-frame.png \
         "$testdir"/videotestsrc-redblue-with-dots.png \
-        match_threshold=0.9 confirm_method=absdiff confirm_threshold=0.16 &&
+        match_threshold=0.9 confirm_method=absdiff confirm_threshold=0.84 &&
     stbt match \
         "$testdir"/videotestsrc-full-frame.png \
         "$testdir"/videotestsrc-redblue-with-dots.png \
-        match_threshold=0.9 confirm_method=absdiff confirm_threshold=0.9
+        match_threshold=0.9 confirm_method=absdiff confirm_threshold=0.1
 }
 
 test_that_stbt_match_rejects_invalid_parameters() {
@@ -46,7 +46,7 @@ test_that_stbt_match_rejects_invalid_parameters() {
     ! stbt match \
         "$testdir"/videotestsrc-full-frame.png \
         "$testdir"/videotestsrc-redblue-with-dots.png \
-        confirm_threshold=0.9 \
+        confirm_threshold=0.1 \
         lahdee=dah &&
     cat log | grep -q "Invalid argument 'lahdee=dah'" &&
     ! stbt match \

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -32,7 +32,7 @@ test_get_frame_and_save_frame() {
 	press("gamut")
 	# confirm_threshold accounts for match rectangle in the screenshot.
 	wait_for_match("gamut.png",
-	               match_parameters=MatchParameters(confirm_threshold=0.7))
+	               match_parameters=MatchParameters(confirm_threshold=0.3))
 	EOF
     stbt run -v match-screenshot.py
 }

--- a/tests/test_stbt_debug.py
+++ b/tests/test_stbt_debug.py
@@ -39,7 +39,7 @@ def test_match_debug():
         matches = list(stbt.match_all(
             "button.png", frame=stbt.load_image("buttons.png"),
             match_parameters=mp(confirm_method="absdiff",
-                                confirm_threshold=0.16)))
+                                confirm_threshold=0.84)))
         print matches
         assert len(matches) == 6
 


### PR DESCRIPTION
Now 0 means "less strict" and 1.0 means "completely strict". i.e. it's measuring the similarity, rather than the difference (error).

This is for consistency with the `match_threshold`. The discrepancy has caused some confusion in the past.

In all the user test-scripts that we've seen, confirm_threshold is never changed from its default values, except to set it to an absurdly high value (where the intent was really to disable the confirm pass; you can do that with `confirm_method=ConfirmMethod.NONE`).