### PR TITLE
Add `for_object_repository` decorator

### DIFF
--- a/_stbt/frameobject.py
+++ b/_stbt/frameobject.py
@@ -20,6 +20,38 @@ except ImportError:
     from itertools import izip_longest as zip_longest
 
 
+def for_object_repository(cls=None):
+    """A decorator that marks classes and functions so they appear in the Object
+    Repository.
+
+    Classes that directly derive from `stbt.FrameObject` have this decorator
+    applied to them automatically.  This can be used to register other classes
+    and functions.
+
+    Usage:
+
+        @for_object_repository
+        class MyClass(object):
+            ...
+    """
+    # These classes are extracted by static analysis, so return the class
+    # unchanged:
+    if cls is None:
+        # Called like:
+        #
+        #     @for_object_repository()
+        #     class MyClass(object):
+        def decorator(cls):
+            return cls
+        return decorator
+    else:
+        # Called like:
+        #
+        #    @for_object_repository
+        #    class MyClass(object):
+        return cls
+
+
 def _memoize_property_fn(fn):
     @functools.wraps(fn)
     def inner(self):
@@ -93,6 +125,7 @@ class _FrameObjectMeta(type):
         super(_FrameObjectMeta, cls).__init__(name, parents, dct)
 
 
+@for_object_repository()
 class FrameObject(with_metaclass(_FrameObjectMeta, object)):
     # pylint: disable=line-too-long
     r'''Base class for user-defined Page Objects.

--- a/_stbt/frameobject.py
+++ b/_stbt/frameobject.py
@@ -109,9 +109,6 @@ class _FrameObjectMeta(type):
                     f = _noneify_property_fn(f)
                 dct[k] = property(f)
 
-        if 'AUTO_SELFTEST_EXPRESSIONS' not in dct:
-            dct['AUTO_SELFTEST_EXPRESSIONS'] = ['%s(frame={frame})' % name]
-
         return super(_FrameObjectMeta, mcs).__new__(mcs, name, parents, dct)
 
     def __init__(cls, name, parents, dct):

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -31,6 +31,7 @@ from _stbt.config import (
     ConfigurationError,
     get_config)
 from _stbt.frameobject import (
+    for_object_repository,
     FrameObject)
 from _stbt.grid import (
     Grid,
@@ -79,6 +80,7 @@ __all__ = [
     "debug",
     "detect_motion",
     "draw_text",
+    "for_object_repository",
     "Frame",
     "FrameObject",
     "frames",


### PR DESCRIPTION
A decorator that marks classes and functions so they appear in the Object
Repository.

Classes that directly derive from `stbt.FrameObject` have this decorator
applied to them automatically.  This can be used to register other classes
and functions.

These classes are extracted by static analysis, so the decorator is a noop,
returning the class unchanged.