### PR TITLE
test_sqdiff_c_numpy_equivalence: Fix generating mask

### DIFF
--- a/_stbt/sqdiff.py
+++ b/_stbt/sqdiff.py
@@ -96,7 +96,7 @@ def _random_template(size=(1280, 720)):
     tt = numpy.random.randint(0, 256, (tsize[1], tsize[0], 4),
                               dtype=numpy.uint8)
     mask = tt[:, :, 3]
-    mask[mask & 1] = 255
+    mask[mask & 1 == 1] = 255
     mask[mask < 255] = 0
 
     f_cropped = f[toff[1]:toff[1] + tsize[1], toff[0]:toff[0] + tsize[0], :]


### PR DESCRIPTION
`mask[mask & 1] == 255` sets *all* elements of the array to 255, unconditionally. Also, it fails if the height or width of the array is 1 (this is how I noticed): "IndexError: index 1 is out of bounds for axis 0 with size 1".

You need to index with an array of bools instead.