### PR TITLE
debug html: Link to bootstrap CSS file with HTTPS 

### DIFF
--- a/_stbt/logging.py
+++ b/_stbt/logging.py
@@ -247,7 +247,7 @@ _INDEX_HTML_HEADER = dedent(u"""\
     <html lang='en'>
     <head>
     <meta charset="utf-8"/>
-    <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
+    <link href="https://stb-tester.com/assets/bootstrap-3.3.2.min.css" rel="stylesheet">
     <style>
         a.nav { margin: 10px; }
         a.nav[href*="/00000/"] { visibility: hidden; }

--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -964,10 +964,6 @@ def _log_match_image_debug(imglog):
             </table>
           {% endif %}
         {% endif %}
-
-        <p>For further help please read
-            <a href="http://stb-tester.com/match-parameters.html">stb-tester
-            image matching parameters</a>.
     """
 
     def link(name, level=None, match=None):  # pylint: disable=redefined-outer-name

--- a/tests/stbt-debug-expected-output/is_screen_black/00001/index.html
+++ b/tests/stbt-debug-expected-output/is_screen_black/00001/index.html
@@ -2,7 +2,7 @@
 <html lang='en'>
 <head>
 <meta charset="utf-8"/>
-<link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
+<link href="https://stb-tester.com/assets/bootstrap-3.3.2.min.css" rel="stylesheet">
 <style>
     a.nav { margin: 10px; }
     a.nav[href*="/00000/"] { visibility: hidden; }

--- a/tests/stbt-debug-expected-output/is_screen_black/00002/index.html
+++ b/tests/stbt-debug-expected-output/is_screen_black/00002/index.html
@@ -2,7 +2,7 @@
 <html lang='en'>
 <head>
 <meta charset="utf-8"/>
-<link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
+<link href="https://stb-tester.com/assets/bootstrap-3.3.2.min.css" rel="stylesheet">
 <style>
     a.nav { margin: 10px; }
     a.nav[href*="/00000/"] { visibility: hidden; }

--- a/tests/stbt-debug-expected-output/is_screen_black/00003/index.html
+++ b/tests/stbt-debug-expected-output/is_screen_black/00003/index.html
@@ -2,7 +2,7 @@
 <html lang='en'>
 <head>
 <meta charset="utf-8"/>
-<link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
+<link href="https://stb-tester.com/assets/bootstrap-3.3.2.min.css" rel="stylesheet">
 <style>
     a.nav { margin: 10px; }
     a.nav[href*="/00000/"] { visibility: hidden; }

--- a/tests/stbt-debug-expected-output/is_screen_black/00004/index.html
+++ b/tests/stbt-debug-expected-output/is_screen_black/00004/index.html
@@ -2,7 +2,7 @@
 <html lang='en'>
 <head>
 <meta charset="utf-8"/>
-<link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
+<link href="https://stb-tester.com/assets/bootstrap-3.3.2.min.css" rel="stylesheet">
 <style>
     a.nav { margin: 10px; }
     a.nav[href*="/00000/"] { visibility: hidden; }

--- a/tests/stbt-debug-expected-output/match/00001/index.html
+++ b/tests/stbt-debug-expected-output/match/00001/index.html
@@ -2,7 +2,7 @@
         <!DOCTYPE html>
         <html lang='en'>
         <head>
-        <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
+        <link href="https://stb-tester.com/assets/bootstrap-3.3.2.min.css" rel="stylesheet">
         <style>
             h5 { margin-top: 40px; }
             .table th { font-weight: normal; background-color: #eee; }

--- a/tests/stbt-debug-expected-output/match/00002/index.html
+++ b/tests/stbt-debug-expected-output/match/00002/index.html
@@ -2,7 +2,7 @@
         <!DOCTYPE html>
         <html lang='en'>
         <head>
-        <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
+        <link href="https://stb-tester.com/assets/bootstrap-3.3.2.min.css" rel="stylesheet">
         <style>
             h5 { margin-top: 40px; }
             .table th { font-weight: normal; background-color: #eee; }

--- a/tests/stbt-debug-expected-output/match/00003/index.html
+++ b/tests/stbt-debug-expected-output/match/00003/index.html
@@ -2,7 +2,7 @@
         <!DOCTYPE html>
         <html lang='en'>
         <head>
-        <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
+        <link href="https://stb-tester.com/assets/bootstrap-3.3.2.min.css" rel="stylesheet">
         <style>
             h5 { margin-top: 40px; }
             .table th { font-weight: normal; background-color: #eee; }

--- a/tests/stbt-debug-expected-output/match/00004/index.html
+++ b/tests/stbt-debug-expected-output/match/00004/index.html
@@ -2,7 +2,7 @@
         <!DOCTYPE html>
         <html lang='en'>
         <head>
-        <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
+        <link href="https://stb-tester.com/assets/bootstrap-3.3.2.min.css" rel="stylesheet">
         <style>
             h5 { margin-top: 40px; }
             .table th { font-weight: normal; background-color: #eee; }

--- a/tests/stbt-debug-expected-output/motion/00001/index.html
+++ b/tests/stbt-debug-expected-output/motion/00001/index.html
@@ -2,7 +2,7 @@
 <html lang='en'>
 <head>
 <meta charset="utf-8"/>
-<link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
+<link href="https://stb-tester.com/assets/bootstrap-3.3.2.min.css" rel="stylesheet">
 <style>
     a.nav { margin: 10px; }
     a.nav[href*="/00000/"] { visibility: hidden; }

--- a/tests/stbt-debug-expected-output/motion/00002/index.html
+++ b/tests/stbt-debug-expected-output/motion/00002/index.html
@@ -2,7 +2,7 @@
 <html lang='en'>
 <head>
 <meta charset="utf-8"/>
-<link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
+<link href="https://stb-tester.com/assets/bootstrap-3.3.2.min.css" rel="stylesheet">
 <style>
     a.nav { margin: 10px; }
     a.nav[href*="/00000/"] { visibility: hidden; }

--- a/tests/stbt-debug-expected-output/motion/00003/index.html
+++ b/tests/stbt-debug-expected-output/motion/00003/index.html
@@ -2,7 +2,7 @@
 <html lang='en'>
 <head>
 <meta charset="utf-8"/>
-<link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
+<link href="https://stb-tester.com/assets/bootstrap-3.3.2.min.css" rel="stylesheet">
 <style>
     a.nav { margin: 10px; }
     a.nav[href*="/00000/"] { visibility: hidden; }

--- a/tests/stbt-debug-expected-output/motion/00004/index.html
+++ b/tests/stbt-debug-expected-output/motion/00004/index.html
@@ -2,7 +2,7 @@
 <html lang='en'>
 <head>
 <meta charset="utf-8"/>
-<link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
+<link href="https://stb-tester.com/assets/bootstrap-3.3.2.min.css" rel="stylesheet">
 <style>
     a.nav { margin: 10px; }
     a.nav[href*="/00000/"] { visibility: hidden; }

--- a/tests/stbt-debug-expected-output/motion/00005/index.html
+++ b/tests/stbt-debug-expected-output/motion/00005/index.html
@@ -2,7 +2,7 @@
 <html lang='en'>
 <head>
 <meta charset="utf-8"/>
-<link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
+<link href="https://stb-tester.com/assets/bootstrap-3.3.2.min.css" rel="stylesheet">
 <style>
     a.nav { margin: 10px; }
     a.nav[href*="/00000/"] { visibility: hidden; }

--- a/tests/stbt-debug-expected-output/motion/00006/index.html
+++ b/tests/stbt-debug-expected-output/motion/00006/index.html
@@ -2,7 +2,7 @@
 <html lang='en'>
 <head>
 <meta charset="utf-8"/>
-<link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
+<link href="https://stb-tester.com/assets/bootstrap-3.3.2.min.css" rel="stylesheet">
 <style>
     a.nav { margin: 10px; }
     a.nav[href*="/00000/"] { visibility: hidden; }


### PR DESCRIPTION
If you were serving these generated HTML files over HTTPS, browsers
would refuse to load the CSS from an HTTP URL.