### PR TITLE
setup.py: Specify pylint & astroid dependencies with pinned versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .stbt-cflags
 .stbt-ldflags
 .stbt-prefix
+.venv
 __pycache__
 _stbt/libxxhash.so
 _stbt/libstbt.so

--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,6 @@ check-pytest: all
 	    $$(printf "%s\n" $(PYTHON_FILES) |\
 	       grep -v tests/vstb-example-html5/)
 check-pythonpackage:
-	PYTHONPATH=$$PWD \
 	STBT_CONFIG_FILE=$$PWD/tests/stbt.conf \
 	$(PYTEST) -vv -rs $(PYTEST_OPTS) \
 	    tests/subdirectory/test_load_image_from_subdirectory.py \

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ This package doesn't bundle the Tesseract OCR engine, so `stbt.ocr()` and
 
 setuptools.setup(
     name="stb-tester",
-    version="31.1.3",
+    version="31.1.4",
     author="Stb-tester.com Ltd.",
     author_email="support@stb-tester.com",
     description="Automated GUI testing for Set-Top Boxes",
@@ -56,10 +56,12 @@ setuptools.setup(
     # I have only tested Python 2.7 & 3.6
     python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*",
     install_requires=[
+        "astroid==1.6.0",
         "future==0.15.2",
         "Jinja2==2.10.1",
         "lxml==4.2",
         "networkx==1.11",
         "opencv-python~=3.2",
+        "pylint==1.8.3",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -63,5 +63,6 @@ setuptools.setup(
         "networkx==1.11",
         "opencv-python~=3.2",
         "pylint==1.8.3",
+        "stbt-extra-stubs~=31.0",
     ],
 )


### PR DESCRIPTION
So that `pylint --load-plugins=stbt.pylint_plugin` will work without
further installation steps.

I have pinned the versions to match Ubuntu 18.04. The latest versions
(pylint-2.4.4 & astroid-2.3.3) fail with:

>   File "venv/lib/python3.6/site-packages/stbt/pylint_plugin.py", line 23, in <module>
>     from astroid import MANAGER, YES
> ImportError: cannot import name 'YES'

We should probably fix that at some point, but pinning these versions
will avoid problems outside our control whenever there's a new astroid
release. We've had trouble with astroid's backward compatibility before.
