### PR TITLE
Region: Allow translating one region by another one

### DIFF
--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -393,7 +393,7 @@ def _match_all(image, frame, match_parameters, region):
                 crop(frame, input_region), t, match_parameters, imglog):
 
             match_region = Region.from_extents(*match_region) \
-                                 .translate(input_region.x, input_region.y)
+                                 .translate(input_region)
             result = MatchResult(
                 getattr(frame, "time", None), matched, match_region,
                 first_pass_certainty, frame,

--- a/_stbt/motion.py
+++ b/_stbt/motion.py
@@ -138,7 +138,7 @@ def detect_motion(timeout_secs=10, noise_threshold=None, mask=None,
             # Undo cv2.erode above:
             out_region = out_region.extend(x=-1, y=-1)
             # Undo crop:
-            out_region = out_region.translate(region.x, region.y)
+            out_region = out_region.translate(region)
 
         motion = bool(out_region)
         if motion:

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -258,7 +258,7 @@ def strict_diff(prev, frame, region, mask_image):
             _ddebug("only found %s diffs <= %s", frame, small_diffs_count,
                     maxdiff)
     if out_region:
-        out_region = out_region.translate(region.x, region.y)
+        out_region = out_region.translate(region)
 
     result = MotionResult(getattr(frame, "time", None), diffs_found,
                           out_region, frame)

--- a/_stbt/types.py
+++ b/_stbt/types.py
@@ -115,9 +115,6 @@ class Region(with_metaclass(_RegionClsMethods,
     Region(x=1, y=1, right=4, bottom=3)
     >>> Region(2, 3, 2, 1).translate(b)
     Region(x=6, y=7, right=8, bottom=8)
-    >>> Region(2, 3, 2, 1).translate(b, 5)
-    Traceback (most recent call last):
-    TypeError
     >>> Region.intersect(Region.ALL, c) == c
     True
     >>> Region.ALL

--- a/_stbt/types.py
+++ b/_stbt/types.py
@@ -269,13 +269,11 @@ class Region(with_metaclass(_RegionClsMethods,
         :returns: A new region with the position of the region adjusted by the
             given amounts.  The width and height are unaffected.
 
-        `translate` either accepts seperate `int` x and y coordinates or a
-        single `Region` argument:
+        ``translate`` accepts separate x and y arguments, or a single `Region`.
+
+        For example, move the region 1px right and 2px down:
 
         >>> b = Region(4, 4, 9, 6)
-
-        Move the region 1px right and 2px down:
-
         >>> b.translate(1, 2)
         Region(x=5, y=6, right=14, bottom=12)
 

--- a/_stbt/types.py
+++ b/_stbt/types.py
@@ -307,7 +307,9 @@ class Region(with_metaclass(_RegionClsMethods,
             p = x or 0, y or 0
         else:
             if y is not None:
-                raise TypeError()
+                raise TypeError(
+                    "translate() takes either a single Region argument or two "
+                    "ints (both given)")
         return Region.from_extents(self.x + p[0], self.y + p[1],
                                    self.right + p[0], self.bottom + p[1])
 

--- a/_stbt/types.py
+++ b/_stbt/types.py
@@ -270,7 +270,36 @@ class Region(with_metaclass(_RegionClsMethods,
     def translate(self, x=None, y=None):
         """
         :returns: A new region with the position of the region adjusted by the
-            given amounts.
+            given amounts.  The width and height are unaffected.
+
+        `translate` either accepts seperate `int` x and y coordinates or a
+        single `Region` argument:
+
+        >>> b = Region(4, 4, 9, 6)
+
+        Move the region 1px right and 2px down:
+
+        >>> b.translate(1, 2)
+        Region(x=5, y=6, right=14, bottom=12)
+
+        Move the region 1px to the left:
+
+        >>> b.translate(x=-1)
+        Region(x=3, y=4, right=12, bottom=10)
+
+        Move the region 3px up:
+
+        >>> b.translate(y=-3)
+        Region(x=4, y=1, right=13, bottom=7)
+
+        Move the region by another region.  This can be helpful if `TITLE`
+        defines a region relative another UI element on screen.  You can then
+        combine the two like so:
+
+        >>> TITLE = Region(20, 5, 160, 40)
+        >>> CELL = Region(140, 45, 200, 200)
+        >>> TITLE.translate(CELL)
+        Region(x=160, y=50, right=320, bottom=90)
         """
         try:
             p = x[0], x[1]

--- a/_stbt/types.py
+++ b/_stbt/types.py
@@ -113,6 +113,11 @@ class Region(with_metaclass(_RegionClsMethods,
     Region(x=-inf, y=-inf, right=2, bottom=2)
     >>> c.translate(x=-9, y=-3)
     Region(x=1, y=1, right=4, bottom=3)
+    >>> Region(2, 3, 2, 1).translate(b)
+    Region(x=6, y=7, right=8, bottom=8)
+    >>> Region(2, 3, 2, 1).translate(b, 5)
+    Traceback (most recent call last):
+    TypeError
     >>> Region.intersect(Region.ALL, c) == c
     True
     >>> Region.ALL
@@ -262,13 +267,20 @@ class Region(with_metaclass(_RegionClsMethods,
         return (other and self.x <= other.x and self.y <= other.y and
                 self.right >= other.right and self.bottom >= other.bottom)
 
-    def translate(self, x=0, y=0):
+    def translate(self, x=None, y=None):
         """
         :returns: A new region with the position of the region adjusted by the
             given amounts.
         """
-        return Region.from_extents(self.x + x, self.y + y,
-                                   self.right + x, self.bottom + y)
+        try:
+            p = x[0], x[1]
+        except TypeError:
+            p = x or 0, y or 0
+        else:
+            if y is not None:
+                raise TypeError()
+        return Region.from_extents(self.x + p[0], self.y + p[1],
+                                   self.right + p[0], self.bottom + p[1])
 
     def extend(self, x=0, y=0, right=0, bottom=0):
         """

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -108,6 +108,12 @@ def test_region_replace():
     yield t, dict(x=11, right=21, y=0, height=5), stbt.Region(x=11, y=0, width=10, height=5)
 
 
+def test_region_translate():
+    with pytest.raises(TypeError):
+        # Both region and y provided
+        stbt.Region(2, 3, 2, 1).translate(stbt.Region(0, 0, 1, 1), 5)
+
+
 @pytest.mark.parametrize("frame,mask,threshold,region,expected", [
     # pylint:disable=line-too-long
     ("black-full-frame.png", None, None, stbt.Region.ALL, True),


### PR DESCRIPTION
...in fact this will allow translating by any tuple that has x and y as the first two items.  This is helpful when dealing with items that have substructure.  For example: A carousel might have multiple items laid out in a grid:

    +---------------+     +----------------+
    |    Title 1    |     |    Title 2     |
    |               |     |                |
    | Description 1 |     | Description 2  |
    | this TV show  |     | this one isn't |
    | is really     |     | so interesting |
    | good and      |     |                |
    | exciting      |     |                |
    |               |     |                |
    +---------------+     +----------------+

The boxes might be given by `REGION[0]` and `REGION[1]`.  You could then
have `TITLE_REGION` and `DESCRIPTION_REGION` relative to the boxes.  To read
all the information it might look like:

    for r in REGION:
        title = stbt.ocr(region=TITLE_REGION.translate(r))
        description = stbt.ocr(region=DESCRIPTION_REGION.translate(r))