### PR TITLE
stbt.ocr docstring: Note that LSTM engine ignores char_whitelist

### DIFF
--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -237,6 +237,7 @@ def ocr(frame=None, region=Region.ALL,
         String of characters that are allowed. Useful when you know that the
         text is only going to contain numbers or IP addresses, for example so
         that tesseract won't think that a zero is the letter o.
+        Note that Tesseract 4.0's LSTM engine ignores ``char_whitelist``.
 
     | Added in v28: The ``upsample`` and ``text_color`` parameters.
     | Added in v29: The ``text_color_threshold`` parameter.


### PR DESCRIPTION
Tesseract 4.0's LSTM engine ignores char_whitelist.[1]

This is fixed in Tesseract 4.1 [2] but it isn't widely available
yet (it'll be in Ubuntu 19.10).

[1]: https://github.com/tesseract-ocr/tesseract/issues/751
[2]: https://github.com/tesseract-ocr/tesseract/wiki/ReleaseNotes#tesseract-release-notes-jul-07-2019---v410