### PR TITLE
stbt.Region: Add `center` property

### DIFF
--- a/_stbt/types.py
+++ b/_stbt/types.py
@@ -84,6 +84,8 @@ class Region(with_metaclass(_RegionClsMethods,
     8
     >>> b.bottom
     10
+    >>> b.center
+    Position(x=8, y=7)
     >>> b.contains(c), a.contains(b), c.contains(b)
     (True, False, False)
     >>> b.extend(x=6, bottom=-4) == c
@@ -162,6 +164,11 @@ class Region(with_metaclass(_RegionClsMethods,
 
     ``x``, ``y``, ``right``, ``bottom``, ``width`` and ``height`` can be
     infinite --- that is, ``float("inf")`` or ``-float("inf")``.
+
+    .. py:attribute:: center
+
+        A `stbt.Position` specifying the x & y coordinates of the region's
+        center.
 
     .. py:staticmethod:: from_extents
 
@@ -247,6 +254,11 @@ class Region(with_metaclass(_RegionClsMethods,
     @property
     def height(self):
         return self.bottom - self.y
+
+    @property
+    def center(self):
+        return Position((self.x + self.right) // 2,
+                        (self.y + self.bottom) // 2)
 
     @staticmethod
     def from_extents(x, y, right, bottom):


### PR DESCRIPTION
This is useful when comparing if some region is above another region,
without having to worry about getting the edges of each region exactly
right. e.g. we might have region1 detected at run-time with `stbt.match`
and region2 hard-coded in the test scripts:

    is_above = region1.center.y < region2.y

If we used `region1.y < region2.y` we would get false positives if
region1 *is* at region2 (the selection is on the desired target) but the
way we calculated region1 is off by 1 pixel compared to region2.

If we used `region1.bottom < region2.y` we would get false negatives if
region1 *is* in the position immediately above region2 but, again, we
got the region off by a few pixels (or the seleted item is bigger and
overlaps surrounding items slightly).

Using the center of region1 solves both of these problems.