### PR TITLE
stbt.press_and_wait: Ignore pixel intensity differences <= 5

### DIFF
--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -246,10 +246,11 @@ def strict_diff(prev, frame, region, mask_image):
         _ddebug("found %s diffs above 20 (max %s) in %r", frame,
                 numpy.count_nonzero(big_diffs), maxdiff, out_region)
     elif maxdiff > 0:
-        small_diffs_count = numpy.count_nonzero(absdiff)
+        small_diffs = absdiff > 5
+        small_diffs_count = numpy.count_nonzero(small_diffs)
         if small_diffs_count > 50:
             diffs_found = True
-            out_region = pixel_bounding_box(absdiff)
+            out_region = pixel_bounding_box(small_diffs.max(axis=2))
             _ddebug("found %s diffs <= %s in %r", frame, small_diffs_count,
                     maxdiff, out_region)
     if out_region:

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -250,7 +250,7 @@ def strict_diff(prev, frame, region, mask_image):
         small_diffs_count = numpy.count_nonzero(small_diffs)
         if small_diffs_count > 50:
             diffs_found = True
-            out_region = pixel_bounding_box(small_diffs.max(axis=2))
+            out_region = pixel_bounding_box(small_diffs)
             _ddebug("found %s diffs <= %s in %r", frame, small_diffs_count,
                     maxdiff, out_region)
     if out_region:

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -253,6 +253,9 @@ def strict_diff(prev, frame, region, mask_image):
             out_region = pixel_bounding_box(small_diffs)
             _ddebug("found %s diffs <= %s in %r", frame, small_diffs_count,
                     maxdiff, out_region)
+        else:
+            _ddebug("only found %s diffs <= %s", frame, small_diffs_count,
+                    maxdiff)
     if out_region:
         out_region = out_region.translate(region.x, region.y)
 


### PR DESCRIPTION
On the Apple TV, successive frames differ by up to 3 (out of 255) on almost every pixel, in a funky multicoloured moire pattern. Here's what it looks like after enhancing the levels (remember the actual differences are <= 3 so you can't see them with the naked eye):

![small_diffs_enhanced](https://user-images.githubusercontent.com/12424/61292875-4a1a9800-a7ca-11e9-94dd-ce2e785481d9.png)
