### PR TITLE
stbt.get_frame: Improve error message if video-capture uninitialised

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -168,7 +168,11 @@ class DeviceUnderTest(object):
 
         if hold_secs is None:
             with self._interpress_delay(interpress_delay_secs):
-                out = _Keypress(key, self._time.time(), None, self.get_frame())
+                if self._display is None:
+                    frame_before = None
+                else:
+                    frame_before = self.get_frame()
+                out = _Keypress(key, self._time.time(), None, frame_before)
                 self._control.press(key)
                 out.end_time = self._time.time()
             self.draw_text(key, duration_secs=3)

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -283,6 +283,9 @@ class DeviceUnderTest(object):
             first = False
 
     def get_frame(self):
+        if self._display is None:
+            raise RuntimeError(
+                "stbt.get_frame(): Video capture has not been initialised")
         return self._display.get_frame()
 
 


### PR DESCRIPTION
If you are importing `stbt` as a library and you try to call `stbt.get_frame()` without initialising the video-capture pipeline (which is normally done by `stbt run`), you'd get the following exception:

> AttributeError: 'NoneType' object has no attribute 'get_frame'

This also happens if you're running `stbt auto-selftest` on your page objects, and you have forgotten to pass `self._frame` explicitly into any image-processing calls like `stbt.match`.