### PR TITLE
press_and_wait: Fix regression

### DIFF
--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -77,6 +77,9 @@ def press_and_wait(
         timestamps can be compared with system time (the output of
         ``time.time()``).
     """
+    if _dut is None:
+        import stbt
+        _dut = stbt
 
     t = _Transition(region, mask, timeout_secs, stable_secs, _dut)
     press_result = _dut.press(key)
@@ -114,6 +117,10 @@ def wait_for_transition_to_end(
 
     :returns: See `press_and_wait`.
     """
+    if _dut is None:
+        import stbt
+        _dut = stbt
+
     t = _Transition(region, mask, timeout_secs, stable_secs, _dut)
     result = t.wait_for_transition_to_end(initial_frame)
     debug("wait_for_transition_to_end() -> %s" % (result,))
@@ -123,12 +130,9 @@ def wait_for_transition_to_end(
 class _Transition(object):
     def __init__(self, region=Region.ALL, mask=None, timeout_secs=10,
                  stable_secs=1, dut=None):
-
         if dut is None:
             import stbt
-            self.dut = stbt
-        else:
-            self.dut = dut
+            dut = stbt
 
         if region is not Region.ALL and mask is not None:
             raise ValueError(
@@ -143,6 +147,7 @@ class _Transition(object):
 
         self.timeout_secs = timeout_secs
         self.stable_secs = stable_secs
+        self.dut = dut
 
         self.frames = self.dut.frames()
         self.diff = strict_diff

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -646,3 +646,25 @@ test_that_press_returns_a_pressresult() {
 	EOF
     stbt run -vv --control=none test.py || fail "Incorrect press() behaviour"
 }
+
+test_press_and_wait() {
+    # This is a regression test - dut was incorrectly injected into
+    # press_and_wait causing failures that our pytest tests didn't find.
+    cat > test.py <<-EOF &&
+	import stbt
+	import threading
+
+	stbt.press("black")
+	stbt.wait_until(stbt.is_screen_black)
+	
+	assert stbt.press_and_wait("white")
+	assert not stbt.press_and_wait("white", timeout_secs=1)
+	
+	stbt.press("ball")
+	stbt.wait_for_motion()
+	threading.Timer(0.1, lambda: stbt.press("black")).start()
+	assert stbt.wait_for_transition_to_end()
+	EOF
+
+    stbt run -vv test.py || fail "Incorrect press_and_wait() behaviour"
+}


### PR DESCRIPTION
Since 75fd9feb65d `press_and_wait` has failed with the exception:

    Traceback (most recent call last):
      ...
      File "test.py", line 7, in <module>
        assert stbt.press_and_wait("white")
      File "_stbt/transition.py", line 82, in press_and_wait
        press_result = _dut.press(key)
    AttributeError: 'NoneType' object has no attribute 'press'

This wasn't caught by our existing tests because each of them inject a
custom `dut` for testing and this issue was caused by not defaulting `dut`
correctly.