### PR TITLE
Python 3 packaging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,6 @@ commands:
           name: make check-pylint
           command: |
             tesseract --version
-            pylint --version
             make check-pylint
   pytest:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ jobs:
       SHELL: /bin/bash
       TERM: xterm
       enable_virtual_stb: no
-      parallel: xargs
     steps:
       - checkout
       - pylint
@@ -26,7 +25,6 @@ jobs:
       SHELL: /bin/bash
       TERM: xterm
       enable_virtual_stb: no
-      parallel: xargs
     steps:
       - checkout
       - pylint

--- a/.circleci/ubuntu1804-python3.dockerfile
+++ b/.circleci/ubuntu1804-python3.dockerfile
@@ -63,8 +63,3 @@ ADD https://github.com/tesseract-ocr/tessdata/raw/590567f/deu.traineddata \
     https://github.com/tesseract-ocr/tessdata/raw/590567f/eng.traineddata \
     https://github.com/tesseract-ocr/tessdata/raw/590567f/osd.traineddata \
     /usr/share/tesseract-ocr/4.00/tessdata/
-
-RUN ln -s python3.6 /usr/bin/python && \
-    ln -s pylint3 /usr/bin/pylint && \
-    ln -s pytest-3 /usr/bin/pytest && \
-    ln -s py.test-3 /usr/bin/py.test

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ INSTALL_PYLIB_FILES = \
     stbt/__init__.py \
     stbt/android.py
 
-INSTALL_CORE_FILES = \
+INSTALL_CORE_SCRIPTS = \
     stbt_config.py \
     stbt_control.py \
     stbt_lint.py \
@@ -100,7 +100,7 @@ INSTALL_CORE_FILES = \
     stbt-screenshot \
     stbt-tv
 
-all: $(INSTALL_CORE_FILES) $(INSTALL_PYLIB_FILES) etc/stbt.conf
+all: $(INSTALL_CORE_SCRIPTS) $(INSTALL_PYLIB_FILES) etc/stbt.conf
 
 INSTALL_VSTB_FILES = \
     stbt_virtual_stb.py
@@ -113,7 +113,7 @@ install-core: all
 	    $(DESTDIR)$(pythondir)/_stbt \
 	    $(DESTDIR)$(sysconfdir)/stbt \
 	    $(DESTDIR)$(sysconfdir)/bash_completion.d \
-	    $(patsubst %,$(DESTDIR)$(libexecdir)/stbt/%,$(sort $(dir $(INSTALL_CORE_FILES))))
+	    $(DESTDIR)$(libexecdir)/stbt
 	sed -e 's,@VERSION@,$(VERSION),g' \
 	    -e 's,@LIBEXECDIR@,$(libexecdir),g' \
 	     bin/stbt >$(DESTDIR)$(bindir)/stbt
@@ -122,9 +122,8 @@ install-core: all
 	    $(DESTDIR)$(sysconfdir)/bash_completion.d/stbt
 	$(INSTALL) -m 0644 etc/stbt.conf \
 	    $(DESTDIR)$(sysconfdir)/stbt/stbt.conf
-	for filename in $(INSTALL_CORE_FILES); do \
-	    [ -x "$$filename" ] && mode=0755 || mode=0644; \
-	    $(INSTALL) -m $$mode $$filename $(DESTDIR)$(libexecdir)/stbt/$$filename; \
+	for filename in $(INSTALL_CORE_SCRIPTS); do \
+	    $(INSTALL) -m 0755 $$filename $(DESTDIR)$(libexecdir)/stbt/$$filename; \
 	done
 	for filename in $(INSTALL_PYLIB_FILES); do \
 	    [ -x "$$filename" ] && mode=0755 || mode=0644; \

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,14 @@ MKTAR = $(TAR) --format=gnu --owner=root --group=root \
     --mtime="$(shell git show -s --format=%ci HEAD)"
 GZIP ?= gzip
 
+ifeq ($(python_version), 2.7)
+PYLINT := pylint
+PYTEST := pytest
+else
+PYLINT := pylint3
+PYTEST := pytest-3
+endif
+
 CFLAGS?=-O2
 
 
@@ -206,7 +214,7 @@ check: check-pylint check-pytest check-integrationtests
 check-pytest: all
 	PYTHONPATH=$$PWD:/usr/lib/python$(python_version)/dist-packages/cec \
 	STBT_CONFIG_FILE=$$PWD/tests/stbt.conf \
-	py.test -vv -rs --doctest-modules $(PYTEST_OPTS) \
+	$(PYTEST) -vv -rs --doctest-modules $(PYTEST_OPTS) \
 	    $(shell git ls-files '*.py' |\
 	      grep -v -e tests/vstb-example-html5/ \
 	              -e tests/webminspector/ \
@@ -219,7 +227,7 @@ check-integrationtests: install-for-test
 	       grep -v -e tests/test-virtual-stb.sh) |\
 	$(parallel) tests/run-tests.sh -i
 check-pylint: all
-	PYTHONPATH=$$PWD extra/pylint.sh $(PYTHON_FILES)
+	PYTHONPATH=$$PWD PYLINT=$(PYLINT) extra/pylint.sh $(PYTHON_FILES)
 
 ifeq ($(enable_virtual_stb), yes)
 install: install-virtual-stb

--- a/extra/pylint.sh
+++ b/extra/pylint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -u
 
 #/ Usage: pylint.sh file.py [file.py...]
 #/
@@ -25,7 +25,9 @@ else
     echo "warning: pep8 not installed; skipping pep8 and only running pylint" >&2
 fi
 
-out=$(pylint --rcfile="$(dirname "$0")/pylint.conf" "$@" 2>&1) || ret=1
+$PYLINT --version
+
+out=$($PYLINT --rcfile="$(dirname "$0")/pylint.conf" "$@" 2>&1) || ret=1
 printf "%s" "$out" |
     grep -v \
         -e 'libdc1394 error: Failed to initialize libdc1394' \

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -28,7 +28,8 @@ export srcdir=$(realpath --no-symlinks "$testdir/..")
 export LANG=C.UTF-8
 export PYTHONUNBUFFERED=x
 export PYLINTRC="$testdir/pylint.conf"
-: ${python_version:=2.7}
+export python_version=${python_version:=2.7}
+export python=python$python_version
 
 testsuites=()
 testcases=()

--- a/tests/test-irnetbox.sh
+++ b/tests/test-irnetbox.sh
@@ -6,7 +6,8 @@ start_fake_irnetbox() {
         return 1
     }
 
-    PYTHONPATH=$srcdir "$testdir"/fake-irnetbox "$@" > fake-irnetbox.log &
+    PYTHONPATH=$srcdir $python "$testdir"/fake-irnetbox "$@" \
+        > fake-irnetbox.log &
     fake_irnetbox=$!
     trap "kill $fake_irnetbox" EXIT
     waitfor "^PORT=" fake-irnetbox.log || fail "fake-irnetbox failed to start"
@@ -24,7 +25,7 @@ test_irnetbox_commands() {
 	    ir.irsend_raw(port=1, power=100, data=rcu["MENU"])
 	    ir.irsend_raw(port=1, power=100, data=rcu["OK"])
 	EOF
-    PYTHONPATH=$srcdir python test.py || return
+    PYTHONPATH=$srcdir $python test.py || return
     grep -q "Received message POWER_ON" fake-irnetbox.log ||
         fail "fake-irnetbox didn't receive POWER_ON message"
     [[ "$(grep "Received message OUTPUT_IR_ASYNC" fake-irnetbox.log |

--- a/tests/test-lirc.sh
+++ b/tests/test-lirc.sh
@@ -6,7 +6,7 @@ start_fake_lircd() {
         return 1
     }
 
-    "$testdir"/fake-lircd "$@" > fake-lircd.log &
+    $python "$testdir"/fake-lircd "$@" > fake-lircd.log &
     fake_lircd=$!
     trap "kill $fake_lircd" EXIT
     waitfor "^SOCKET=" fake-lircd.log || fail "fake-lircd failed to start"

--- a/tests/test-match.sh
+++ b/tests/test-match.sh
@@ -2,7 +2,7 @@
 
 skip_if_opencv_2() {
     local version=$(
-        python -c 'from _stbt.cv2_compat import version; print(version[0])')
+        $python -c 'from _stbt.cv2_compat import version; print(version[0])')
     [[ "$version" -ge 3 ]] || skip "Skipping because OpenCV version < 3"
 }
 

--- a/tests/test-motion.sh
+++ b/tests/test-motion.sh
@@ -49,9 +49,7 @@ test_wait_for_motion_nonexistent_mask() {
 	press("OK")
 	wait_for_motion(mask="idontexist.png")
 	EOF
-    timeout 10 stbt run -v test.py &> test.log
-    local ret=$?
-    [ $ret -ne $timedout -a $ret -ne 0 ] || fail "Unexpected exit status $ret"
+    ! stbt run -v test.py &> test.log || fail "Expected script to fail"
     grep -q "No such file: idontexist.png" test.log ||
         fail "Expected 'No such file: idontexist.png' but saw '$(
             grep 'No such file' test.log | head -n1)'"

--- a/tests/test-packaging.sh
+++ b/tests/test-packaging.sh
@@ -7,7 +7,7 @@ test_importing_stbt_without_stbt_run() {
 	    "$testdir/videotestsrc-redblue.png",
 	    frame=cv2.imread("$testdir/videotestsrc-full-frame.png"))
 	EOF
-    python test.py
+    $python test.py
 }
 
 test_that_stbt_imports_the_installed_version() {
@@ -20,12 +20,12 @@ test_that_stbt_imports_the_installed_version() {
 	assert stbt.__file__.startswith(prefix)
 	assert stbt._stbt.__file__.startswith(prefix)
 	EOF
-    python test.py || fail "Python imported the wrong _stbt"
+    $python test.py || fail "Python imported the wrong _stbt"
     stbt run test.py || fail "stbt run imported the wrong _stbt"
 }
 
 test_that_stbt_imports_the_source_version() {
-    (cd "$srcdir" && python <<-EOF) || fail "Python from srcdir imported the wrong _stbt"
+    (cd "$srcdir" && $python <<-EOF) || fail "Python from srcdir imported the wrong _stbt"
 	import re, stbt
 	print(stbt.__file__)
 	print(stbt._stbt.__file__)
@@ -42,9 +42,9 @@ test_that_stbt_imports_the_source_version() {
 	assert re.match(r"$srcdir/_stbt/__init__.pyc?$", stbt._stbt.__file__)
 	EOF
 
-    PYTHONPATH="$srcdir" python test.py ||
+    PYTHONPATH="$srcdir" $python test.py ||
         fail 'Python with PYTHONPATH=$srcdir imported the wrong _stbt'
 
-    "$srcdir"/stbt_run.py "$scratchdir"/test.py ||
+    $python "$srcdir"/stbt_run.py "$scratchdir"/test.py ||
         fail "stbt run imported the wrong _stbt"
 }

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -266,7 +266,7 @@ test_press_visualisation() {
 }
 
 test_clock_visualisation() {
-    PYTHONPATH="$srcdir" python -c "import stbt, _stbt.ocr, distutils, sys; \
+    PYTHONPATH="$srcdir" $python -c "import stbt, _stbt.ocr, distutils, sys; \
         sys.exit(0 if (_stbt.ocr._tesseract_version() \
                        >= distutils.version.LooseVersion('3.03')) else 77)"
     case $? in

--- a/tests/test-stbt-run.sh
+++ b/tests/test-stbt-run.sh
@@ -112,7 +112,7 @@ test_that_stbt_run_saves_last_grabbed_screenshot_on_error() {
     ! stbt run -v test.py &&
     [ -f screenshot.png ] &&
     ! [ -f thumbnail.jpg ] &&
-    python <<-EOF
+    $python <<-EOF
 	import cv2, numpy
 	ss = cv2.imread('screenshot.png')
 	gf = cv2.imread('grabbed-frame.png')

--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -25,7 +25,7 @@ killtree() {
 }
 
 set_config() {
-    PYTHONPATH=$srcdir python - "$@" <<-EOF
+    PYTHONPATH=$srcdir $python - "$@" <<-EOF
 	import sys, _stbt.config
 	section, name = sys.argv[1].split('.')
 	_stbt.config.set_config(section, name, sys.argv[2])


### PR DESCRIPTION
The main change here is that `make install` modifies the shebang lines upon installation, from `#!/usr/bin/python` to `#!/usr/bin/python2.7` or `#!/usr/bin/python3` depending on the value of `$python_version`.

The rest of the changes are just test infrastructure to cope with that, plus other test fixes.
