### PR TITLE
Bump imgproc_cache version to 31

### DIFF
--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -487,7 +487,7 @@ class MatchTimeout(UITestFailure):
             self.expected, self.timeout_secs)
 
 
-@memoize_iterator({"version": "30"})
+@memoize_iterator({"version": "31"})
 def _find_matches(image, template, match_parameters, imglog):
     """Our image-matching algorithm.
 

--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -460,7 +460,7 @@ def _tesseract(frame, region, mode, lang, _config, user_patterns, user_words,
             region)
 
 
-@imgproc_cache.memoize({"version": "30"})
+@imgproc_cache.memoize({"version": "31"})
 def _tesseract_subprocess(
         frame, mode, lang, _config, user_patterns, user_words, upsample,
         text_color, text_color_threshold, engine, char_whitelist,


### PR DESCRIPTION
The behaviour of `stbt.match` changed in commit 0a4e6a1 (stbt.match: Pyramid optimisation: Ignore pixels on edge of reference image) to fix a bug where mostly-transparent images with a thin border wouldn't match (false negatives). Don't know about `stbt.ocr` but it doesn't hurt to bump that version too.