### PR TITLE
stbt.Keyboard: Verify that you've reached the target

### DIFF
--- a/stbt/keyboard.py
+++ b/stbt/keyboard.py
@@ -147,7 +147,7 @@ class Keyboard(object):
     #   use press_and_wait because the text-box might be masked out (some UIs
     #   have a blinking cursor there).
 
-    def enter_text(self, text, page):
+    def enter_text(self, text, page, verify_every_keypress=False):
         """Enter the specified text using the on-screen keyboard.
 
         :param str text: The text to enter. If your keyboard only supports a
@@ -170,6 +170,19 @@ class Keyboard(object):
 
             The ``page`` instance that you provide must represent the current
             state of the device-under-test.
+
+        :param bool verify_every_keypress:
+            If True, we will read the selected key after every keypress and
+            assert that it matches the model (``graph``). If False (the
+            default) we will only verify the selected key corresponding to each
+            of the characters in ``text``. For example: to get from Q to D on a
+            qwerty keyboard you need to press KEY_DOWN, KEY_RIGHT, KEY_RIGHT.
+            The default behaviour will only verify that the selected key is D
+            after pressing KEY_RIGHT the last time. This is faster, and closer
+            to the way a human uses the on-screen keyboard.
+
+            Set this to True to help debug your model if ``enter_text`` is
+            behaving incorrectly.
 
         Typically your FrameObject will provide its own ``enter_text`` method,
         so your test scripts won't call this ``Keyboard`` class directly. For
@@ -215,11 +228,11 @@ class Keyboard(object):
                 raise ValueError("'%s' isn't in the keyboard" % (letter,))
 
         for letter in text:
-            page = self.navigate_to(letter, page)
+            page = self.navigate_to(letter, page, verify_every_keypress)
             stbt.press("KEY_OK")
         return page
 
-    def navigate_to(self, target, page):
+    def navigate_to(self, target, page, verify_every_keypress=False):
         """Move the selection to the specified character.
 
         Note that this won't press KEY_OK on the target, it only moves the
@@ -228,6 +241,7 @@ class Keyboard(object):
         :param str target: The key or button to navigate to, for example "A",
             " ", or "CLEAR".
         :param stbt.FrameObject page: See ``enter_text``.
+        :param bool verify_every_keypress: See ``enter_text``.
 
         :returns: A new FrameObject instance of the same type as ``page``,
             reflecting the device-under-test's new state after the navigation
@@ -247,20 +261,22 @@ class Keyboard(object):
             keys = list(_keys_to_press(self.G, current, target))
             log.info("Keyboard: navigating from %s to %s by pressing %r",
                      current, target, keys)
-            for k, _ in keys[:-1]:
-                stbt.press(k)
-            key, possible_targets = keys[-1]
-            assert stbt.press_and_wait(key, mask=self.mask, stable_secs=0.5)
-            page = page.refresh()
-            assert page, "%s page isn't visible" % type(page).__name__
-            current = _selection_to_text(page.selection)
-            assert current in possible_targets, \
-                "Expected to see %s after pressing %s, but saw %r" % (
-                    _join_with_commas(
-                        [repr(x) for x in sorted(possible_targets)],
-                        last_one=" or "),
-                    key,
-                    current)
+            if not verify_every_keypress:
+                for k, _ in keys[:-1]:
+                    stbt.press(k)
+                keys = keys[-1:]  # only verify the last one
+            for key, possible_targets in keys:
+                assert stbt.press_and_wait(key, mask=self.mask, stable_secs=0.5)
+                page = page.refresh()
+                assert page, "%s page isn't visible" % type(page).__name__
+                current = _selection_to_text(page.selection)
+                assert current in possible_targets, \
+                    "Expected to see %s after pressing %s, but saw %r" % (
+                        _join_with_commas(
+                            [repr(x) for x in sorted(possible_targets)],
+                            last_one=" or "),
+                        key,
+                        current)
         return page
 
     @staticmethod

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -292,9 +292,9 @@ def buggykeyboard():
 def test_enter_text(youtubekeyboard):  # pylint:disable=redefined-outer-name
     page = youtubekeyboard.page
     assert page.selection == "A"
-    page.enter_text("hi there")
+    page = page.enter_text("hi there")
+    assert page.selection == "E"
     assert youtubekeyboard.entered == "HI THERE"
-    assert youtubekeyboard.selection == "E"
 
 
 def test_that_enter_text_uses_minimal_keypresses(youtubekeyboard):  # pylint:disable=redefined-outer-name
@@ -318,8 +318,8 @@ def test_that_keyboard_validates_the_targets(youtubekeyboard):  # pylint:disable
 def test_navigate_to(youtubekeyboard):  # pylint:disable=redefined-outer-name
     page = youtubekeyboard.page
     assert page.selection == "A"
-    page.navigate_to("SEARCH")
-    assert youtubekeyboard.selection == "SEARCH"
+    page = page.navigate_to("SEARCH")
+    assert page.selection == "SEARCH"
     assert youtubekeyboard.pressed == ["KEY_DOWN"] * 4 + ["KEY_RIGHT"] * 2
 
 

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -146,15 +146,19 @@ nx.relabel_nodes(G, {"SPACE": " "}, copy=False)
 
 def test_keys_to_press():
     assert list(_keys_to_press(G, "A", "A")) == []
-    assert list(_keys_to_press(G, "A", "B")) == ["KEY_RIGHT"]
-    assert list(_keys_to_press(G, "B", "A")) == ["KEY_LEFT"]
-    assert list(_keys_to_press(G, "A", "C")) == ["KEY_RIGHT", "KEY_RIGHT"]
-    assert list(_keys_to_press(G, "C", "A")) == ["KEY_LEFT", "KEY_LEFT"]
-    assert list(_keys_to_press(G, "A", "H")) == ["KEY_DOWN"]
-    assert list(_keys_to_press(G, "H", "A")) == ["KEY_UP"]
-    assert list(_keys_to_press(G, "A", "I")) in (["KEY_RIGHT", "KEY_DOWN"],
-                                                 ["KEY_DOWN", "KEY_RIGHT"])
-    assert list(_keys_to_press(G, " ", "A")) == ["KEY_UP"]
+    assert list(_keys_to_press(G, "A", "B")) == [("KEY_RIGHT", {"B"})]
+    assert list(_keys_to_press(G, "B", "A")) == [("KEY_LEFT", {"A"})]
+    assert list(_keys_to_press(G, "A", "C")) == [("KEY_RIGHT", {"B"}),
+                                                 ("KEY_RIGHT", {"C"})]
+    assert list(_keys_to_press(G, "C", "A")) == [("KEY_LEFT", {"B"}),
+                                                 ("KEY_LEFT", {"A"})]
+    assert list(_keys_to_press(G, "A", "H")) == [("KEY_DOWN", {"H"})]
+    assert list(_keys_to_press(G, "H", "A")) == [("KEY_UP", {"A"})]
+    assert list(_keys_to_press(G, "A", "I")) in (
+        [("KEY_RIGHT", {"B"}), ("KEY_DOWN", {"I"})],
+        [("KEY_DOWN", {"H"}), ("KEY_RIGHT", {"I"})])
+    assert list(_keys_to_press(G, " ", "A")) == [
+        ("KEY_UP", {"V", "W", "X", "Y", "Z", "-", "'"})]
 
 
 def test_add_weights():


### PR DESCRIPTION
Previously the only verification was in the while loop's condition:
`while current != target`. So if your model of the keyboard was wrong,
`navigate_to` would keep on trying to reach the target until
`navigate_timeout` was reached (default 20 seconds). Maybe this would
allow to eventually reach the key, but it can also lead to very
confusing, hard to debug, behaviour.

Now we verify that we've reached each letter in the word you're trying
to type, so we fail earlier and we provide a useful error message.

Optionally we can also verify each state in the journey from the current
selection to the target letter, by specifying
`verify_every_keypress=True`. This is slower and less human-like but
you'd only set while debugging your model.

---

TODO:

- [x] Tests with ~an incorrect model~ a model that doesn't match the actual behaviour.