### PR TITLE
stbt.match merge_regions: Use line-sweep algorithm

### DIFF
--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -365,7 +365,9 @@ def test_merge_regions_performance(n):
         y, h = min(y, bottom), max(y, bottom) - min(y, bottom) + 1
         regions.append(stbt.Region(x, y, w, h))
 
-    times = timeit.repeat(lambda: _merge_regions(regions), number=1, repeat=10)
+    times = timeit.repeat(lambda: _merge_regions(regions), number=1, repeat=100)
     print times
-    print min(times)
+    print "max: %f" % max(times)
+    print "avg: %f" % (sum(times) / len(times))
+    print "min: %f" % min(times)
     assert min(times) < (0.001 * n / 20)

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -343,7 +343,7 @@ def test_merge_regions():
         (0, 60, 17, 10), (111, 54, 2, 2), (138, 47, 5, 2), (132, 47, 3, 1),
         (130, 46, 1, 2), (55, 32, 11, 1), (52, 32, 1, 1), (0, 29, 50, 28),
         (0, 20, 57, 4), (33, 0, 233, 139)]]
-    _merge_regions(regions)
+    regions = _merge_regions(regions)
     assert len(regions) == 9
     assert sorted(regions) == (
         [stbt.Region(*x) for x in [
@@ -365,8 +365,7 @@ def test_merge_regions_performance(n):
         y, h = min(y, bottom), max(y, bottom) - min(y, bottom) + 1
         regions.append(stbt.Region(x, y, w, h))
 
-    times = timeit.repeat(lambda: _merge_regions(regions[:]),
-                          number=1, repeat=10)
+    times = timeit.repeat(lambda: _merge_regions(regions), number=1, repeat=10)
     print times
     print min(times)
     assert min(times) < (0.001 * n / 20)


### PR DESCRIPTION
It's still quadratic, or rather M×N but with a smaller N because we only consider regions currently under the "sweep line".

![screenshot from 2019-02-15 11-40-18](https://user-images.githubusercontent.com/12424/52854503-7bf1da80-3116-11e9-8529-3a75a117a783.png)

*From https://www.cs.princeton.edu/~rs/AlgsDS07/17GeometricSearch.pdf*

Unfortunately the extra complexity means it's slower than the previous implementation. On my laptop:

| number of regions | line-sweep (min/avg/max, ms) | previous implementation |
|-------------------|------------------------------|-------------------------|
|                20 |  0.4 /  0.4 /  0.9           |  0.05 /  0.07 /  0.6    |
|               200 |  2   /  2   /  4             |  1    /  1    /  2      |
|              2000 | 20   / 22   / 40             | 12    / 12    / 15      |

I'm raising a pull request to keep a record, but I don't intend to merge it.