### PR TITLE
Remove "restart_source" config setting

### DIFF
--- a/_stbt/stbt.conf
+++ b/_stbt/stbt.conf
@@ -10,10 +10,6 @@ verbose=0
 power_outlet=none
 v4l2_ctls=
 
-# Handle loss of video (but without end-of-stream event) from the video capture
-# device. Set to "True" if you're using the Hauppauge HD PVR.
-restart_source = False
-
 [match]
 match_method=sqdiff
 match_threshold=0.98

--- a/docs/stbt.1.rst
+++ b/docs/stbt.1.rst
@@ -183,10 +183,6 @@ Global options
 --sink-pipeline=<pipeline>
   A GStreamer pipeline to use for video output, like `xvimagesink`.
 
---restart-source
-  Restart the GStreamer source pipeline when video loss is detected, to work
-  around the behaviour of the Hauppauge HD PVR video-capture device.
-
 -v, --verbose
   Enable debug output.
 

--- a/stbt-completion
+++ b/stbt-completion
@@ -50,7 +50,7 @@ _stbt_run() {
         --save-video=*) COMPREPLY=($(_stbt_filenames "$cur"));;
         *) COMPREPLY=(
                 $(compgen -W "$(_stbt_trailing_space \
-                        --help --verbose --restart-source --save-video \
+                        --help --verbose --save-video \
                         --control --source-pipeline --sink-pipeline)" \
                     -- "$cur")
                 $(_stbt_filename_possibly_with_test_functions));;
@@ -69,7 +69,7 @@ _stbt_record() {
         -o=*|--output-file=*) COMPREPLY=($(_stbt_filenames "$cur"));;
         *) COMPREPLY=($(compgen \
             -W "$(_stbt_trailing_space \
-                    --help --verbose --restart-source \
+                    --help --verbose \
                     --control --source-pipeline --sink-pipeline \
                     --control-recorder --output-file)" \
             -- "$cur"));;

--- a/tests/stbt.conf
+++ b/tests/stbt.conf
@@ -2,7 +2,6 @@
 source_pipeline = videotestsrc is-live=true ! video/x-raw,format=BGR,width=320,height=240,framerate=10/1
 sink_pipeline =
 control = test
-restart_source = False
 verbose = 1
 power_outlet = none
 

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -227,23 +227,6 @@ test_that_verbose_command_line_argument_overrides_config_file() {
     cat log | grep "verbose: 1"
 }
 
-test_that_restart_source_option_is_read() {
-    cat > test.py <<-EOF &&
-	import stbt
-	print "value: %s" % stbt._dut._display.restart_source_enabled
-	EOF
-    # Read from the command line
-    stbt run -v --restart-source --control none test.py &&
-    cat log | grep "restart_source: True" &&
-    cat log | grep "value: True" &&
-    echo > log &&
-    # Read from the config file
-    set_config global.restart_source "True" &&
-    stbt run -v --control none test.py &&
-    cat log | grep "restart_source: True" &&
-    cat log | grep "value: True"
-}
-
 test_press_visualisation() {
     cat > press.py <<-EOF &&
 	import signal, time


### PR DESCRIPTION
This was a workaround for a bug in the Hauppauge HDPVR video-capture
device, which is ancient and unreliable hardware. As far as I know,
nobody uses this setting.

Note that we *do* restart the source pipeline if we receive EOS (always,
regardless of configuration). This setting also restarted the source
pipeline on underrun (no buffers received, but without an EOS either).