### PR TITLE
setup.py: Upgrade Jinja2 dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ This package doesn't bundle the Tesseract OCR engine, so `stbt.ocr()` and
 
 setuptools.setup(
     name="stb-tester",
-    version="31.1.2",
+    version="31.1.3",
     author="Stb-tester.com Ltd.",
     author_email="support@stb-tester.com",
     description="Automated GUI testing for Set-Top Boxes",
@@ -57,7 +57,7 @@ setuptools.setup(
     python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*",
     install_requires=[
         "future==0.15.2",
-        "Jinja2==2.10",
+        "Jinja2==2.10.1",
         "lxml==4.2",
         "networkx==1.11",
         "opencv-python~=3.2",


### PR DESCRIPTION
Fixes GitHub warning:

> CVE-2019-10906
> high severity
> Vulnerable versions: < 2.10.1
> Patched version: 2.10.1
>
> In Pallets Jinja before 2.10.1, str.format_map allows a sandbox escape.

Not that it's particularly relevant as any user-provided code that could
affect the Jinja output (used to generate the detailed stbt-debug html)
comes from the user's test scripts which are run outside Jinja's sandbox
already.