### PR TITLE
stbt.FrameObject base class: Remove @for_object_repository decorator

### DIFF
--- a/_stbt/frameobject.py
+++ b/_stbt/frameobject.py
@@ -122,7 +122,6 @@ class _FrameObjectMeta(type):
         super(_FrameObjectMeta, cls).__init__(name, parents, dct)
 
 
-@for_object_repository()
 class FrameObject(with_metaclass(_FrameObjectMeta, object)):
     # pylint: disable=line-too-long
     r'''Base class for user-defined Page Objects.


### PR DESCRIPTION
This decorator is used for marking indirect subclasses of FrameObject,
that wouldn't be otherwise detected by Stb-tester's [Object Repository].
It doesn't make any sense to apply it to the FrameObject base class
itself.

[Object Repository]: https://stb-tester.com/manual/object-repository