### PR TITLE
stbt.Keyboard: Automatically refresh page if it's out of date

### DIFF
--- a/stbt/keyboard.py
+++ b/stbt/keyboard.py
@@ -235,6 +235,9 @@ class Keyboard(object):
             if letter not in self.G:
                 raise ValueError("'%s' isn't in the keyboard" % (letter,))
 
+        if page._frame.time < stbt._dut._last_keypress.end_time:  # pylint:disable=protected-access
+            page = page.refresh()
+
         for letter in text:
             page = self.navigate_to(letter, page, verify_every_keypress)
             stbt.press("KEY_OK")
@@ -258,6 +261,9 @@ class Keyboard(object):
 
         if target not in self.G:
             raise ValueError("'%s' isn't in the keyboard" % (target,))
+
+        if page._frame.time < stbt._dut._last_keypress.end_time:  # pylint:disable=protected-access
+            page = page.refresh()
 
         assert page, "%s page isn't visible" % type(page).__name__
         deadline = time.time() + self.navigate_timeout


### PR DESCRIPTION
This bypasses a common error in user code when we forget to update
`page` between calls to `enter_text` and `navigate_to`. For example:

    def enter_text(self, text):
        kb.enter_text("peppa pig", page=self)
        kb.navigate_to("SEARCH", page=self)  # self.selection is outdated!
        stbt.press_and_wait("OK")

We consider the Page Object instance to be out of date if its frame is
older than the last keypress. This won't reflect changes that aren't
triggered by the remote control (particularly changes triggered by the
passage of time, such as the screensaver activating) but in practice
it'll solve a common bug.

Of course it doesn't fix any other (non-Keyboard) bug caused by
out-of-date Page Object instances. Maybe this will only add to the
confusion ("If this code pattern causes a bug, how come the same pattern
does work when it's using stbt.Keyboard?"). Or maybe this is a good
pattern that we can start using elsewhere. Thoughts please.