### PR TITLE
Keyboard.enter_text: Fix navigation after the first letter 

### DIFF
--- a/stbt/keyboard.py
+++ b/stbt/keyboard.py
@@ -158,8 +158,12 @@ class Keyboard(object):
                     self._kb.enter_text(page=self, text=text.upper())
                     self._kb.navigate_to(page=self, target="SEARCH")
                     stbt.press("KEY_OK")
-
         """
+
+        for letter in text:
+            if letter not in self.G:
+                raise ValueError("'%s' isn't in the keyboard" % (letter,))
+
         for letter in text:
             page = self.navigate_to(page, letter)
             stbt.press("KEY_OK")
@@ -179,6 +183,9 @@ class Keyboard(object):
             reflecting the device-under-test's new state after the navigation
             completed.
         """
+
+        if target not in self.G:
+            raise ValueError("'%s' isn't in the keyboard" % (target,))
 
         deadline = time.time() + self.navigate_timeout
         current = _selection_to_text(page.selection)

--- a/stbt/keyboard.py
+++ b/stbt/keyboard.py
@@ -161,8 +161,9 @@ class Keyboard(object):
 
         """
         for letter in text:
-            self.navigate_to(page, letter)
+            page = self.navigate_to(page, letter)
             stbt.press("KEY_OK")
+        return page
 
     def navigate_to(self, page, target):
         """Move the selection to the specified character.
@@ -173,6 +174,10 @@ class Keyboard(object):
         :param stbt.FrameObject page: See ``enter_text``.
         :param str target: The key or button to navigate to, for example "A",
             " ", or "CLEAR".
+
+        :returns: A new FrameObject instance of the same type as ``page``,
+            reflecting the device-under-test's new state after the navigation
+            completed.
         """
 
         deadline = time.time() + self.navigate_timeout
@@ -190,6 +195,7 @@ class Keyboard(object):
             assert stbt.press_and_wait(keys[-1], mask=self.mask)
             page = page.refresh()
             current = _selection_to_text(page.selection)
+        return page
 
 
 def _selection_to_text(selection):

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -252,7 +252,7 @@ class YouTubeKeyboard(object):
 
     def press_and_wait(self, key, mask):  # pylint:disable=unused-argument
         self.press(key)
-        return _TransitionResult(None, TransitionStatus.COMPLETE, 0, 0, 0)
+        return _TransitionResult(key, None, TransitionStatus.COMPLETE, 0, 0, 0)
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
@@ -277,6 +279,16 @@ def test_that_enter_text_uses_minimal_keypresses(youtubekeyboard):  # pylint:dis
     page.enter_text("HI")
     assert youtubekeyboard.pressed == ["KEY_DOWN", "KEY_OK",
                                        "KEY_RIGHT", "KEY_OK"]
+
+
+def test_that_keyboard_validates_the_targets(youtubekeyboard):  # pylint:disable=redefined-outer-name
+    page = youtubekeyboard.page
+    with pytest.raises(ValueError):
+        page.enter_text("ABCÑ")
+    assert youtubekeyboard.pressed == []
+    with pytest.raises(ValueError):
+        page.navigate_to("Ñ")
+    assert youtubekeyboard.pressed == []
 
 
 def test_navigate_to(youtubekeyboard):  # pylint:disable=redefined-outer-name

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -13,7 +13,7 @@ from stbt.keyboard import _add_weights, _keys_to_press
 from _stbt.transition import _TransitionResult, TransitionStatus
 
 
-YOUTUBE_SEARCH_KEYBOARD = """
+GRAPH = """
     A B KEY_RIGHT
     A H KEY_DOWN
     B A KEY_LEFT
@@ -137,7 +137,7 @@ YOUTUBE_SEARCH_KEYBOARD = """
     SEARCH - KEY_UP
     SEARCH ' KEY_UP
 """
-G = nx.parse_edgelist(YOUTUBE_SEARCH_KEYBOARD.split("\n"),
+G = nx.parse_edgelist(GRAPH.split("\n"),
                       create_using=nx.DiGraph(),
                       data=[("key", str)])
 nx.relabel_nodes(G, {"SPACE": " "}, copy=False)
@@ -182,7 +182,7 @@ def test_add_weights():
 
 
 class YouTubeKeyboard(object):
-    KEYBOARD = stbt.Keyboard(YOUTUBE_SEARCH_KEYBOARD, navigate_timeout=0.1)
+    KEYBOARD = stbt.Keyboard(GRAPH, navigate_timeout=0.1)
 
     """FrameObject-alike that doesn't require real video-capture."""
     def __init__(self):

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -6,6 +6,7 @@ from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-impor
 
 import networkx as nx
 import mock
+import numpy
 import pytest
 
 import stbt
@@ -181,45 +182,73 @@ def test_add_weights():
         "W", "X", "Y", "Z"]
 
 
-class YouTubeKeyboard(object):
+class _Keyboard(stbt.FrameObject):
+    """Immutable FrameObject representing the test's view of the Device Under
+    Test (``dut``).
+
+    The keyboard looks like this::
+
+        A  B  C  D  E  F  G
+        H  I  J  K  L  M  N
+        O  P  Q  R  S  T  U
+        V  W  X  Y  Z  -  '
+         SPACE  CLEAR  SEARCH
+
+    """
+    def __init__(self, dut):
+        super(_Keyboard, self).__init__(
+            frame=numpy.zeros((720, 1280, 3), dtype=numpy.uint8))
+        self._dut = dut  # Device Under Test -- i.e. ``YouTubeKeyboard``
+        self._selection = self._dut.selection
+
+    @property
+    def is_visible(self):
+        return True
+
+    @property
+    def selection(self):
+        return self._selection
+
+    def refresh(self, frame=None, **kwargs):
+        print("_Keyboard.refresh: Now on %r" % self._dut.selection)
+        return _Keyboard(dut=self._dut)
+
     KEYBOARD = stbt.Keyboard(GRAPH, navigate_timeout=0.1)
 
-    """FrameObject-alike that doesn't require real video-capture."""
+    def enter_text(self, text):
+        return self.KEYBOARD.enter_text(self, text.upper())
+
+    def navigate_to(self, target):
+        return self.KEYBOARD.navigate_to(self, target)
+
+
+class YouTubeKeyboard(object):
+    """Fake keyboard implementation for testing."""
+
     def __init__(self):
-        self.is_visible = True
         self.selection = "A"
-        self.actual_state = "A"
+        self.page = _Keyboard(dut=self)
         self.pressed = []
         self.entered = ""
         # Pressing up from SPACE returns to the last letter we were at:
         self.prev_state = "A"
 
-    def refresh(self):
-        self.selection = self.actual_state
-        return self
-
-    def enter_text(self, text):
-        self.KEYBOARD.enter_text(self, text.upper())
-
-    def navigate_to(self, target):
-        self.KEYBOARD.navigate_to(self, target)
-
     def press(self, key):
         print("Pressed %s" % key)
         self.pressed.append(key)
         if key == "KEY_OK":
-            self.entered += self.actual_state
+            self.entered += self.selection
         else:
             next_states = [
-                t for _, t, k in G.edges(self.actual_state, data="key")
+                t for _, t, k in G.edges(self.selection, data="key")
                 if k == key]
             if self.prev_state in next_states:
                 next_state = self.prev_state
             else:
                 next_state = next_states[0]
-            if self.actual_state not in (" ", "CLEAR", "SEARCH"):
-                self.prev_state = self.actual_state
-            self.actual_state = next_state
+            if self.selection not in (" ", "CLEAR", "SEARCH"):
+                self.prev_state = self.selection
+            self.selection = next_state
 
     def press_and_wait(self, key, mask):  # pylint:disable=unused-argument
         self.press(key)
@@ -235,14 +264,24 @@ def youtubekeyboard():
 
 
 def test_enter_text(youtubekeyboard):  # pylint:disable=redefined-outer-name
-    assert youtubekeyboard.selection == "A"
-    youtubekeyboard.enter_text("hi there")
+    page = youtubekeyboard.page
+    assert page.selection == "A"
+    page.enter_text("hi there")
     assert youtubekeyboard.entered == "HI THERE"
     assert youtubekeyboard.selection == "E"
 
 
+def test_that_enter_text_uses_minimal_keypresses(youtubekeyboard):  # pylint:disable=redefined-outer-name
+    page = youtubekeyboard.page
+    assert page.selection == "A"
+    page.enter_text("HI")
+    assert youtubekeyboard.pressed == ["KEY_DOWN", "KEY_OK",
+                                       "KEY_RIGHT", "KEY_OK"]
+
+
 def test_navigate_to(youtubekeyboard):  # pylint:disable=redefined-outer-name
-    assert youtubekeyboard.selection == "A"
-    youtubekeyboard.navigate_to("SEARCH")
+    page = youtubekeyboard.page
+    assert page.selection == "A"
+    page.navigate_to("SEARCH")
     assert youtubekeyboard.selection == "SEARCH"
     assert youtubekeyboard.pressed == ["KEY_DOWN"] * 4 + ["KEY_RIGHT"] * 2


### PR DESCRIPTION
It was always calculating the path as if it was starting again from the initial position (before it had entered any of the previous letters).

Sometimes this would work, because `navigate_to` has a loop where it double-checks that it landed where it expected, and then recalculates. Other times it might end up navigating away from the keyboard (e.g. into the search results).

This bug was introduced in commit 5756985 (keyboard: Move `page` parameter from constructor to `enter_text`). I suppose I didn't re-test against a real set-top-box after doing that change.

This bug wasn't caught by the unit tests because it was using a class that wasn't a real `stbt.FrameObject` -- in particular it didn't have the immutable behaviour of FrameObjects, so the `selection` property was updating even when the `page` instance wasn't properly refreshed. Now I have split the test's implementation into 2 classes:

* `YouTubeKeyboard` is the "device under test" -- it knows what the   actual state is at all times.
* `_Keyboard` is a real `stbt.FrameObject` subclass, just like you'd use in your test scripts. The only difference with a real test script is that it overrides `__init__` and `refresh` so that it can wire in our fake device under test.