### PR TITLE
Keyboard & Grid fixes

### DIFF
--- a/_stbt/grid.py
+++ b/_stbt/grid.py
@@ -138,7 +138,7 @@ class Grid(object):
                               else self._position_to_region(position))
                     break
             else:
-                raise IndexError("data '%r' not found" % data)
+                raise IndexError("data %r not found" % (data,))
 
         return Grid.Cell(
             index,

--- a/_stbt/grid.py
+++ b/_stbt/grid.py
@@ -161,7 +161,11 @@ class Grid(object):
             return self.get(data=key)
 
     def __iter__(self):
-        return _GridIter(self)
+        for i in range(len(self)):  # pylint:disable=consider-using-enumerate
+            yield self[i]
+
+    def __len__(self):
+        return self.cols * self.rows
 
     def _index_to_position(self, index):
         area = self.cols * self.rows
@@ -214,25 +218,6 @@ class Grid(object):
         else:
             raise IndexError("Index out of range: position %r in %r" %
                              (position, self))
-
-
-class _GridIter(object):
-    def __init__(self, grid):
-        self.grid = grid
-        self.index = 0
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        i = self.index
-        if i == self.grid.area:
-            raise StopIteration()
-        self.index += 1
-        return self.grid[i]
-
-    def next(self):  # Python 2
-        return self.__next__()
 
 
 def grid_to_navigation_graph(grid):

--- a/_stbt/grid.py
+++ b/_stbt/grid.py
@@ -212,48 +212,6 @@ class Grid(object):
             raise IndexError("Index out of range: position %r in %r" %
                              (position, self))
 
-    def navigation_graph(self, names):
-        """Generate a Graph that describes navigation between cells in the grid.
-
-        Creates a `Directed Graph`_ that links adjacent cells in the grid with
-        edges named "KEY_LEFT", "KEY_RIGHT", "KEY_UP", and "KEY_DOWN",
-        corresponding to the keypress that will move a selection from one cell
-        to another.
-
-        :param names: An iterable containing the names for each node in the
-            graph (cell in the grid) in the order corresponding to the cell's
-            1D index into the grid (see `Grid.index_to_position`). For example
-            if you have an on-screen keyboard that looks like this::
-
-                A  B  C  D  E  F  G
-                H  I  J  K  L  M  N
-                O  P  Q  R  S  T  U
-                V  W  X  Y  Z  -  '
-
-            then ``names`` could be the string "ABCDEFGHIJKLMNOPQRSTUVWXYZ-'".
-
-        :returns: A `networkx.DiGraph` suitable as the ``graph`` parameter of
-            `stbt.Keyboard`.
-
-        .. _Directed Graph: https://en.wikipedia.org/wiki/Directed_graph
-        """
-        G = nx.DiGraph()
-        for index, name in enumerate(names):
-            x, y = self._index_to_position(index)
-            if x > 0:
-                G.add_edge(name, names[self._position_to_index((x - 1, y))],
-                           key="KEY_LEFT")
-            if x < self.cols - 1:
-                G.add_edge(name, names[self._position_to_index((x + 1, y))],
-                           key="KEY_RIGHT")
-            if y > 0:
-                G.add_edge(name, names[self._position_to_index((x, y - 1))],
-                           key="KEY_UP")
-            if y < self.rows - 1:
-                G.add_edge(name, names[self._position_to_index((x, y + 1))],
-                           key="KEY_DOWN")
-        return G
-
 
 class _GridIter(object):
     def __init__(self, grid):
@@ -272,3 +230,52 @@ class _GridIter(object):
 
     def next(self):  # Python 2
         return self.__next__()
+
+
+def grid_to_navigation_graph(grid):
+    """Generate a Graph that describes navigation between cells in the grid.
+
+    Creates a `networkx.DiGraph` (`Directed Graph`_) that models cells in the
+    grid as nodes in the graph. Each edge in the graph has a ``key`` attribute
+    set to "KEY_LEFT", "KEY_RIGHT", "KEY_UP", or "KEY_DOWN", corresponding to
+    the keypress that will move a selection from one node to another.
+
+    :param Grid grid: The grid to model. If the Grid has data associated
+        with the cells, each node in the graph will be named with the
+        corresponding cell's ``data``; otherwise the nodes are numbered
+        according to the cell's ``index``. This means that the cell's ``data``
+        must be `hashable`_ so that it can be used as a `networkx` node.
+
+    :returns: A `networkx.DiGraph`.
+
+    For example, to create a graph suitable as the ``graph`` parameter of
+    `stbt.Keyboard`::
+
+        grid = stbt.Grid(region, data=["ABCDEFG",
+                                       "HIJKLMN",
+                                       "OPQRSTU",
+                                       "VWXYZ-'"])
+        keyboard = stbt.Keyboard(grid_to_navigation_graph(grid))
+
+    .. _Directed Graph: https://en.wikipedia.org/wiki/Directed_graph
+    .. _hashable: https://docs.python.org/3.6/glossary.html#term-hashable
+    """
+    G = nx.DiGraph()
+
+    def name(c):
+        if c.data is None:
+            return c.index
+        else:
+            return c.data
+
+    for cell in grid:
+        x, y = cell.position
+        if x > 0:
+            G.add_edge(name(cell), name(grid[x - 1, y]), key="KEY_LEFT")
+        if x < grid.cols - 1:
+            G.add_edge(name(cell), name(grid[x + 1, y]), key="KEY_RIGHT")
+        if y > 0:
+            G.add_edge(name(cell), name(grid[x, y - 1]), key="KEY_UP")
+        if y < grid.rows - 1:
+            G.add_edge(name(cell), name(grid[x, y + 1]), key="KEY_DOWN")
+    return G

--- a/_stbt/grid.py
+++ b/_stbt/grid.py
@@ -157,6 +157,9 @@ class Grid(object):
         else:
             return self.get(data=key)
 
+    def __iter__(self):
+        return _GridIter(self)
+
     def _index_to_position(self, index):
         area = self.cols * self.rows
         if index < -area:
@@ -250,3 +253,22 @@ class Grid(object):
                 G.add_edge(name, names[self._position_to_index((x, y + 1))],
                            key="KEY_DOWN")
         return G
+
+
+class _GridIter(object):
+    def __init__(self, grid):
+        self.grid = grid
+        self.index = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        i = self.index
+        if i == self.grid.area:
+            raise StopIteration
+        self.index += 1
+        return self.grid[i]
+
+    def next(self):  # Python 2
+        return self.__next__()

--- a/_stbt/grid.py
+++ b/_stbt/grid.py
@@ -227,7 +227,7 @@ class _GridIter(object):
     def __next__(self):
         i = self.index
         if i == self.grid.area:
-            raise StopIteration
+            raise StopIteration()
         self.index += 1
         return self.grid[i]
 

--- a/_stbt/grid.py
+++ b/_stbt/grid.py
@@ -132,7 +132,7 @@ class Grid(object):
         elif data is not None:
             for i in range(self.cols * self.rows):
                 position = self._index_to_position(i)
-                if data == self.data[position.y][position.x]:
+                if data == self.data[position[1]][position[0]]:
                     index = i
                     region = (None if self.region is None
                               else self._position_to_region(position))
@@ -144,7 +144,7 @@ class Grid(object):
             index,
             position,
             region,
-            self.data and self.data[position.y][position.x])
+            self.data and self.data[position[1]][position[0]])
 
     def __getitem__(self, key):
         if isinstance(key, int):

--- a/_stbt/grid.py
+++ b/_stbt/grid.py
@@ -6,6 +6,8 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
 
+from collections import namedtuple
+
 import networkx as nx
 
 from _stbt.types import Position, Region
@@ -20,21 +22,65 @@ class Grid(object):
         FGHIJ
         KLMNO
 
-    This class contains methods for converting between pixel coordinates on a
-    screen, to x & y indexes into the grid positions.
+    This class is useful for converting between pixel coordinates on a screen,
+    to x & y indexes into the grid positions.
 
     :param Region region: Where the grid is on the screen.
     :param int cols: Width of the grid, in number of columns.
     :param int rows: Height of the grid, in number of rows.
+    :param data: A 2D array (list of lists) containing data to associate with
+        each cell. The data can be of any type. For example, if you are
+        modelling a grid-shaped keyboard, the data could be the letter at each
+        grid position. If ``data`` is specified, then ``cols`` and ``rows`` are
+        optional.
     """
-    def __init__(self, region, cols, rows):
+    def __init__(self, region, cols=None, rows=None, data=None):
         self.region = region
-        self.cols = cols
-        self.rows = rows
+        self.data = data
+        if (rows is None or cols is None) and data is None:
+            raise ValueError(
+                "Either `cols` and `rows`, or `data` must be specified")
+        if rows is None:
+            self.rows = len(data)
+        else:
+            self.rows = rows
+        if cols is None:
+            self.cols = len(data[0])
+        else:
+            self.cols = cols
+
+    class Cell(namedtuple("Cell", "index position region data")):
+        """A single cell in a `Grid`.
+
+        Don't construct Cells directly; create a `Grid` instead.
+
+        :ivar int index: The cell's 1D index into the grid, starting from 0 at
+            the top left, counting along the top row left to right, then the
+            next row left to right, etc.
+
+        :ivar Position position: The cell's 2D index (x, y) into the grid
+            (zero-based). For example in this grid "I" is index ``8`` and
+            position ``(x=3, y=1)``::
+
+                ABCDE
+                FGHIJ
+                KLMNO
+
+        :ivar Region region: Pixel coordinates (relative to the entire frame)
+            of the cell's bounding box.
+
+        :ivar data: The data corresponding to the cell, if data was specified
+            when you created the `Grid`.
+        """
+        pass
 
     def __repr__(self):
-        return "Grid(region=%r, cols=%r, rows=%r)" % (
+        s = "Grid(region=%r, cols=%r, rows=%r)" % (
             self.region, self.cols, self.rows)
+        if self.data:
+            return "<" + s + ">"
+        else:
+            return s
 
     @property
     def area(self):
@@ -42,61 +88,92 @@ class Grid(object):
 
     @property
     def cells(self):
-        return [self.position_to_region(x)
-                for x in range(self.cols * self.rows)]
+        return [self.get(index=i)
+                for i in range(self.cols * self.rows)]
 
-    def index_to_position(self, index):
-        """Convert a 1D index into a 2D position.
+    def get(self, index=None, position=None, region=None, data=None):
+        """Retrieve a single cell in the Grid.
 
-        For example in this grid "I" is index ``9`` and position
-        ``(x=3, y=1)``::
+        For example, let's say that you're looking for the selected item in
+        a grid by matching a reference image of the selection border. Then you
+        can find the (x, y) position in the grid of the selection, like this::
 
-            ABCDE
-            FGHIJ
-            KLMNO
+            selection = stbt.match("selection.png")
+            cell = grid.get(region=selection.region)
+            position = cell.position
 
-        :param int index: A 1D index into the grid, starting from 0 at the top
-            left, counting along the top row left to right, then the next row,
-            etc.
-            A negative index counts backwards from the end of the grid (so
-            ``-1`` is the bottom right position).
+        You must specify one (and only one) of ``index``, ``position``,
+        ``region``, or ``data``. For the meaning of these parameters see
+        `Grid.Cell`. A negative index counts backwards from the end of the grid
+        (so ``-1`` is the bottom right position).
 
-        :rtype: Position
-        :returns: x & y indexes into the grid (zero-based).
+        :returns: The `Grid.Cell` that matches the specified query; raises
+            `IndexError` if the index/position/region is out of bounds or the
+            data is not found.
         """
+        if len([x for x in [index, position, region, data]
+                if x is not None]) != 1:
+            raise ValueError("Exactly one of index, position, region, or data "
+                             "must be specified")
+        if data is not None and self.data is None:
+            raise IndexError("Searching by data %r but this Grid doesn't have "
+                             "any data associated" % data)
+        if index is not None:
+            position = self._index_to_position(index)
+            region = self._position_to_region(position)
+        elif position is not None:
+            index = self._position_to_index(position)
+            region = self._position_to_region(position)
+        elif region is not None:
+            position = self._region_to_position(region)
+            index = self._position_to_index(position)
+        elif data is not None:
+            for i in range(self.cols * self.rows):
+                position = self._index_to_position(i)
+                if data == self.data[position.y][position.x]:
+                    index = i
+                    region = self._position_to_region(position)
+                    break
+            else:
+                raise IndexError("data '%r' not found" % data)
+
+        return Grid.Cell(
+            index,
+            position,
+            region,
+            self.data and self.data[position.y][position.x])
+
+    def __getitem__(self, key):
+        if isinstance(key, int):
+            return self.get(index=key)
+        elif isinstance(key, Region):
+            return self.get(region=key)
+        elif isinstance(key, Position) or (
+                isinstance(key, tuple) and
+                len(key) == 2 and
+                isinstance(key[0], int) and
+                isinstance(key[1], int)):
+            return self.get(position=key)
+        else:
+            return self.get(data=key)
+
+    def _index_to_position(self, index):
         area = self.cols * self.rows
         if index < -area:
             raise IndexError("Index out of range: index %r in %r" %
                              (index, self))
         elif index < 0:
-            return self.index_to_position(area + index)
+            return self._index_to_position(area + index)
         elif index < area:
             return Position(x=index % self.cols, y=index // self.cols)
         else:
             raise IndexError("Index out of range: index %r in %r" %
                              (index, self))
 
-    def position_to_index(self, position):
-        """Convert a 2D position into a 1D index.
-
-        The inverse of `Grid.index_to_position`.
-
-        :param Position position: x & y indexes into the grid (zero-based).
-
-        :rtype: int
-        :returns: A 1D index into the grid, starting from 0 at the top
-            left, counting along the top row left to right, then the next row,
-            etc.
-        """
+    def _position_to_index(self, position):
         return position[0] + position[1] * self.cols
 
-    def region_to_position(self, region):
-        """Find the grid position that contains ``region``'s centre.
-
-        :param stbt.Region region: Pixel coordinates on the screen, relative to
-            the entire frame.
-        :returns: A `Position`.
-        """
+    def _region_to_position(self, region):
         rel = region.translate(x=-self.region.x, y=-self.region.y)
         centre = (float(rel.x + rel.right) / 2,
                   float(rel.y + rel.bottom) / 2)
@@ -104,22 +181,14 @@ class Grid(object):
                centre[1] * self.rows // self.region.height)
         if (pos[0] < 0 or pos[1] < 0 or
                 pos[0] >= self.cols or pos[1] >= self.rows):
-            raise ValueError(
+            raise IndexError(
                 "The centre of region %r is outside the grid area %r" % (
                     region, self.region))
         return Position(int(pos[0]), int(pos[1]))
 
-    def position_to_region(self, position):
-        """Calculate the region of the screen that is covered by a grid cell.
-
-        :param Position position: A 2D index (x, y) into the grid.
-
-        :rtype: stbt.Region
-        :returns: The pixel coordinates (relative to the entire frame) that
-            correspond to the specified position.
-        """
+    def _position_to_region(self, position):
         if isinstance(position, int):
-            position = self.index_to_position(position)
+            position = self._index_to_position(position)
         elif not isinstance(position, Position):
             position = Position(position[0], position[1])
 
@@ -139,25 +208,6 @@ class Grid(object):
         else:
             raise IndexError("Index out of range: position %r in %r" %
                              (position, self))
-
-    def region_to_index(self, region):
-        """Like `Grid.region_to_position`, but returns a 1D index instead of
-        a 2D position.
-
-        :param stbt.Region region: See `Grid.region_to_position`.
-        :returns: See `Grid.position_to_index`.
-        """
-        pos = self.region_to_position(region)
-        return pos.x + pos.y * self.cols
-
-    def index_to_region(self, index):
-        """Like `Grid.position_to_region`, but takes a 1D index instead of a 2D
-        position.
-
-        :param int index: See `Grid.index_to_position`.
-        :returns: See `Grid.position_to_region`.
-        """
-        return self.position_to_region(self.index_to_position(index))
 
     def navigation_graph(self, names):
         """Generate a Graph that describes navigation between cells in the grid.
@@ -186,17 +236,17 @@ class Grid(object):
         """
         G = nx.DiGraph()
         for index, name in enumerate(names):
-            x, y = self.index_to_position(index)
+            x, y = self._index_to_position(index)
             if x > 0:
-                G.add_edge(name, names[self.position_to_index((x - 1, y))],
+                G.add_edge(name, names[self._position_to_index((x - 1, y))],
                            key="KEY_LEFT")
             if x < self.cols - 1:
-                G.add_edge(name, names[self.position_to_index((x + 1, y))],
+                G.add_edge(name, names[self._position_to_index((x + 1, y))],
                            key="KEY_RIGHT")
             if y > 0:
-                G.add_edge(name, names[self.position_to_index((x, y - 1))],
+                G.add_edge(name, names[self._position_to_index((x, y - 1))],
                            key="KEY_UP")
             if y < self.rows - 1:
-                G.add_edge(name, names[self.position_to_index((x, y + 1))],
+                G.add_edge(name, names[self._position_to_index((x, y + 1))],
                            key="KEY_DOWN")
         return G

--- a/_stbt/grid.py
+++ b/_stbt/grid.py
@@ -120,10 +120,12 @@ class Grid(object):
                              "any data associated" % data)
         if index is not None:
             position = self._index_to_position(index)
-            region = self._position_to_region(position)
+            region = (None if self.region is None
+                      else self._position_to_region(position))
         elif position is not None:
             index = self._position_to_index(position)
-            region = self._position_to_region(position)
+            region = (None if self.region is None
+                      else self._position_to_region(position))
         elif region is not None:
             position = self._region_to_position(region)
             index = self._position_to_index(position)
@@ -132,7 +134,8 @@ class Grid(object):
                 position = self._index_to_position(i)
                 if data == self.data[position.y][position.x]:
                     index = i
-                    region = self._position_to_region(position)
+                    region = (None if self.region is None
+                              else self._position_to_region(position))
                     break
             else:
                 raise IndexError("data '%r' not found" % data)

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -33,7 +33,8 @@ from _stbt.config import (
 from _stbt.frameobject import (
     FrameObject)
 from _stbt.grid import (
-    Grid)
+    Grid,
+    grid_to_navigation_graph)
 from _stbt.imgutils import (
     crop,
     Frame)
@@ -84,6 +85,7 @@ __all__ = [
     "get_config",
     "get_frame",
     "Grid",
+    "grid_to_navigation_graph",
     "is_screen_black",
     "Keyboard",
     "load_image",

--- a/stbt/keyboard.py
+++ b/stbt/keyboard.py
@@ -68,9 +68,9 @@ class Keyboard(object):
         For advanced users: instead of a string, ``graph`` can be a
         `networkx.DiGraph` where each edge has an attribute called ``key`` with
         a value like ``"KEY_RIGHT"``. If your keyboard's buttons are positioned
-        in a regular grid, you can use `stbt.Grid.navigation_graph` to generate
-        this graph (or part of the graph, and then you can add any irregular
-        connections explicitly with `networkx.DiGraph.add_edge`).
+        in a regular grid, you can use `stbt.grid_to_navigation_graph` to
+        generate this graph (or part of the graph, and then you can add any
+        irregular connections explicitly with `networkx.DiGraph.add_edge`).
 
     :type mask: str or `numpy.ndarray`
     :param str mask:

--- a/stbt/keyboard.py
+++ b/stbt/keyboard.py
@@ -98,7 +98,8 @@ class Keyboard(object):
     Has two attributes:
 
     * ``text`` (*str*) — The selected letter or button.
-    * ``region`` (`stbt.Region`) — The position on screen of the selection box.
+    * ``region`` (`stbt.Region`) — The position on screen of the selection /
+      highlight.
     """
 
     def __init__(self, graph, mask=None, navigate_timeout=20):
@@ -146,8 +147,7 @@ class Keyboard(object):
     #   have a blinking cursor there).
 
     def enter_text(self, text, page):
-        """
-        Enter the specified text using the on-screen keyboard.
+        """Enter the specified text using the on-screen keyboard.
 
         :param str text: The text to enter. If your keyboard only supports a
             single case then you need to convert the text to uppercase or

--- a/stbt/keyboard.py
+++ b/stbt/keyboard.py
@@ -105,7 +105,10 @@ class Keyboard(object):
             self.G = nx.parse_edgelist(graph.split("\n"),
                                        create_using=nx.DiGraph(),
                                        data=[("key", str)])
-        nx.relabel_nodes(self.G, {"SPACE": " "}, copy=False)
+        try:
+            nx.relabel_nodes(self.G, {"SPACE": " "}, copy=False)
+        except KeyError:  # Node SPACE is not in the graph
+            pass
         _add_weights(self.G)
 
         self.mask = None

--- a/stbt/keyboard.py
+++ b/stbt/keyboard.py
@@ -163,6 +163,10 @@ class Keyboard(object):
               property can return a string, or an object with a ``text``
               attribute that is a string.
 
+              For grid-shaped keyboards, you can map the region of the
+              selection (highlight) to the corresponding letter using
+              `stbt.Grid` (see the example below).
+
             The ``page`` instance that you provide must represent the current
             state of the device-under-test.
 
@@ -175,6 +179,13 @@ class Keyboard(object):
                     A B KEY_RIGHT
                     ...etc...
                     ''')
+                letters = stbt.Grid(region=...,
+                                    data=["ABCDEFG",
+                                          "HIJKLMN",
+                                          "OPQRSTU",
+                                          "VWXYZ-'"])
+                space_row = stbt.Grid(region=...,
+                                      data=[[" ", "CLEAR", "SEARCH"]])
 
                 @property
                 def is_visible(self):
@@ -182,7 +193,14 @@ class Keyboard(object):
 
                 @property
                 def selection(self):
-                    ...  # implementation not shown
+                    m = stbt.match("keyboard-selection.png", frame=self._frame)
+                    if not m:
+                        return stbt.Keyboard.Selection(None, None)
+                    try:
+                        text = self.letters.get(region=m.region).data
+                    except IndexError:
+                        text = self.space_row.get(region=m.region).data
+                    return stbt.Keyboard.Selection(text, r)
 
                 def enter_text(self, text):
                     page = self

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -52,6 +52,9 @@ def test_grid():
     for r1, r2 in combinations(g.cells, 2):
         assert Region.intersect(r1.region, r2.region) is None
 
+    for i, c in enumerate(g):
+        assert i == c.index
+
 
 def test_grid_with_data():
     layout = ["ABCDEFG",

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -68,6 +68,8 @@ def test_grid_with_data():
     assert g.get(position=Position(x=2, y=1)).data == "J"
     assert g.get(data="J").index == 9
     assert g["J"].index == 9
+    assert g[Position(x=2, y=1)].data == "J"
+    assert g[2, 1].data == "J"
     assert g[-1].data == "'"
     for x in ["a", layout[0], layout]:
         with raises(IndexError):

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,9 +1,15 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+
 from itertools import combinations
 
 import networkx as nx
 from pytest import raises
 
-from stbt import Grid, Region
+from stbt import Grid, Position, Region
 
 
 def test_grid():
@@ -11,28 +17,58 @@ def test_grid():
     assert g.area == 12
 
     def check_conversions(g, region, position, index):
-        assert g.region_to_position(region) == position
-        assert g.index_to_position(index) == position
-        assert g.region_to_index(region) == index
-        assert g.position_to_index(position) == index
-        assert g.index_to_region(index) == region
-        assert g.position_to_region(position) == region
+        c = g.get(index=index)
+        assert c.region == region
+        assert c.position == position
+        assert c.data is None
+        assert c == g.get(region=region)
+        assert c == g.get(position=position)
+        assert c == g[index]
+        assert c == g[position]
+        assert c == g[region]
 
     check_conversions(g, Region(0, 0, 1, 1), (0, 0), 0)
     check_conversions(g, Region(5, 1, 1, 1), (5, 1), 11)
+    check_conversions(g, Region(5, 1, 1, 1), Position(5, 1), 11)
 
-    assert g.region_to_position(Region(4, 0, 3, 3)) == (5, 1)
+    assert g.get(region=Region(4, 0, 3, 3)).position == (5, 1)
     for x, y in [(-1, 0), (0, -1), (6, 0), (0, 2), (6, 2)]:
-        with raises(ValueError):
-            g.region_to_position(Region(x, y, 1, 1))
+        with raises(IndexError):
+            g.get(region=Region(x, y, 1, 1))
+
+    with raises(IndexError):
+        g.get(index=12)
+    with raises(IndexError):
+        g.get(index=-13)
+    with raises(IndexError):
+        g.get(position=(6, 1))
+    with raises(IndexError):
+        g.get(data="J")
 
     g = Grid(Region(x=99, y=212, width=630, height=401), cols=5, rows=3)
-    check_conversions(g, Region(351, 212, 126, 133), (2, 0), 2)
     check_conversions(g, Region(351, 212, 126, 133), (2, 0), 2)
     check_conversions(g, Region(477, 345, 126, 134), (3, 1), 8)
 
     for r1, r2 in combinations(g.cells, 2):
-        assert Region.intersect(r1, r2) is None
+        assert Region.intersect(r1.region, r2.region) is None
+
+
+def test_grid_with_data():
+    layout = ["ABCDEFG",
+              "HIJKLMN",
+              "OPQRSTU",
+              "VWXYZ-'"]
+    g = Grid(Region(0, 0, 100, 50), data=layout)
+    assert g.cols == 7
+    assert g.rows == 4
+    assert g.get(index=9).data == "J"
+    assert g.get(position=Position(x=2, y=1)).data == "J"
+    assert g.get(data="J").index == 9
+    assert g["J"].index == 9
+    assert g[-1].data == "'"
+    for x in ["a", layout[0], layout]:
+        with raises(IndexError):
+            print(g[x])
 
 
 def test_grid_navigation_graph():

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -15,6 +15,7 @@ from stbt import Grid, grid_to_navigation_graph, Position, Region
 def test_grid():
     g = Grid(Region(0, 0, 6, 2), cols=6, rows=2)
     assert g.area == 12
+    assert len(g) == 12
 
     def check_conversions(g, region, position, index):
         c = g.get(index=index)


### PR DESCRIPTION
Provides a much easier way of specifying grid-like keyboards. See `test_composing_complex_keyboards` in 1df3d7b for an example.