### PR TITLE
ocr, match_text: Raise exception if region is outside of frame

### DIFF
--- a/_stbt/black.py
+++ b/_stbt/black.py
@@ -16,8 +16,8 @@ from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-impor
 import cv2
 
 from .config import get_config
-from .imgutils import (_frame_repr, _image_region, load_image,
-                       pixel_bounding_box, crop)
+from .imgutils import (crop, _frame_repr, load_image, pixel_bounding_box,
+                       _validate_region)
 from .logging import debug, ImageLogger
 from .types import Region
 
@@ -72,11 +72,12 @@ def is_screen_black(frame=None, mask=None, threshold=None, region=Region.ALL):
     if mask is not None:
         mask = load_image(mask, cv2.IMREAD_GRAYSCALE)
 
+    region = _validate_region(frame, region)
+
     imglog = ImageLogger("is_screen_black", region=region, threshold=threshold)
     imglog.imwrite("source", frame)
 
-    _region = Region.intersect(_image_region(frame), region)
-    greyframe = cv2.cvtColor(crop(frame, _region), cv2.COLOR_BGR2GRAY)
+    greyframe = cv2.cvtColor(crop(frame, region), cv2.COLOR_BGR2GRAY)
     if mask is not None:
         imglog.imwrite("mask", mask)
         cv2.bitwise_and(greyframe, mask, dst=greyframe)

--- a/_stbt/diff.py
+++ b/_stbt/diff.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 import cv2
 
 from .config import get_config
-from .imgutils import crop, _frame_repr, _image_region, pixel_bounding_box
+from .imgutils import (crop, _frame_repr, pixel_bounding_box, _validate_region)
 from .logging import ImageLogger
 from .types import Region
 
@@ -24,7 +24,7 @@ class FrameDiffer(object):
 
     def __init__(self, initial_frame, region=Region.ALL, mask=None):
         self.prev_frame = initial_frame
-        self.region = Region.intersect(_image_region(self.prev_frame), region)
+        self.region = _validate_region(self.prev_frame, region)
         self.mask = mask
         if (self.mask is not None and
                 self.mask.shape[:2] != (self.region.height, self.region.width)):

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -145,11 +145,21 @@ def crop(frame, region):
       of the source frame. This is a view onto the original data, so if you
       want to modify the cropped image call its ``copy()`` method first.
     """
-    r = Region.intersect(region, _image_region(frame))
-    if r is None:
-        raise ValueError("%r is outside of frame dimensions %ix%i"
-                         % (region, frame.shape[1], frame.shape[0]))
+    r = _validate_region(frame, region)
     return frame[r.y:r.bottom, r.x:r.right]
+
+
+def _validate_region(frame, region):
+    if region is None:
+        raise TypeError(
+            "'region=None' means an empty region. To analyse the entire "
+            "frame use 'region=Region.ALL' (which is the default)")
+    f = _image_region(frame)
+    r = Region.intersect(f, region)
+    if r is None:
+        raise ValueError("%r doesn't overlap with the frame dimensions %ix%i"
+                         % (region, frame.shape[1], frame.shape[0]))
+    return r
 
 
 def _image_region(image):

--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -23,7 +23,8 @@ import numpy
 from . import cv2_compat
 from .config import ConfigurationError, get_config
 from .imgproc_cache import memoize_iterator
-from .imgutils import _frame_repr, _image_region, crop, limit_time, load_image
+from .imgutils import (crop, _frame_repr, _image_region, limit_time, load_image,
+                       _validate_region)
 from .logging import (_Annotation, ddebug, debug, draw_on, get_debug_level,
                       ImageLogger)
 from .types import Position, Region, UITestFailure
@@ -382,10 +383,7 @@ def _match_all(image, frame, match_parameters, region):
                 "(you specified %s)."
                 % (template.relative_filename, match_parameters.match_method))
 
-    input_region = Region.intersect(_image_region(frame), region)
-    if input_region is None:
-        raise ValueError("frame with dimensions %r doesn't contain %r"
-                         % (frame.shape, region))
+    input_region = _validate_region(frame, region)
     if input_region.height < t.shape[0] or input_region.width < t.shape[1]:
         raise ValueError("%r must be larger than reference image %r"
                          % (input_region, t.shape))

--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -362,9 +362,8 @@ def match_text(text, frame=None, region=Region.ALL,
         p = _hocr_find_phrase(hocr, to_unicode(text).split(), case_sensitive)
         if p:
             # Find bounding box
-            box = None
-            for _, elem in p:
-                box = Region.bounding_box(box, _hocr_elem_region(elem))
+            box = Region.bounding_box(*[_hocr_elem_region(elem)
+                                        for _, elem in p])
             # _tesseract crops to region and scales up by a factor of 3 so
             # we must undo this transformation here.
             n = 3 if upsample else 1

--- a/_stbt/types.py
+++ b/_stbt/types.py
@@ -237,9 +237,11 @@ class Region(with_metaclass(_RegionClsMethods,
         if bottom is None:
             bottom = y + height
         if right <= x:
-            raise ValueError("'right' must be greater than 'x'")
+            raise ValueError("'right' (%r) must be greater than 'x' (%r)"
+                             % (right, x))
         if bottom <= y:
-            raise ValueError("'bottom' must be greater than 'y'")
+            raise ValueError("'bottom' (%r) must be greater than 'y' (%r)"
+                             % (bottom, y))
         return super(Region, cls).__new__(cls, x, y, right, bottom)
 
     def __repr__(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -118,7 +118,7 @@ def test_crop():
                                    right=10, bottom=10)))
 
     # But a region entirely outside the frame is not allowed:
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         stbt.crop(img, None)
     with pytest.raises(ValueError):
         stbt.crop(img, stbt.Region(x=-10, y=-10, right=0, bottom=0))

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -36,7 +36,6 @@ def requires_tesseract(func):
     # pylint: disable=line-too-long
     ("Connection-status--white-on-dark-blue.png", "Connection status: Connected", stbt.Region.ALL, None),
     ("Connection-status--white-on-dark-blue.png", "Connected", stbt.Region(x=210, y=0, width=120, height=40), None),
-    # ("Connection-status--white-on-dark-blue.png", "", None, None),  # uncomment when region=None doesn't raise -- see #433
     ("programme--white-on-black.png", "programme", stbt.Region.ALL, None),
     ("UJJM--white-text-on-grey-boxes.png", "", stbt.Region.ALL, None),
     ("UJJM--white-text-on-grey-boxes.png", "UJJM", stbt.Region.ALL, stbt.OcrMode.SINGLE_LINE),
@@ -48,15 +47,28 @@ def test_ocr_on_static_images(image, expected_text, region, mode):
     text = stbt.ocr(load_image("ocr/" + image), **kwargs)
     assert text == expected_text
 
-    # Don't leak python future newtypes
-    assert type(text).__name__ in ["unicode", "str"]
 
-
-# Remove when region=None doesn't raise -- see #433
 @requires_tesseract
-def test_that_ocr_region_none_isnt_allowed():
-    with pytest.raises(TypeError):
-        stbt.ocr(frame=load_image("ocr/small.png"), region=None)
+def test_ocr_doesnt_leak_python_future_newtypes():
+    f = load_image("ocr/small.png")
+    result = stbt.ocr(f)
+    assert type(result).__name__ in ["str", "unicode"]
+
+    result = stbt.match_text("Small", f)
+    assert type(result.text).__name__ in ["str", "unicode"]
+
+
+@requires_tesseract
+@pytest.mark.parametrize("region", [
+    None,
+    stbt.Region(1280, 0, 1280, 720),
+])
+def test_that_ocr_region_none_isnt_allowed(region):
+    f = load_image("ocr/small.png")
+    with pytest.raises((TypeError, ValueError)):
+        stbt.ocr(frame=f, region=region)
+    with pytest.raises((TypeError, ValueError)):
+        stbt.match_text("Small", frame=f, region=region)
 
 
 @requires_tesseract
@@ -295,34 +307,6 @@ def test_that_text_region_is_correct_even_with_regions_larger_than_frame():
         text, frame=frame, region=region.extend(right=+12800))
     assert result
     assert region.contains(result.region)
-
-
-@requires_tesseract
-@pytest.mark.parametrize("region", [
-    stbt.Region(1280, 0, 1280, 720),
-    None,
-])
-def test_that_match_text_still_returns_if_region_doesnt_intersect_with_frame(
-        region):
-    frame = load_image("ocr/menu.png")
-    result = stbt.match_text("Onion Bhaji", frame=frame, region=region)
-    assert result.match is False
-    assert result.region is None
-    assert result.text == "Onion Bhaji"
-
-    # Avoid future.types.newtypes in return values
-    assert type(result.text).__name__ in ["str", "unicode"]
-
-
-@requires_tesseract
-@pytest.mark.parametrize("region", [
-    stbt.Region(1280, 0, 1280, 720),
-    # None,  # uncomment when region=None doesn't raise -- see #433
-])
-def test_that_ocr_still_returns_if_region_doesnt_intersect_with_frame(region):
-    frame = load_image("ocr/menu.png")
-    result = stbt.ocr(frame=frame, region=region)
-    assert result == u''
 
 
 @requires_tesseract

--- a/tests/test_stbt_debug.py
+++ b/tests/test_stbt_debug.py
@@ -416,19 +416,16 @@ def test_ocr_debug():
     f = stbt.load_image("action-panel.png")
     r = stbt.Region(0, 370, right=1280, bottom=410)
     c = (235, 235, 235)
-    nonoverlapping = stbt.Region(2000, 2000, width=10, height=10)
 
     with scoped_curdir(), scoped_debug_level(2):
 
         stbt.ocr(f)
         stbt.ocr(f, region=r)
         stbt.ocr(f, region=r, text_color=c)
-        stbt.ocr(f, region=nonoverlapping)
 
         stbt.match_text("Summary", f)  # no match
         stbt.match_text("Summary", f, region=r)  # no match
         stbt.match_text("Summary", f, region=r, text_color=c)
-        stbt.match_text("Summary", f, region=nonoverlapping)
 
         files = subprocess.check_output("find stbt-debug | sort", shell=True) \
                           .decode("utf-8")
@@ -454,6 +451,8 @@ def test_ocr_debug():
             stbt-debug/00004
             stbt-debug/00004/index.html
             stbt-debug/00004/source.png
+            stbt-debug/00004/tessinput.png
+            stbt-debug/00004/upsampled.png
             stbt-debug/00005
             stbt-debug/00005/index.html
             stbt-debug/00005/source.png
@@ -463,17 +462,9 @@ def test_ocr_debug():
             stbt-debug/00006/index.html
             stbt-debug/00006/source.png
             stbt-debug/00006/tessinput.png
+            stbt-debug/00006/text_color_difference.png
+            stbt-debug/00006/text_color_threshold.png
             stbt-debug/00006/upsampled.png
-            stbt-debug/00007
-            stbt-debug/00007/index.html
-            stbt-debug/00007/source.png
-            stbt-debug/00007/tessinput.png
-            stbt-debug/00007/text_color_difference.png
-            stbt-debug/00007/text_color_threshold.png
-            stbt-debug/00007/upsampled.png
-            stbt-debug/00008
-            stbt-debug/00008/index.html
-            stbt-debug/00008/source.png
             """)
 
         # To see the generated files in tests/dave-debug/:


### PR DESCRIPTION
For `ocr` and `match_text` this is a change in behaviour: Previously if the region was entirely outside of the frame, they would log a warning and return "" or a Falsey TextMatchResult, respectively (but for `region=None` they would already raise a TypeError). I don't think the old behaviour is anything you'd ever want to do intentionally, it's far more likely to be a bug in your test. And the new behaviour is consistent with all the other stbt APIs.

For all the other functions this is a nicer error message. `press_and_wait` would raise "UnboundLocalError: local variable 'f1' referenced before assignment". The others would raise either "ValueError: frame with dimensions (720, 1280, 3) doesn't contain None" (from stbt.crop) or "AttributeError: 'NoneType' object has no attribute 'x/y/right/bottom'".