### PR TITLE
[WIP]Test on UI elements by color range

### DIFF
--- a/_stbt/color.py
+++ b/_stbt/color.py
@@ -1,5 +1,9 @@
+from copy import deepcopy
+
 import cv2
 import numpy as np
+
+import stbt
 
 
 class Color(object):
@@ -55,3 +59,44 @@ class Color(object):
     def from_bgr(cls, blue, green, red):
         [[[h, s, v]]] = cv2.cvtColor(np.uint8([[[blue, green, red]]]), cv2.COLOR_BGR2HSV)
         return cls(h, s, v)
+
+
+def get_mask_by_color_range(hsv_starting_boundary, hsv_ending_boundary, frame=None, region=None):
+    """
+    The method to get a mask of a frame according to the range of color defined by two boundaries in HSV. The hue value
+    goes cyclic from 0 to 179, if the target range of color overlaps the hue limits (e.g. a range of red between 0-10
+    and 170-179), the method will mask each side of the hue limit separately and then combine them.
+
+    :type hsv_starting_boundary: `Color`
+    :param hsv_starting_boundary: The clockwise starting boundary of color in HSV
+
+    :type hsv_ending_boundary: `Color`
+    :param hsv_ending_boundary: The clockwise ending boundary of color in HSV
+
+    :param frame: the target frame to mask, will grab a new frame from DUT if not defined.
+
+    :type region: `Region`
+    :param region: the ROI to mask, the rest of the frame will be ignored once defined.
+
+    :return: `numpy.ndarray` the mask with value of 0 (black) or 255 (white) only.
+    """
+    frame = stbt.get_frame() if frame is None else frame
+    # convert the color of the target frame from BGR to HSV for masking
+    hsv_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
+
+    if hsv_ending_boundary.hue < hsv_starting_boundary.hue:
+        hsv_to_179 = deepcopy(hsv_ending_boundary)
+        hsv_to_179.hue = 179
+        hsv_from_0 = deepcopy(hsv_starting_boundary)
+        hsv_from_0.hue = 0
+        mask = cv2.bitwise_or(cv2.inRange(hsv_frame, hsv_starting_boundary.np_array, hsv_to_179.np_array),
+                              cv2.inRange(hsv_frame, hsv_from_0.np_array, hsv_ending_boundary.np_array))
+    else:
+        mask = cv2.inRange(hsv_frame, hsv_starting_boundary.np_array, hsv_ending_boundary.np_array)
+
+    # if the ROI is required then mask it again to only focus on the target region
+    if region:
+        roi = np.zeros_like(mask, dtype=np.uint8)
+        cv2.rectangle(roi, (region.x, region.y), (region.right, region.bottom), color=255, thickness=cv2.FILLED)
+        mask = cv2.bitwise_and(mask, mask, mask=roi)
+    return mask

--- a/_stbt/color.py
+++ b/_stbt/color.py
@@ -1,0 +1,57 @@
+import cv2
+import numpy as np
+
+
+class Color(object):
+    """
+    The basic class to specify a color, defaults to be instantiated by HSV but can be parsed from BGR, all color values
+    stored are `numpy.uint8`.
+    """
+
+    def __init__(self, hue, saturation, value):
+        self.hue, self.saturation, self.value = np.array([hue, saturation, value], dtype=np.uint8)
+
+    @property
+    def hue(self):
+        return self._hue
+
+    @property
+    def saturation(self):
+        return self._saturation
+
+    @property
+    def value(self):
+        return self._value
+
+    @hue.setter
+    def hue(self, value):
+        if 0 <= value <= 179:
+            self._hue = np.uint8(value)
+        else:
+            raise ValueError("Hue has to be 0-179")
+
+    @saturation.setter
+    def saturation(self, value):
+        if 0 <= value <= 255:
+            self._saturation = np.uint8(value)
+        else:
+            raise ValueError("Saturation has to be 0-255")
+
+    @value.setter
+    def value(self, value):
+        if 0 <= value <= 255:
+            self._value = np.uint8(value)
+        else:
+            raise ValueError("Value has to be 0-255")
+
+    @property
+    def np_array(self):
+        return np.array([self.hue, self.saturation, self.value])
+
+    def __repr__(self):
+        return 'Color(hue=%r, saturation=%r, value=%r)' % (self.hue, self.saturation, self.value)
+
+    @classmethod
+    def from_bgr(cls, blue, green, red):
+        [[[h, s, v]]] = cv2.cvtColor(np.uint8([[[blue, green, red]]]), cv2.COLOR_BGR2HSV)
+        return cls(h, s, v)

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -67,6 +67,7 @@ from _stbt.types import (
     UITestError,
     UITestFailure)
 from stbt.keyboard import Keyboard
+from _stbt.color import Color
 
 __all__ = [
     "as_precondition",
@@ -112,6 +113,7 @@ __all__ = [
     "wait_for_motion",
     "wait_for_transition_to_end",
     "wait_until",
+    "Color",
 ]
 
 _dut = _stbt.core.DeviceUnderTest()

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -67,7 +67,10 @@ from _stbt.types import (
     UITestError,
     UITestFailure)
 from stbt.keyboard import Keyboard
-from _stbt.color import Color, get_mask_by_color_range
+from _stbt.color import (
+    Color,
+    get_mask_by_color_range,
+    get_colored_box_region)
 
 __all__ = [
     "as_precondition",
@@ -114,7 +117,8 @@ __all__ = [
     "wait_for_transition_to_end",
     "wait_until",
     "Color",
-    "get_mask_by_color_range"
+    "get_mask_by_color_range",
+    "get_colored_box_region"
 ]
 
 _dut = _stbt.core.DeviceUnderTest()

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -67,7 +67,7 @@ from _stbt.types import (
     UITestError,
     UITestFailure)
 from stbt.keyboard import Keyboard
-from _stbt.color import Color
+from _stbt.color import Color, get_mask_by_color_range
 
 __all__ = [
     "as_precondition",
@@ -114,6 +114,7 @@ __all__ = [
     "wait_for_transition_to_end",
     "wait_until",
     "Color",
+    "get_mask_by_color_range"
 ]
 
 _dut = _stbt.core.DeviceUnderTest()


### PR DESCRIPTION
### Challenges
I would like to share some functions to test on UI elements by color range which I've been using for a long time in our test pack. I implemented the functions due to the following challenges:

I wanted to match a red icon which appears when recording is enabled on a channel from planner. We needed to test the same software on two different STBs, the UI layout were exactly the same but there is slight color difference which is enough to cause the image matching to fail. As I only wanted to quickly check whether the icon pops up when the recording is started, so I wrote the method `get_mask_by_color_range` to filter the frame to get a mask, then wrote another method `get_color_existence` to check whether the color is existed. In this way, I could make my test code generic for both STBs.

Later on in another project, we needed to determine the selected tab on a top level menu. The tabs do not have the same size and the size depends on how long the text is. The color of a tab will change when the cursor is on it. In this case, it was too verbose to match by the tab images, so again I used the method `get_mask_by_color_range` to get a mask highlighting the tab selected, and based on that, I wrote the method `get_colored_box_region` to find the bounding region of the selected tab then use OCR to read the content of the tab.

### List of class and functions implemented
+ `stbt.Color` the class to represent a specific color, defaults to be instantiated by HSV but can be parsed from BGR
+ `stbt.get_mask_by_color_range` the method to get a mask highlighting the area where the range of color exists
+ `stbt.get_color_existence` (I have not yet migrated this function) the method to determine whether the specified color
is existed in a given `stbt.Region`
+ `stbt.get_colored_box_region` the method to find the bounding `stbt.Region` of the colored area

Please check the docstrings for more details.

### Todo
- [ ] To migrate `get_color_existence`
- [ ] To implement self-test
- [ ] To discuss whether there is a need to wrap the matching results into something like `stbt.MatchResult`
- [ ] To pass `make check`

### Things to note
+ HSV was used to easier define a range of color.
+ In terms of performance, I'm not sure whether all methods can finish processing within 1/25 second on all platforms but for functional test requirements, this is not a big deal. Matching by color is generally faster and more reliable.

It seems like color matching/recognition is a common requirement for test development. I'm not too sure whether we are trying to solve the same problem? #592 