### PR TITLE
stbt.OcrMode docstring: Recommend tesseract's v3 engine

### DIFF
--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -82,13 +82,16 @@ class OcrMode(IntEnum):
 
 class OcrEngine(IntEnum):
 
-    #: Tesseract's "legacy" OCR engine (v3).
+    #: Tesseract's "legacy" OCR engine (v3). Recommended.
     TESSERACT = 0
 
-    #: Tesseract v4's "Long Short-Term Memory" neural network.
+    #: Tesseract v4's "Long Short-Term Memory" neural network. Not recommended
+    #: for reading menus, buttons, prices, numbers, times, etc, because it
+    #: hallucinates text that isn't there when the input isn't long prose.
     LSTM = 1
 
-    #: Combine results from Tesseract legacy & LSTM engines.
+    #: Combine results from Tesseract legacy & LSTM engines. Not recommended
+    #: because it favours the result from the LSTM engine too heavily.
     TESSERACT_AND_LSTM = 2
 
     #: Default engine, based on what is installed.


### PR DESCRIPTION
The LSTM engine hallucinates text that isn't there when the input isn't long prose, so it doesn't work for typical GUI testing where we want to read menus, buttons, prices, numbers, times, etc.
