### PR TITLE
Backport parts of #629 to v31

### DIFF
--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -222,7 +222,7 @@ class LircControl(RemoteControl):
                                         to_bytes(key))
         s.sendall(command + b"\n")
         _read_lircd_reply(s, command)
-        debug("Pressed " + key)
+        debug("Pressed %s" % key)
 
     def keydown(self, key):
         s = self._connect()
@@ -230,7 +230,7 @@ class LircControl(RemoteControl):
                                          to_bytes(key))
         s.sendall(command + b"\n")
         _read_lircd_reply(s, command)
-        debug("Holding " + key)
+        debug("Holding %s" % key)
 
     def keyup(self, key):
         s = self._connect()
@@ -238,7 +238,7 @@ class LircControl(RemoteControl):
                                         to_bytes(key))
         s.sendall(command + b"\n")
         _read_lircd_reply(s, command)
-        debug("Released " + key)
+        debug("Released %s" % key)
 
 
 def _read_lircd_reply(stream, command):
@@ -477,7 +477,7 @@ class IRNetBoxControl(RemoteControl):
         with self._connect() as irnb:
             irnb.irsend_raw(
                 port=self.output, power=100, data=self.config[key])
-        debug("Pressed " + key)
+        debug("Pressed %s" % key)
 
     def _connect(self):
         try:
@@ -534,7 +534,7 @@ class RokuHttpControl(RemoteControl):
             "http://%s:8060/keypress/%s" % (self.hostname, roku_keyname),
             timeout=self.timeout_secs)
         response.raise_for_status()
-        debug("Pressed " + key)
+        debug("Pressed %s" % key)
 
     def keydown(self, key):
         import requests
@@ -544,7 +544,7 @@ class RokuHttpControl(RemoteControl):
             "http://%s:8060/keydown/%s" % (self.hostname, roku_keyname),
             timeout=self.timeout_secs)
         response.raise_for_status()
-        debug("Holding " + key)
+        debug("Holding %s" % key)
 
     def keyup(self, key):
         import requests
@@ -554,7 +554,7 @@ class RokuHttpControl(RemoteControl):
             "http://%s:8060/keyup/%s" % (self.hostname, roku_keyname),
             timeout=self.timeout_secs)
         response.raise_for_status()
-        debug("Released " + key)
+        debug("Released %s" % key)
 
 
 class SamsungTCPControl(RemoteControl):
@@ -596,7 +596,7 @@ class SamsungTCPControl(RemoteControl):
         payload_start = bytearray([0x00, 0x00, 0x00])
         key_enc = self._encode_string(key)
         self._send_payload(payload_start + key_enc)
-        debug("Pressed " + key)
+        debug("Pressed %s" % key)
         reply = self.socket.recv(4096)
         debug("SamsungTCPControl reply: %s\n" % reply)
 
@@ -632,7 +632,7 @@ class X11Control(RemoteControl):
             e['DISPLAY'] = self.display
         subprocess.check_call(
             ['xdotool', 'key', self.mapping.get(key, key)], env=e)
-        debug("Pressed " + key)
+        debug("Pressed %s" % key)
 
 
 def file_control_recorder(filename):

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -37,7 +37,7 @@ from _stbt.gst_utils import array_from_sample, gst_sample_make_writable
 from _stbt.imgutils import _frame_repr, find_user_file, Frame, imread
 from _stbt.logging import ddebug, debug, warn
 from _stbt.types import Region, UITestError, UITestFailure
-from _stbt.utils import to_unicode
+from _stbt.utils import text_type, to_unicode
 
 gi.require_version("Gst", "1.0")
 from gi.repository import GLib, GObject, Gst  # pylint:disable=wrong-import-order
@@ -927,7 +927,7 @@ class Display(object):
                     self.last_used_frame = self.last_frame
                     return self.last_frame
                 elif isinstance(self.last_frame, Exception):
-                    raise RuntimeError(str(self.last_frame))
+                    raise RuntimeError(text_type(self.last_frame))
                 t = time.time()
                 if t > end_time:
                     break

--- a/_stbt/grid.py
+++ b/_stbt/grid.py
@@ -10,7 +10,8 @@ from collections import namedtuple
 
 import networkx as nx
 
-from _stbt.types import Position, Region
+from .types import Position, Region
+from .utils import native_int
 
 
 class Grid(object):
@@ -196,7 +197,7 @@ class Grid(object):
             raise IndexError(
                 "The centre of region %r is outside the grid area %r" % (
                     region, self.region))
-        return Position(int(pos[0]), int(pos[1]))
+        return Position(native_int(pos[0]), native_int(pos[1]))
 
     def _position_to_region(self, position):
         if isinstance(position, int):

--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -27,6 +27,7 @@ from .imgutils import _frame_repr, _image_region, _load_image, crop, limit_time
 from .logging import ddebug, debug, draw_on, get_debug_level, ImageLogger
 from .sqdiff import sqdiff
 from .types import Position, Region, UITestFailure
+from .utils import native_str
 
 
 class MatchMethod(enum.Enum):
@@ -37,7 +38,7 @@ class MatchMethod(enum.Enum):
 
     # For nicer formatting in generated API documentation:
     def __repr__(self):
-        return str(self)
+        return native_str(self)
 
 
 class ConfirmMethod(enum.Enum):
@@ -47,7 +48,7 @@ class ConfirmMethod(enum.Enum):
 
     # For nicer formatting in generated API documentation:
     def __repr__(self):
-        return str(self)
+        return native_str(self)
 
 
 class MatchParameters(object):

--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -22,7 +22,8 @@ from .config import get_config
 from .imgutils import _frame_repr, _image_region, crop
 from .logging import debug, ImageLogger, warn
 from .types import Region
-from .utils import named_temporary_directory, native_str, text_type, to_unicode
+from .utils import (
+    named_temporary_directory, native_int, native_str, text_type, to_unicode)
 
 # Tesseract sometimes has a hard job distinguishing certain glyphs such as
 # ligatures and different forms of the same punctuation.  We strip out this
@@ -631,7 +632,7 @@ def _hocr_elem_region(elem):
     while elem is not None:
         m = re.search(r'bbox (\d+) (\d+) (\d+) (\d+)', elem.get('title') or u'')
         if m:
-            extents = [int(x) for x in m.groups()]
+            extents = [native_int(x) for x in m.groups()]
             return Region.from_extents(*extents)
         elem = elem.getparent()
 

--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -22,7 +22,7 @@ from .config import get_config
 from .imgutils import _frame_repr, _image_region, crop
 from .logging import debug, ImageLogger, warn
 from .types import Region
-from .utils import named_temporary_directory, to_unicode
+from .utils import named_temporary_directory, native_str, text_type, to_unicode
 
 # Tesseract sometimes has a hard job distinguishing certain glyphs such as
 # ligatures and different forms of the same punctuation.  We strip out this
@@ -77,7 +77,7 @@ class OcrMode(IntEnum):
 
     # For nicer formatting of `ocr` signature in generated API documentation:
     def __repr__(self):
-        return str(self)
+        return native_str(self)
 
 
 class OcrEngine(IntEnum):
@@ -98,7 +98,7 @@ class OcrEngine(IntEnum):
     DEFAULT = 3
 
     def __repr__(self):
-        return str(self)
+        return native_str(self)
 
 
 class TextMatchResult(object):
@@ -602,7 +602,7 @@ def _hocr_iterate(hocr):
                     if need_space and started:
                         yield (u' ', None)
                     need_space = False
-                    yield (str(t).strip(), e)
+                    yield (text_type(t).strip(), e)
                     started = True
                 else:
                     need_space = True

--- a/_stbt/utils.py
+++ b/_stbt/utils.py
@@ -128,6 +128,7 @@ else:
 
 
 native_str = str
+native_int = int
 
 
 def to_bytes(text):

--- a/stbt/keyboard.py
+++ b/stbt/keyboard.py
@@ -14,6 +14,7 @@ from logging import getLogger
 import networkx as nx
 import numpy
 import stbt
+from _stbt.utils import text_type
 
 
 log = getLogger("stbt.keyboard")
@@ -312,7 +313,7 @@ class Keyboard(object):
         """
         return nx.parse_edgelist(graph.split("\n"),
                                  create_using=nx.DiGraph(),
-                                 data=[("key", str)])
+                                 data=[("key", text_type)])
 
 
 def _selection_to_text(selection):

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -6,6 +6,8 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
 
+import sys
+
 import networkx as nx
 import mock
 import numpy
@@ -143,21 +145,29 @@ GRAPH = """
 G = stbt.Keyboard.parse_edgelist(GRAPH)
 nx.relabel_nodes(G, {"SPACE": " "}, copy=False)
 
+if sys.version_info.major == 2:
+    G_BYTES = stbt.Keyboard.parse_edgelist(GRAPH.encode('utf-8'))
+    nx.relabel_nodes(G_BYTES, {b"SPACE": b" "}, copy=False)
+    GRAPHS = [G, G_BYTES]
+else:
+    GRAPHS = [G]
 
-def test_keys_to_press():
-    assert list(_keys_to_press(G, "A", "A")) == []
-    assert list(_keys_to_press(G, "A", "B")) == [("KEY_RIGHT", {"B"})]
-    assert list(_keys_to_press(G, "B", "A")) == [("KEY_LEFT", {"A"})]
-    assert list(_keys_to_press(G, "A", "C")) == [("KEY_RIGHT", {"B"}),
+
+@pytest.mark.parametrize("g", GRAPHS)
+def test_keys_to_press(g):
+    assert list(_keys_to_press(g, "A", "A")) == []
+    assert list(_keys_to_press(g, "A", "B")) == [("KEY_RIGHT", {"B"})]
+    assert list(_keys_to_press(g, "B", "A")) == [("KEY_LEFT", {"A"})]
+    assert list(_keys_to_press(g, "A", "C")) == [("KEY_RIGHT", {"B"}),
                                                  ("KEY_RIGHT", {"C"})]
-    assert list(_keys_to_press(G, "C", "A")) == [("KEY_LEFT", {"B"}),
+    assert list(_keys_to_press(g, "C", "A")) == [("KEY_LEFT", {"B"}),
                                                  ("KEY_LEFT", {"A"})]
-    assert list(_keys_to_press(G, "A", "H")) == [("KEY_DOWN", {"H"})]
-    assert list(_keys_to_press(G, "H", "A")) == [("KEY_UP", {"A"})]
-    assert list(_keys_to_press(G, "A", "I")) in (
+    assert list(_keys_to_press(g, "A", "H")) == [("KEY_DOWN", {"H"})]
+    assert list(_keys_to_press(g, "H", "A")) == [("KEY_UP", {"A"})]
+    assert list(_keys_to_press(g, "A", "I")) in (
         [("KEY_RIGHT", {"B"}), ("KEY_DOWN", {"I"})],
         [("KEY_DOWN", {"H"}), ("KEY_RIGHT", {"I"})])
-    assert list(_keys_to_press(G, " ", "A")) == [
+    assert list(_keys_to_press(g, " ", "A")) == [
         ("KEY_UP", {"V", "W", "X", "Y", "Z", "-", "'"})]
 
 

--- a/tests/test_lirc_control.py
+++ b/tests/test_lirc_control.py
@@ -1,3 +1,6 @@
+from future.types.newbytes import newbytes
+from future.types.newstr import newstr
+
 import os
 import subprocess
 from collections import namedtuple
@@ -31,80 +34,85 @@ def lircd():
 
 
 def test_press(lircd):
-    control = uri_to_control("lirc:%s:Apple_TV" % lircd.socket)
-    control.press("KEY_OK")
-    lircd_output = open(lircd.logfile, "r").read()
-    expected = dedent("""\
-        pulse 9000
-        space 4500
-        pulse 527
-        space 527
-        pulse 527
-        space 1703
-        pulse 527
-        space 1703
-        pulse 527
-        space 1703
-        pulse 527
-        space 527
-        pulse 527
-        space 1703
-        pulse 527
-        space 1703
-        pulse 527
-        space 1703
-        pulse 527
-        space 1703
-        pulse 527
-        space 1703
-        pulse 527
-        space 1703
-        pulse 527
-        space 527
-        pulse 527
-        space 527
-        pulse 527
-        space 527
-        pulse 527
-        space 527
-        pulse 527
-        space 1703
-        pulse 527
-        space 527
-        pulse 527
-        space 527
-        pulse 527
-        space 1703
-        pulse 527
-        space 1703
-        pulse 527
-        space 1703
-        pulse 527
-        space 527
-        pulse 527
-        space 1703
-        pulse 527
-        space 527
-        pulse 527
-        space 527
-        pulse 527
-        space 1703
-        pulse 527
-        space 1703
-        pulse 527
-        space 527
-        pulse 527
-        space 1703
-        pulse 527
-        space 1703
-        pulse 527
-        space 1703
-        pulse 527
-        space 527
-        pulse 527
-        space 38000
-        """)
-    assert expected == lircd_output
+    logfile = open(lircd.logfile)
+
+    # newbytes doesn't play well with parameterize here, so we use a for loop:
+    for key in [b'KEY_OK', u'KEY_OK', newbytes(b'KEY_OK'), newstr(u'KEY_OK')]:
+        print("key = %r (%s)" % (key, type(key)))  # pylint: disable=superfluous-parens
+        control = uri_to_control("lirc:%s:Apple_TV" % lircd.socket)
+        control.press(key)
+        lircd_output = logfile.read()
+        expected = dedent("""\
+            pulse 9000
+            space 4500
+            pulse 527
+            space 527
+            pulse 527
+            space 1703
+            pulse 527
+            space 1703
+            pulse 527
+            space 1703
+            pulse 527
+            space 527
+            pulse 527
+            space 1703
+            pulse 527
+            space 1703
+            pulse 527
+            space 1703
+            pulse 527
+            space 1703
+            pulse 527
+            space 1703
+            pulse 527
+            space 1703
+            pulse 527
+            space 527
+            pulse 527
+            space 527
+            pulse 527
+            space 527
+            pulse 527
+            space 527
+            pulse 527
+            space 1703
+            pulse 527
+            space 527
+            pulse 527
+            space 527
+            pulse 527
+            space 1703
+            pulse 527
+            space 1703
+            pulse 527
+            space 1703
+            pulse 527
+            space 527
+            pulse 527
+            space 1703
+            pulse 527
+            space 527
+            pulse 527
+            space 527
+            pulse 527
+            space 1703
+            pulse 527
+            space 1703
+            pulse 527
+            space 527
+            pulse 527
+            space 1703
+            pulse 527
+            space 1703
+            pulse 527
+            space 1703
+            pulse 527
+            space 527
+            pulse 527
+            space 38000
+            """)
+        assert expected == lircd_output
 
 
 def test_press_with_unknown_remote(lircd):

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -89,8 +89,9 @@ def test_that_ligatures_and_ambiguous_punctuation_are_normalised():
 def test_that_match_text_accepts_unicode():
     f = load_image("ocr/unicode.png")
     assert stbt.match_text("David", f, lang='eng+deu')  # ascii
-    assert stbt.match_text(u"Röthlisberger", f, lang='eng+deu')  # unicode
-    assert stbt.match_text("Röthlisberger", f, lang='eng+deu')  # utf-8 bytes
+    assert stbt.match_text("Röthlisberger", f, lang='eng+deu')  # unicode
+    assert stbt.match_text(
+        "Röthlisberger".encode('utf-8'), f, lang='eng+deu')  # utf-8 bytes
 
 
 def test_that_default_language_is_configurable():

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -38,6 +38,9 @@ def test_ocr_on_static_images(image, expected_text, region, mode):
     text = stbt.ocr(load_image("ocr/" + image), **kwargs)
     assert text == expected_text
 
+    # Don't leak python future newtypes
+    assert type(text).__name__ in ["unicode", "str"]
+
 
 # Remove when region=None doesn't raise -- see #433
 def test_that_ocr_region_none_isnt_allowed():
@@ -249,6 +252,9 @@ def test_that_match_text_still_returns_if_region_doesnt_intersect_with_frame(
     assert result.match is False
     assert result.region is None
     assert result.text == "Onion Bhaji"
+
+    # Avoid future.types.newtypes in return values
+    assert type(result.text).__name__ in ["str", "unicode"]
 
 
 @pytest.mark.parametrize("region", [


### PR DESCRIPTION
So `stbt.Keyboard` isn't broken for our customers who use Python 2.