### PR TITLE
Filter out xxhash header file to prevent clang error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,7 @@ XXHASH_SOURCES = \
     vendor/xxHash/xxhash.h
 
 _stbt/libxxhash.so : $(XXHASH_SOURCES)
-	$(CC) -shared -fPIC -O3 -o $@ $(XXHASH_SOURCES) $(CFLAGS)
+	$(CC) -shared -fPIC -O3 -o $@ $(filter-out vendor/xxHash/xxhash.h, $(XXHASH_SOURCES)) $(CFLAGS)
 
 _stbt/libstbt.so : _stbt/sqdiff.c
 	$(CC) -shared -fPIC -O3 -o $@ _stbt/sqdiff.c $(CFLAGS)


### PR DESCRIPTION
If you attempt to run make using clang, you would currently get an error where xxHash is being compiled because it appears clang will treat all the files as .c files. Since the .h file is still necessary in the sources, this change circumvents that error by simply filtering it out from the compilation step. 

```sh
clang: error: cannot specify -o when generating multiple output files
make: *** [_stbt/libxxhash.so] Error 1
```

See issue #632 