### PR TITLE
stbt.Keyboard: Reverse order of arguments to enter_text & navigate_to

### DIFF
--- a/stbt/keyboard.py
+++ b/stbt/keyboard.py
@@ -155,8 +155,9 @@ class Keyboard(object):
                     ...  # implementation not shown
 
                 def enter_text(self, text):
-                    self._kb.enter_text(page=self, text=text.upper())
-                    self._kb.navigate_to(page=self, target="SEARCH")
+                    page = self
+                    page = self._kb.enter_text(page, text.upper())
+                    self._kb.navigate_to(page, "SEARCH")
                     stbt.press("KEY_OK")
         """
 

--- a/stbt/keyboard.py
+++ b/stbt/keyboard.py
@@ -116,9 +116,13 @@ class Keyboard(object):
     #   use press_and_wait because the text-box might be masked out (some UIs
     #   have a blinking cursor there).
 
-    def enter_text(self, page, text):
+    def enter_text(self, text, page):
         """
         Enter the specified text using the on-screen keyboard.
+
+        :param str text: The text to enter. If your keyboard only supports a
+            single case then you need to convert the text to uppercase or
+            lowercase, as appropriate, before passing it to this method.
 
         :param stbt.FrameObject page: An instance of a `stbt.FrameObject`
             sub-class that describes the appearance of the on-screen keyboard.
@@ -131,10 +135,6 @@ class Keyboard(object):
 
             The ``page`` instance that you provide must represent the current
             state of the device-under-test.
-
-        :param str text: The text to enter. If your keyboard only supports a
-            single case then you need to convert the text to uppercase or
-            lowercase, as appropriate, before passing it to this method.
 
         Typically your FrameObject will provide its own ``enter_text`` method,
         so your test scripts won't call this ``Keyboard`` class directly. For
@@ -156,8 +156,8 @@ class Keyboard(object):
 
                 def enter_text(self, text):
                     page = self
-                    page = self._kb.enter_text(page, text.upper())
-                    self._kb.navigate_to(page, "SEARCH")
+                    page = self._kb.enter_text(text.upper(), page)
+                    self._kb.navigate_to("SEARCH", page)
                     stbt.press("KEY_OK")
         """
 
@@ -166,19 +166,19 @@ class Keyboard(object):
                 raise ValueError("'%s' isn't in the keyboard" % (letter,))
 
         for letter in text:
-            page = self.navigate_to(page, letter)
+            page = self.navigate_to(letter, page)
             stbt.press("KEY_OK")
         return page
 
-    def navigate_to(self, page, target):
+    def navigate_to(self, target, page):
         """Move the selection to the specified character.
 
         Note that this won't press KEY_OK on the target, it only moves the
         selection there.
 
-        :param stbt.FrameObject page: See ``enter_text``.
         :param str target: The key or button to navigate to, for example "A",
             " ", or "CLEAR".
+        :param stbt.FrameObject page: See ``enter_text``.
 
         :returns: A new FrameObject instance of the same type as ``page``,
             reflecting the device-under-test's new state after the navigation

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -218,10 +218,10 @@ class _Keyboard(stbt.FrameObject):
     KEYBOARD = stbt.Keyboard(GRAPH, navigate_timeout=0.1)
 
     def enter_text(self, text):
-        return self.KEYBOARD.enter_text(self, text.upper())
+        return self.KEYBOARD.enter_text(text.upper(), page=self)
 
     def navigate_to(self, target):
-        return self.KEYBOARD.navigate_to(self, target)
+        return self.KEYBOARD.navigate_to(target, page=self)
 
 
 class YouTubeKeyboard(object):


### PR DESCRIPTION
This API is a little bit hard to use: In the example from the docstring, we were passing an out-of-date page object into `Keyboard.navigate_to`. So after typing the text, it was calculating the path to the "SEARCH" button from your initial state, not from the actual state (which should be the last letter in the text you've typed). This could lead it to pressing a sequence of keys that take it out of the keyboard altogether.

This fixes the example in the docstring, and we also reverse the order of arguments to give us a bit more flexibility in how we might solve this in the future without breaking the Keyboard API.