### PR TITLE
stbt.match: Improve error message when region is too small

### DIFF
--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -382,6 +382,9 @@ def _match_all(image, frame, match_parameters, region):
     if input_region is None:
         raise ValueError("frame with dimensions %r doesn't contain %r"
                          % (frame.shape, region))
+    if input_region.height < t.shape[0] or input_region.width < t.shape[1]:
+        raise ValueError("%r must be larger than reference image %r"
+                         % (input_region, t.shape))
 
     imglog = ImageLogger(
         "match", match_parameters=match_parameters,

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -56,6 +56,44 @@ def test_that_match_rejects_greyscale_array(match_method):
                    match_parameters=mp(match_method=match_method))
 
 
+def test_match_error_message_for_too_small_frame_and_region():
+    stbt.match("videotestsrc-redblue.png", frame=black(width=92, height=160))
+    stbt.match("videotestsrc-redblue.png", frame=black(),
+               region=stbt.Region(x=1188, y=560, width=92, height=160))
+
+    with pytest.raises(ValueError) as excinfo:
+        stbt.match("videotestsrc-redblue.png",
+                   frame=black(width=91, height=160))
+    assert (
+        "Frame (160, 91, 3) must be larger than reference image (160, 92, 3)"
+        in str(excinfo.value))
+
+    with pytest.raises(ValueError) as excinfo:
+        stbt.match("videotestsrc-redblue.png",
+                   frame=black(width=92, height=159))
+    assert (
+        "Frame (159, 92, 3) must be larger than reference image (160, 92, 3)"
+        in str(excinfo.value))
+
+    with pytest.raises(ValueError) as excinfo:
+        # Region seems large enough but actually it extends beyond the frame
+        stbt.match("videotestsrc-redblue.png", frame=black(),
+                   region=stbt.Region(x=1189, y=560, width=92, height=160))
+    assert (
+        "Region(x=1189, y=560, right=1280, bottom=720) must be larger than "
+        "reference image (160, 92, 3)"
+        in str(excinfo.value))
+
+    with pytest.raises(ValueError) as excinfo:
+        # Region seems large enough but actually it extends beyond the frame
+        stbt.match("videotestsrc-redblue.png", frame=black(),
+                   region=stbt.Region(x=1188, y=561, width=92, height=160))
+    assert (
+        "Region(x=1188, y=561, right=1280, bottom=720) must be larger than "
+        "reference image (160, 92, 3)"
+        in str(excinfo.value))
+
+
 @pytest.mark.parametrize("match_method", [
     stbt.MatchMethod.SQDIFF,
     stbt.MatchMethod.SQDIFF_NORMED,


### PR DESCRIPTION
It used to raise an exception deep in the `stbt.match` implementation:

>   File "/usr/lib/python2.7/dist-packages/_stbt/match.py", line 273, in match
>     result = next(_match_all(image, frame, match_parameters, region))
>   File "/usr/lib/python2.7/dist-packages/_stbt/match.py", line 395, in _match_all
>     crop(frame, input_region), t, match_parameters, imglog):
>   File "/usr/lib/python2.7/dist-packages/_stbt/imgproc_cache.py", line 142, in inner
>     for x in function(*args, **kwargs):
>   File "/usr/lib/python2.7/dist-packages/_stbt/match.py", line 513, in _find_matches
>     _find_candidate_matches(image, template, match_parameters, imglog):
>   File "/usr/lib/python2.7/dist-packages/_stbt/match.py", line 596, in _find_candidate_matches
>     method, roi_mask, level, imwrite)
>   File "/usr/lib/python2.7/dist-packages/_stbt/match.py", line 668, in _match_template
>     dtype=numpy.float32)
>   File "/usr/lib/python2.7/dist-packages/numpy/core/numeric.py", line 302, in full
>     a = empty(shape, dtype, order)
> ValueError: negative dimensions are not allowed

Now the ValueError tells you the region size (after intersecting with
with frame's boundaries) and the reference-image's size.