### PR TITLE
stbt.FrameObject repr: Limit float property values to 3 decimal places

### DIFF
--- a/_stbt/frameobject.py
+++ b/_stbt/frameobject.py
@@ -180,8 +180,13 @@ class FrameObject(with_metaclass(_FrameObjectMeta, object)):
         """
         The object's string representation includes all its public properties.
         """
-        args = ", ".join(("%s=%r" % x) for x in self._iter_fields())
-        return "%s(%s)" % (self.__class__.__name__, args)
+        args = []
+        for name, value in self._iter_fields():
+            if isinstance(value, float) and ("time" in name or "_secs" in name):
+                args.append("%s=%.3f" % (name, value))
+            else:
+                args.append("%s=%r" % (name, value))
+        return "%s(%s)" % (self.__class__.__name__, ", ".join(args))
 
     def _iter_fields(self):
         if self:

--- a/tests/test_frameobject.py
+++ b/tests/test_frameobject.py
@@ -55,7 +55,7 @@ class FrameObjectWithProperties(stbt.FrameObject):
 
     >>> frame = _load_frame("with-dialog")
     >>> FrameObjectWithProperties(frame)
-    FrameObjectWithProperties(is_visible=True, public=5)
+    FrameObjectWithProperties(is_visible=True, offset_secs=0.017, public=5)
     """
     @property
     def is_visible(self):
@@ -66,8 +66,19 @@ class FrameObjectWithProperties(stbt.FrameObject):
         return 5
 
     @property
+    def offset_secs(self):
+        return 1 / 60
+
+    @property
     def _private(self):
         return 6
+
+
+def test_frameobject_repr():
+    # Needs an explicit test because we run doctests with pytest's ALLOW_UNICODE
+    assert (repr(FrameObjectWithProperties(_load_frame("with-dialog"))) ==
+            "FrameObjectWithProperties(is_visible=True, "
+            "offset_secs=0.017, public=5)")
 
 
 class FrameObjectThatCallsItsOwnProperties(stbt.FrameObject):


### PR DESCRIPTION
Otherwise doctest output of floating-point values might vary from run to
run.

60 frames per second is 17ms per frame, so a 1ms precision should be
enough for any measurements related to video-frames. For example we have
been affected by this in a FrameObject that we use in our A/V sync
tests, that has a property showing the lag or lead time from the audio
to the corresponding video frame.

We only apply this to properties that have "time" or "_secs" in the
name, because we don't know what other use-cases people are using
floating-point values for. If you need this, at least now you have the
option of working "time" or "_secs" into your property name.

This won't help properties that are lists of floats, etc. But it's a
start.