### PR TITLE
Replace treating `None` as `Region` with `Region.NONE`

### DIFF
--- a/_stbt/logging.py
+++ b/_stbt/logging.py
@@ -180,7 +180,7 @@ class ImageLogger(object):
     def _draw(self, region, source_size, css_class, title=None):
         import jinja2
 
-        if region is None:
+        if not region:
             return ""
 
         if isinstance(css_class, bool):

--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -374,7 +374,7 @@ def _match_all(image, frame, match_parameters, region):
                 % (template.relative_filename, match_parameters.match_method))
 
     input_region = Region.intersect(_image_region(frame), region)
-    if input_region is None:
+    if not input_region:
         raise ValueError("frame with dimensions %r doesn't contain %r"
                          % (frame.shape, region))
     if input_region.height < t.shape[0] or input_region.width < t.shape[1]:

--- a/_stbt/types.py
+++ b/_stbt/types.py
@@ -55,6 +55,9 @@ class _RegionClsMethods(type):
             max(r.bottom for r in args))
 
 
+INF = float('inf')
+
+
 class Region(with_metaclass(_RegionClsMethods,
                             namedtuple('Region', 'x y right bottom'))):
     r"""
@@ -108,7 +111,7 @@ class Region(with_metaclass(_RegionClsMethods,
     Region(x=0, y=0, right=8, bottom=8)
     >>> Region.intersect()
     Region.ALL
-    >>> quadrant = Region(x=float("-inf"), y=float("-inf"), right=0, bottom=0)
+    >>> quadrant = Region(x=-INF, y=-INF, right=0, bottom=0)
     >>> quadrant.translate(2, 2)
     Region(x=-inf, y=-inf, right=2, bottom=2)
     >>> c.translate(x=-9, y=-3)
@@ -333,28 +336,28 @@ class Region(with_metaclass(_RegionClsMethods,
         else:
             return None
 
-    def above(self, height=float('inf')):
+    def above(self, height=INF):
         """
         :returns: A new region above the current region, extending to the top
             of the frame (or to the specified height).
         """
         return self.replace(y=self.y - height, bottom=self.y)
 
-    def below(self, height=float('inf')):
+    def below(self, height=INF):
         """
         :returns: A new region below the current region, extending to the bottom
             of the frame (or to the specified height).
         """
         return self.replace(y=self.bottom, bottom=self.bottom + height)
 
-    def right_of(self, width=float('inf')):
+    def right_of(self, width=INF):
         """
         :returns: A new region to the right of the current region, extending to
             the right edge of the frame (or to the specified width).
         """
         return self.replace(x=self.right, right=self.right + width)
 
-    def left_of(self, width=float('inf')):
+    def left_of(self, width=INF):
         """
         :returns: A new region to the left of the current region, extending to
             the left edge of the frame (or to the specified width).
@@ -362,8 +365,7 @@ class Region(with_metaclass(_RegionClsMethods,
         return self.replace(x=self.x - width, right=self.x)
 
 
-Region.ALL = Region(x=-float('inf'), y=-float('inf'),
-                    right=float('inf'), bottom=float('inf'))
+Region.ALL = Region(x=-INF, y=-INF, right=INF, bottom=INF)
 
 
 class UITestError(Exception):

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -26,7 +26,7 @@ from stbt import load_image
     # pylint: disable=line-too-long
     ("Connection-status--white-on-dark-blue.png", "Connection status: Connected", stbt.Region.ALL, None),
     ("Connection-status--white-on-dark-blue.png", "Connected", stbt.Region(x=210, y=0, width=120, height=40), None),
-    # ("Connection-status--white-on-dark-blue.png", "", None, None),  # uncomment when region=None doesn't raise -- see #433
+    ("Connection-status--white-on-dark-blue.png", "", stbt.Region.NONE, None),
     ("programme--white-on-black.png", "programme", stbt.Region.ALL, None),
     ("UJJM--white-text-on-grey-boxes.png", "", stbt.Region.ALL, None),
     ("UJJM--white-text-on-grey-boxes.png", "UJJM", stbt.Region.ALL, stbt.OcrMode.SINGLE_LINE),
@@ -39,7 +39,6 @@ def test_ocr_on_static_images(image, expected_text, region, mode):
     assert text == expected_text
 
 
-# Remove when region=None doesn't raise -- see #433
 def test_that_ocr_region_none_isnt_allowed():
     with pytest.raises(TypeError):
         stbt.ocr(frame=load_image("ocr/small.png"), region=None)
@@ -246,7 +245,7 @@ def test_that_match_text_still_returns_if_region_doesnt_intersect_with_frame(
     frame = load_image("ocr/menu.png")
     result = stbt.match_text("Onion Bhaji", frame=frame, region=region)
     assert result.match is False
-    assert result.region is None
+    assert not result.region
     assert result.text == "Onion Bhaji"
 
 


### PR DESCRIPTION
This may make it easier to use functions that return a `Region` that might
be `None` because in many cases they may not need to check `region is None`
before performing operations on that region.  It also makes it easier to
implement functions with take a default `Region` because we can follow the
standard `region is not None` to mean "did the caller pass a region
argument".  For an example of this see `Grid`.

I don't think this should go in the next release.  It would be better to let it bake for a while.

**TODO:**

- [ ] Should `Region.NONE == Region.NONE`?  Currently `Region.NONE == Region.NONE`, but `Region.NONE != Region(float('nan'), float('nan'), float('nan'), float('nan'))` because `NAN != NAN` and `NAN != float('nan')` but `(NAN,) == (NAN,)` and `(NAN,) != (float('nan'))`
- [ ] Should `Region.NONE.width == 0` or `nan`?, equally for height
- [ ] Is `NONE` a good name?  Perhaps `EMPTY` would be better?
- [ ] Codify all these weird behaviours in tests so we'll know if we break them
- [ ] Validate that we've converted all the uses of `None` as `Region` in our codebase.
- [ ] Release note