### PR TITLE
Dont expose future newtypes

### DIFF
--- a/_stbt/black.py
+++ b/_stbt/black.py
@@ -11,7 +11,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 import cv2
 

--- a/_stbt/config.py
+++ b/_stbt/config.py
@@ -2,7 +2,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 from future.utils import native_str
 
 import configparser

--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 from future.utils import text_to_native_str
 
 import os

--- a/_stbt/control_gpl.py
+++ b/_stbt/control_gpl.py
@@ -405,9 +405,9 @@ def _fake_cec():
     def cec_cmd_get_data(cmd):
         # Ugly, but can't find another way to do it
         import ctypes
-        return bytes(memoryview(ctypes.cast(  # pylint:disable=undefined-variable
-            int(cmd.parameters.data), ctypes.POINTER(ctypes.c_uint8)).contents,
-            0, cmd.parameters.size))
+        return bytearray(ctypes.cast(
+            int(cmd.parameters.data),
+            ctypes.POINTER(ctypes.c_uint8 * cmd.parameters.size)).contents)
 
     def Transmit(_, cmd):
         io.write(b"Transmit(dest: 0x%x, src: 0x%x, op: 0x%x, data: <%s>)\n" % (

--- a/_stbt/control_gpl.py
+++ b/_stbt/control_gpl.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future.utils import string_types
+import codecs
 import re
 import sys
 import threading
@@ -386,14 +387,14 @@ def _fake_cec():
     def cec_cmd_get_data(cmd):
         # Ugly, but can't find another way to do it
         import ctypes
-        return str(buffer(ctypes.cast(  # pylint:disable=undefined-variable
+        return bytes(memoryview(ctypes.cast(  # pylint:disable=undefined-variable
             int(cmd.parameters.data), ctypes.POINTER(ctypes.c_uint8)).contents,
             0, cmd.parameters.size))
 
     def Transmit(_, cmd):
         io.write(b"Transmit(dest: 0x%x, src: 0x%x, op: 0x%x, data: <%s>)\n" % (
             cmd.destination, cmd.initiator, cmd.opcode,
-            cec_cmd_get_data(cmd).encode('hex')))
+            codecs.encode(cec_cmd_get_data(cmd), 'hex')))
         return True
 
     def RescanActiveDevices(_):

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -12,7 +12,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
 from __future__ import print_function
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 from future.utils import native, raise_, string_types, text_to_native_str
 
 import argparse

--- a/_stbt/cv2_compat.py
+++ b/_stbt/cv2_compat.py
@@ -5,7 +5,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 from distutils.version import LooseVersion
 

--- a/_stbt/frameobject.py
+++ b/_stbt/frameobject.py
@@ -8,7 +8,8 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from past.builtins import cmp
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 import functools
 import threading
 from future.utils import with_metaclass

--- a/_stbt/grid.py
+++ b/_stbt/grid.py
@@ -4,7 +4,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 from collections import namedtuple
 

--- a/_stbt/gst_hacks.py
+++ b/_stbt/gst_hacks.py
@@ -13,6 +13,8 @@ import gi
 gi.require_version("Gst", "1.0")
 from gi.repository import Gst  # pylint:disable=wrong-import-order
 
+from .utils import text_type
+
 # Here we are using ctypes to call `gst_buffer_map` and `gst_buffer_unmap`
 # because PyGObject does not properly expose struct GstMapInfo (see
 # [bz #678663]).  Apparently this is fixed upstream but we are still awaiting
@@ -91,7 +93,7 @@ def _sample_borrow_buffer(sample):
     """
     if not isinstance(sample, Gst.Sample):
         raise TypeError("sample_borrow_buffer must take a Gst.Sample.  "
-                        "Received a %s instead" % str(type(sample)))
+                        "Received a %s instead" % text_type(type(sample)))
 
     # hashing a GObject actually gives the address (pointer) of the C struct
     # that backs it!:

--- a/_stbt/gst_hacks.py
+++ b/_stbt/gst_hacks.py
@@ -2,7 +2,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 import ctypes
 import platform
 from contextlib import contextmanager

--- a/_stbt/gst_utils.py
+++ b/_stbt/gst_utils.py
@@ -2,7 +2,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 import ctypes
 import sys
 from functools import reduce  # pylint:disable=redefined-builtin

--- a/_stbt/gst_utils.py
+++ b/_stbt/gst_utils.py
@@ -11,6 +11,7 @@ import gi
 
 from .gst_hacks import map_gst_sample, sample_get_size
 from .imgutils import Frame
+from .utils import text_type
 
 gi.require_version("Gst", "1.0")
 from gi.repository import GObject, Gst  # pylint:disable=wrong-import-order
@@ -51,7 +52,7 @@ class _MappedSample(object):
     def __init__(self, sample, readwrite=False):
         if not isinstance(sample, Gst.Sample):
             raise TypeError("MappedSample must take a Gst.Sample.  Received a "
-                            "%s" % str(type(sample)))
+                            "%s" % text_type(type(sample)))
 
         flags = Gst.MapFlags.READ
         if readwrite:

--- a/_stbt/imgproc_cache.py
+++ b/_stbt/imgproc_cache.py
@@ -31,7 +31,8 @@ except ImportError:
     lmdb = None
 
 from _stbt.logging import ImageLogger
-from _stbt.utils import mkdir_p, named_temporary_directory, scoped_curdir
+from _stbt.utils import (
+    mkdir_p, named_temporary_directory, scoped_curdir, to_bytes)
 
 try:
     from itertools import zip_longest
@@ -155,7 +156,7 @@ def memoize_iterator(additional_fields=None):
 
             for i in itertools.count():
                 with _cache.begin() as txn:
-                    out = txn.get(key + str(i).encode())
+                    out = txn.get(key + to_bytes(str(i)))
                 if out is None:
                     break
                 out_, stop_ = json.loads(out)
@@ -169,10 +170,10 @@ def memoize_iterator(additional_fields=None):
                 try:
                     output = next(it)
                     if i >= skip:
-                        _cache_put(key + str(i).encode(), [output, None])
+                        _cache_put(key + to_bytes(str(i)), [output, None])
                         yield output
                 except StopIteration:
-                    _cache_put(key + str(i).encode(), [None, "StopIteration"])
+                    _cache_put(key + to_bytes(str(i)), [None, "StopIteration"])
                     raise
 
         return inner

--- a/_stbt/imgproc_cache.py
+++ b/_stbt/imgproc_cache.py
@@ -12,7 +12,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 import functools
 import inspect

--- a/_stbt/imgproc_cache.py
+++ b/_stbt/imgproc_cache.py
@@ -32,7 +32,7 @@ except ImportError:
 
 from _stbt.logging import ImageLogger
 from _stbt.utils import (
-    mkdir_p, named_temporary_directory, scoped_curdir, to_bytes)
+    mkdir_p, named_temporary_directory, scoped_curdir, text_type, to_bytes)
 
 try:
     from itertools import zip_longest
@@ -207,7 +207,7 @@ class _ArgsEncoder(json.JSONEncoder):
                 raise NotCachable()
             return None
         elif isinstance(o, LooseVersion):
-            return str(o)
+            return text_type(o)
         elif isinstance(o, set):
             return sorted(o)
         elif isinstance(o, MatchParameters):

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -4,7 +4,8 @@ from __future__ import division
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 from future.utils import text_to_native_str
 
 import inspect

--- a/_stbt/irnetbox.py
+++ b/_stbt/irnetbox.py
@@ -47,7 +47,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 import binascii
 import errno

--- a/_stbt/logging.py
+++ b/_stbt/logging.py
@@ -4,7 +4,8 @@ from __future__ import division
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 import argparse
 import itertools
 import os

--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -27,7 +27,7 @@ from .imgutils import _frame_repr, _image_region, _load_image, crop, limit_time
 from .logging import (_Annotation, ddebug, debug, draw_on, get_debug_level,
                       ImageLogger)
 from .types import Position, Region, UITestFailure
-from .utils import native_str
+from .utils import native_str, text_type
 
 try:
     from .sqdiff import sqdiff
@@ -273,9 +273,9 @@ def match(image, frame=None, match_parameters=None, region=Region.ALL):
     """
     result = next(_match_all(image, frame, match_parameters, region))
     if result.match:
-        debug("Match found: %s" % str(result))
+        debug("Match found: %s" % text_type(result))
     else:
-        debug("No match found. Closest match: %s" % str(result))
+        debug("No match found. Closest match: %s" % text_type(result))
     return result
 
 
@@ -304,12 +304,12 @@ def match_all(image, frame=None, match_parameters=None, region=Region.ALL):
     any_matches = False
     for result in _match_all(image, frame, match_parameters, region):
         if result.match:
-            debug("Match found: %s" % str(result))
+            debug("Match found: %s" % text_type(result))
             any_matches = True
             yield result
         else:
             if not any_matches:
-                debug("No match found. Closest match: %s" % str(result))
+                debug("No match found. Closest match: %s" % text_type(result))
             break
 
 

--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -11,7 +11,8 @@ from __future__ import division
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 import enum
 import itertools

--- a/_stbt/motion.py
+++ b/_stbt/motion.py
@@ -15,6 +15,7 @@ from .imgutils import (_frame_repr, _image_region, _ImageFromUser, _load_image,
                        pixel_bounding_box, crop, limit_time)
 from .logging import debug, draw_on, ImageLogger
 from .types import Region, UITestFailure
+from .utils import text_type
 
 
 def detect_motion(timeout_secs=10, noise_threshold=None, mask=None,
@@ -153,7 +154,7 @@ def detect_motion(timeout_secs=10, noise_threshold=None, mask=None,
                               out_region, frame)
         draw_on(frame, result, label="detect_motion()")
         debug("%s found: %s" % (
-            "Motion" if motion else "No motion", str(result)))
+            "Motion" if motion else "No motion", text_type(result)))
         _log_motion_image_debug(imglog, result)
         yield result
 
@@ -207,7 +208,7 @@ def wait_for_motion(
     if consecutive_frames is None:
         consecutive_frames = get_config('motion', 'consecutive_frames')
 
-    consecutive_frames = str(consecutive_frames)
+    consecutive_frames = text_type(consecutive_frames)
     if '/' in consecutive_frames:
         motion_frames = int(consecutive_frames.split('/')[0])
         considered_frames = int(consecutive_frames.split('/')[1])

--- a/_stbt/motion.py
+++ b/_stbt/motion.py
@@ -4,7 +4,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 from collections import deque
 

--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -352,9 +352,9 @@ def match_text(text, frame=None, region=Region.ALL,
             result = TextMatchResult(rts, False, None, frame, text)
 
     if result.match:
-        debug("match_text: Match found: %s" % str(result))
+        debug("match_text: Match found: %s" % text_type(result))
     else:
-        debug("match_text: No match found: %s" % str(result))
+        debug("match_text: No match found: %s" % text_type(result))
 
     imglog.set(text=text, case_sensitive=case_sensitive,
                result=result, hocr=hocr)
@@ -447,7 +447,7 @@ def _tesseract(frame, region, mode, lang, _config, user_patterns, user_words,
     intersection = Region.intersect(frame_region, region)
     if intersection is None:
         warn("Requested OCR in region %s which doesn't overlap with "
-             "the frame %s" % (str(region), frame_region))
+             "the frame %s" % (text_type(region), frame_region))
         imglog.set(region=None)
         return (u'', None)
     else:
@@ -468,7 +468,7 @@ def _tesseract_subprocess(
         imglog, tesseract_version):
 
     if tesseract_version >= LooseVersion("4.0"):
-        engine_flags = ["--oem", str(int(engine))]
+        engine_flags = ["--oem", native_str(int(engine))]
         tessdata_suffix = ''
     else:
         engine_flags = []
@@ -509,7 +509,7 @@ def _tesseract_subprocess(
         cmd = ["tesseract", '-l', lang,
                tmp + '/input.png',
                tmp + '/output',
-               psm_flag, str(int(mode))] + engine_flags
+               psm_flag, native_str(int(mode))] + engine_flags
 
         tessenv = os.environ.copy()
 

--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -4,7 +4,8 @@ from __future__ import division
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 import errno
 import glob

--- a/_stbt/power.py
+++ b/_stbt/power.py
@@ -2,7 +2,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 import errno
 import os
 import re

--- a/_stbt/sqdiff.py
+++ b/_stbt/sqdiff.py
@@ -2,7 +2,8 @@ from __future__ import division
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 import ctypes
 import os
 

--- a/_stbt/stbt_run.py
+++ b/_stbt/stbt_run.py
@@ -2,7 +2,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 import os
 import sys
 import traceback

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -16,7 +16,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 import enum
 

--- a/_stbt/types.py
+++ b/_stbt/types.py
@@ -5,7 +5,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 from future.utils import with_metaclass
 
 from collections import namedtuple

--- a/_stbt/x11.py
+++ b/_stbt/x11.py
@@ -2,7 +2,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 import os
 import queue
 import random

--- a/_stbt/xxhash.py
+++ b/_stbt/xxhash.py
@@ -8,7 +8,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 import binascii
 import ctypes
 import os

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -13,7 +13,8 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 from contextlib import contextmanager
 

--- a/stbt/android.py
+++ b/stbt/android.py
@@ -37,7 +37,8 @@ from __future__ import division
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 from future.utils import raise_
 
 import configparser

--- a/stbt/android.py
+++ b/stbt/android.py
@@ -51,6 +51,7 @@ from collections import namedtuple
 from enum import Enum
 
 from _stbt.logging import debug
+from _stbt.utils import native_str
 
 
 class CoordinateSystem(Enum):
@@ -308,7 +309,8 @@ class AdbDevice(object):
         x1, y1 = self._to_native_coordinates(x1, y1)
         x2, y2 = self._to_native_coordinates(x2, y2)
         command = ["shell", "input", "swipe",
-                   str(x1), str(y1), str(x2), str(y2)]
+                   native_str(x1), native_str(y1),
+                   native_str(x2), native_str(y2)]
         self.adb(command, timeout_secs=10)
 
     def tap(self, position):
@@ -326,7 +328,8 @@ class AdbDevice(object):
         debug("AdbDevice.tap((%d,%d))" % (x, y))
 
         x, y = self._to_native_coordinates(x, y)
-        self.adb(["shell", "input", "tap", str(x), str(y)], timeout_secs=10)
+        self.adb(["shell", "input", "tap", native_str(x), native_str(y)],
+                 timeout_secs=10)
 
     def _adb(self, command, timeout_secs=None, **kwargs):
         _command = []

--- a/stbt/keyboard.py
+++ b/stbt/keyboard.py
@@ -5,7 +5,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 import time
 from collections import namedtuple

--- a/stbt/pylint_plugin.py
+++ b/stbt/pylint_plugin.py
@@ -13,7 +13,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 from future.utils import string_types
 
 import os

--- a/stbt_config.py
+++ b/stbt_config.py
@@ -9,7 +9,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 import argparse
 import sys

--- a/stbt_control.py
+++ b/stbt_control.py
@@ -5,7 +5,8 @@ from __future__ import division
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 import argparse
 import collections

--- a/stbt_control.py
+++ b/stbt_control.py
@@ -22,6 +22,7 @@ from textwrap import dedent
 
 import _stbt.control
 from _stbt.config import ConfigurationError, get_config
+from _stbt.utils import text_type
 
 SPECIAL_CHARS = {
     curses.ascii.SP: "Space",
@@ -164,7 +165,7 @@ def main_loop(control_uri, keymap_file):
                 clear_last_command(term)
             if control_key:
                 yield control_key
-            term.addstr(str(control_key))
+            term.addstr(text_type(control_key))
             timer = threading.Timer(1, clear_last_command, [term])
             timer.start()
             time.sleep(.2)
@@ -291,7 +292,7 @@ def default_keymap_file():
 
 def error(s):
     sys.stderr.write("%s: error: %s\n" % (
-        os.path.basename(sys.argv[0]), str(s)))
+        os.path.basename(sys.argv[0]), text_type(s)))
     sys.exit(1)
 
 

--- a/stbt_control_relay.py
+++ b/stbt_control_relay.py
@@ -41,7 +41,7 @@ import socket
 import sys
 
 from _stbt.control import uri_to_control
-from _stbt.utils import to_bytes
+from _stbt.utils import native_str, to_bytes
 
 
 def main(argv):
@@ -62,7 +62,7 @@ def main(argv):
     signal.signal(signal.SIGTERM, lambda _signo, _stack_frame: sys.exit(0))
 
     if os.environ.get('LISTEN_FDS') == '1' and \
-            os.environ.get('LISTEN_PID') == str(os.getpid()):
+            os.environ.get('LISTEN_PID') == native_str(os.getpid()):
         s = socket.fromfd(3, socket.AF_UNIX, socket.SOCK_STREAM)
     else:
         s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -102,7 +102,8 @@ def main(argv):
             except Exception as e:  # pylint: disable=broad-except
                 logging.error("Error pressing key %r: %s", key, e,
                               exc_info=True)
-                send_response(conn, cmd, success=False, data=to_bytes(str(e)))
+                send_response(conn, cmd, success=False,
+                              data=to_bytes(native_str(e)))
                 continue
             send_response(conn, cmd, success=True)
 

--- a/stbt_control_relay.py
+++ b/stbt_control_relay.py
@@ -31,7 +31,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 import argparse
 import logging
 import os

--- a/stbt_lint.py
+++ b/stbt_lint.py
@@ -32,7 +32,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 import argparse
 import subprocess

--- a/stbt_match.py
+++ b/stbt_match.py
@@ -9,7 +9,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 import argparse
 import sys

--- a/stbt_power.py
+++ b/stbt_power.py
@@ -4,7 +4,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 import argparse
 import sys
 from textwrap import dedent

--- a/stbt_record.py
+++ b/stbt_record.py
@@ -9,7 +9,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 import itertools
 import sys

--- a/stbt_run.py
+++ b/stbt_run.py
@@ -10,7 +10,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 import argparse
 import sys

--- a/stbt_virtual_stb.py
+++ b/stbt_virtual_stb.py
@@ -28,7 +28,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 import argparse
 import errno

--- a/stbt_virtual_stb.py
+++ b/stbt_virtual_stb.py
@@ -41,6 +41,7 @@ import time
 from contextlib import contextmanager
 
 from _stbt.config import get_config, set_config
+from _stbt.utils import text_type
 from _stbt.x11 import x_server
 
 
@@ -70,8 +71,8 @@ def virtual_stb(command, x_keymap=None, verbose=False):
                     'ximagesrc use-damage=false remote=true show-pointer=false '
                     'display-name=%(x_display)s ! video/x-raw,framerate=24/1'),
                 "x_display": display,
-                "vstb_child_pid": str(child.pid),
-                "vstb_pid": str(os.getpid()),
+                "vstb_child_pid": text_type(child.pid),
+                "vstb_pid": text_type(os.getpid()),
             })
             yield (child, config)
         finally:

--- a/tests/fake-irnetbox
+++ b/tests/fake-irnetbox
@@ -8,7 +8,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 import binascii
 import socket

--- a/tests/fake-lircd
+++ b/tests/fake-lircd
@@ -15,7 +15,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 import os
 import re

--- a/tests/run_performance_test.py
+++ b/tests/run_performance_test.py
@@ -4,7 +4,8 @@ from __future__ import division
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 import glob
 import os
 import subprocess

--- a/tests/subdirectory/test_load_image_from_subdirectory.py
+++ b/tests/subdirectory/test_load_image_from_subdirectory.py
@@ -2,7 +2,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 import os
 
 import cv2

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -2,7 +2,8 @@ from __future__ import division
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 import os
 import re

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,8 +12,7 @@ import pytest
 
 from _stbt.config import (_config_init, _sponge, ConfigurationError,
                           get_config, set_config)
-from _stbt.utils import (named_temporary_directory, scoped_curdir, text_type,
-                         to_native_str)
+from _stbt.utils import named_temporary_directory, scoped_curdir, to_native_str
 
 
 def test_sponge_that_new_data_end_up_in_file():
@@ -133,7 +132,7 @@ def test_to_enum():
 
         with pytest.raises(ConfigurationError) as excinfo:
             get_config("global", "byvaluc", type_=MyEnum)
-        assert "Valid values are NAME_1, NAME_2" in str(excinfo.value)
+        assert "Valid values are NAME_1, NAME_2" in text_type(excinfo.value)
 
         with pytest.raises(ConfigurationError):
             get_config("global", "badstr", type_=MyEnum)
@@ -148,7 +147,7 @@ def test_to_enum():
 
         with pytest.raises(ConfigurationError) as excinfo:
             get_config("global", "badint", type_=MyIntEnum)
-        assert "Valid values are NAME_5, NAME_6" in str(excinfo.value)
+        assert "Valid values are NAME_5, NAME_6" in text_type(excinfo.value)
 
 
 @contextmanager

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 import enum
 import os
 from contextlib import contextmanager

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,7 +4,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 import itertools
 import os

--- a/tests/test_frameobject.py
+++ b/tests/test_frameobject.py
@@ -2,7 +2,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 import threading
 
 import stbt

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -2,7 +2,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 from itertools import combinations
 

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -4,7 +4,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 import sys
 

--- a/tests/test_lirc_control.py
+++ b/tests/test_lirc_control.py
@@ -10,7 +10,7 @@ import pytest
 
 from stbt import wait_until
 from _stbt.control import uri_to_control
-from _stbt.utils import named_temporary_directory, scoped_process
+from _stbt.utils import named_temporary_directory, scoped_process, native_str
 
 # pylint:disable=redefined-outer-name
 
@@ -119,14 +119,14 @@ def test_press_with_unknown_remote(lircd):
     control = uri_to_control("lirc:%s:roku" % lircd.socket)
     with pytest.raises(RuntimeError) as excinfo:
         control.press("KEY_OK")
-    assert 'unknown remote: "roku"' in str(excinfo.value)
+    assert 'unknown remote: "roku"' in native_str(excinfo.value)
 
 
 def test_press_with_unknown_key(lircd):
     control = uri_to_control("lirc:%s:Apple_TV" % lircd.socket)
     with pytest.raises(RuntimeError) as excinfo:
         control.press("KEY_MAGIC")
-    assert 'unknown command: "KEY_MAGIC"' in str(excinfo.value)
+    assert 'unknown command: "KEY_MAGIC"' in native_str(excinfo.value)
 
 
 def _find_file(path, root=os.path.dirname(os.path.abspath(__file__))):

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -19,6 +19,7 @@ from _stbt import cv2_compat
 from _stbt.imgutils import _image_region
 from _stbt.logging import scoped_debug_level
 from _stbt.match import _merge_regions
+from _stbt.utils import text_type
 from tests.test_core import _find_file
 from tests.test_ocr import requires_tesseract
 
@@ -43,11 +44,11 @@ def test_that_matchresult_image_matches_template_passed_to_match():
 
 def test_that_matchresult_str_image_matches_template_passed_to_match():
     assert re.search(r"image=u?'black.png'",
-                     str(stbt.match("black.png", frame=black())))
+                     text_type(stbt.match("black.png", frame=black())))
 
 
 def test_that_matchresult_str_image_matches_template_passed_to_match_custom():
-    assert "image=<Custom Image>" in str(
+    assert "image=<Custom Image>" in text_type(
         stbt.match(black(30, 30), frame=black()))
 
 
@@ -79,14 +80,14 @@ def test_match_error_message_for_too_small_frame_and_region():
                    frame=black(width=91, height=160))
     assert (
         "Frame (160, 91, 3) must be larger than reference image (160, 92, 3)"
-        in str(excinfo.value))
+        in text_type(excinfo.value))
 
     with pytest.raises(ValueError) as excinfo:
         stbt.match("videotestsrc-redblue.png",
                    frame=black(width=92, height=159))
     assert (
         "Frame (159, 92, 3) must be larger than reference image (160, 92, 3)"
-        in str(excinfo.value))
+        in text_type(excinfo.value))
 
     with pytest.raises(ValueError) as excinfo:
         # Region seems large enough but actually it extends beyond the frame
@@ -95,7 +96,7 @@ def test_match_error_message_for_too_small_frame_and_region():
     assert (
         "Region(x=1189, y=560, right=1280, bottom=720) must be larger than "
         "reference image (160, 92, 3)"
-        in str(excinfo.value))
+        in text_type(excinfo.value))
 
     with pytest.raises(ValueError) as excinfo:
         # Region seems large enough but actually it extends beyond the frame
@@ -104,7 +105,7 @@ def test_match_error_message_for_too_small_frame_and_region():
     assert (
         "Region(x=1188, y=561, right=1280, bottom=720) must be larger than "
         "reference image (160, 92, 3)"
-        in str(excinfo.value))
+        in text_type(excinfo.value))
 
 
 @pytest.mark.parametrize("match_method", [
@@ -369,7 +370,7 @@ def test_that_results_dont_overlap(match_method):
                             match_parameters=mp(match_method=match_method)):
         print(m)
         assert m.region not in all_matches, "Match %s already seen:\n    %s" % (
-            m, "\n    ".join(str(x) for x in all_matches))
+            m, "\n    ".join(text_type(x) for x in all_matches))
         assert all(stbt.Region.intersect(m.region, x) is None
                    for x in all_matches)
         all_matches.add(m.region)

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -2,7 +2,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 from future.utils import string_types
 
 import os

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -2,7 +2,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 import time
 from contextlib import contextmanager
 

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -4,7 +4,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 import os
 import re
 from contextlib import contextmanager

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -18,7 +18,7 @@ import pytest
 import _stbt.config
 import stbt
 from _stbt.ocr import _tesseract_version
-from _stbt.utils import named_temporary_directory
+from _stbt.utils import named_temporary_directory, text_type
 from stbt import load_image
 
 
@@ -251,7 +251,7 @@ def test_match_text_stringify_result():
     assert re.match(
         r"TextMatchResult\(time=None, match=True, region=Region\(.*\), "
         r"frame=<1280x720x3>, text=u?'Onion Bhaji'\)",
-        str(result))
+        text_type(result))
 
 
 @requires_tesseract

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -3,7 +3,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 from contextlib import contextmanager
 
 import pytest

--- a/tests/test_press.py
+++ b/tests/test_press.py
@@ -6,6 +6,7 @@ from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-impor
 import pytest
 
 from _stbt.core import DeviceUnderTest, NoSinkPipeline
+from _stbt.utils import text_type
 
 
 def test_that_pressing_context_manager_raises_keyup_exceptions():
@@ -15,7 +16,7 @@ def test_that_pressing_context_manager_raises_keyup_exceptions():
     with pytest.raises(RuntimeError) as excinfo:
         with dut.pressing("KEY_MENU"):
             pass
-    assert "keyup KEY_MENU failed" in str(excinfo.value)
+    assert "keyup KEY_MENU failed" in text_type(excinfo.value)
 
 
 def test_that_pressing_context_manager_suppresses_keyup_exceptions():

--- a/tests/test_press.py
+++ b/tests/test_press.py
@@ -2,7 +2,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 import pytest
 
 from _stbt.core import DeviceUnderTest, NoSinkPipeline

--- a/tests/test_stbt_control_relay.py
+++ b/tests/test_stbt_control_relay.py
@@ -15,7 +15,7 @@ import pytest
 
 from _stbt.control import uri_to_control
 from _stbt.wait import wait_until
-from _stbt.utils import named_temporary_directory, scoped_process
+from _stbt.utils import named_temporary_directory, native_str, scoped_process
 
 
 # For py.test fixtures:
@@ -92,7 +92,7 @@ def socket_passing_setup(socket):
     def preexec_fn():
         fd = socket.fileno()
         os.environ['LISTEN_FDS'] = '1'
-        os.environ['LISTEN_PID'] = str(os.getpid())
+        os.environ['LISTEN_PID'] = native_str(os.getpid())
         if fd != 3:
             os.dup2(fd, 3)
         if sys.version_info.major > 2:

--- a/tests/test_stbt_control_relay.py
+++ b/tests/test_stbt_control_relay.py
@@ -2,7 +2,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 import os
 import socket
 import subprocess

--- a/tests/test_stbt_debug.py
+++ b/tests/test_stbt_debug.py
@@ -2,7 +2,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 import itertools
 import os
 import subprocess

--- a/tests/test_transition.py
+++ b/tests/test_transition.py
@@ -2,8 +2,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
-
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 import time
 from collections import namedtuple
 

--- a/tests/validate-ocr.py
+++ b/tests/validate-ocr.py
@@ -33,7 +33,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+from builtins import (ascii, chr, filter, hex, input, map, next, oct, open, pow,  # pylint:disable=redefined-builtin,unused-import,wildcard-import,wrong-import-order
+                      range, round, super, zip)
 
 import argparse
 import os


### PR DESCRIPTION
This fixes using `stbt.Keyboard` on Python 2.

Don't expose future.types.newxxx to our users
--------------------------------------------------

I've checked all our code for instances of `bytes(` or `str(`.  On Python 2
with the `future` library they can actually return instances of `newbytes`
and `newstr` rather than what you'd expect.  This changes some calls to
`str` to be explicit about what type you'll get, and to avoid these
future newtypes.  future newtypes can behave oddly so I want to avoid
exposing them to our users.

I'm of the opinion that as a library that intends to support Python 2 and 3
`stbt` shouldn't leak that we've implemented this support with
python-future so we should return normal Python types wherever possible.
We need to support both Python 2 and 3, but it doesn't make sense for our
customers' test-packs to be python-version agnostic.

We're still exposing some details of python-future to our users - most notably as we're deriving from `future.object`.  I've not come across any issues caused by this yet.