### PR TITLE
stbt.load_image: Fix UnicodeDecodeError when filename is utf-8 bytes

### DIFF
--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
-from future.utils import text_to_native_str
 
 import os
 import re
@@ -18,7 +17,7 @@ from distutils.spawn import find_executable
 from . import irnetbox
 from .config import ConfigurationError
 from .logging import debug, scoped_debug_level
-from .utils import named_temporary_directory, to_bytes
+from .utils import named_temporary_directory, to_bytes, to_native_str
 
 __all__ = ['uri_to_control', 'uri_to_control_recorder']
 
@@ -198,7 +197,7 @@ class VideoTestSrcControl(RemoteControl):
                 20, "bar"]:
             raise RuntimeError(
                 'Key "%s" not valid for the "test" control' % key)
-        self.videosrc.props.pattern = text_to_native_str(key)
+        self.videosrc.props.pattern = to_native_str(key)
         debug("Pressed %s" % key)
 
 

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -13,7 +13,7 @@ from __future__ import division
 from __future__ import unicode_literals
 from __future__ import print_function
 from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
-from future.utils import native, raise_, string_types, text_to_native_str
+from future.utils import native, raise_, string_types
 
 import argparse
 import datetime
@@ -35,7 +35,7 @@ from _stbt.gst_utils import array_from_sample, gst_sample_make_writable
 from _stbt.imgutils import _frame_repr, Frame
 from _stbt.logging import _Annotation, ddebug, debug, warn
 from _stbt.types import NoVideo, Region
-from _stbt.utils import text_type, to_unicode
+from _stbt.utils import text_type, to_native_str, to_unicode
 
 gi.require_version("Gst", "1.0")
 from gi.repository import GLib, GObject, Gst  # pylint:disable=wrong-import-order
@@ -605,7 +605,7 @@ class Display(object):
                 Gst.StateChangeReturn.NO_PREROLL):
             # This is a live source, drop frames if we get behind
             self.source_pipeline.get_by_name('_stbt_raw_frames_queue') \
-                .set_property('leaky', text_to_native_str('downstream'))
+                .set_property('leaky', to_native_str('downstream'))
             self.source_pipeline.get_by_name('appsink') \
                 .set_property('sync', False)
 

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
 from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
-from future.utils import text_to_native_str
 
 import inspect
 import os
@@ -16,6 +15,7 @@ import numpy
 
 from .logging import ddebug, debug, warn
 from .types import Region
+from .utils import to_native_str, to_unicode
 
 
 class Frame(numpy.ndarray):
@@ -128,10 +128,11 @@ def load_image(filename, flags=None):
 
     absolute_filename = find_user_file(filename)
     if not absolute_filename:
-        raise IOError("No such file: %s" % filename)
+        raise IOError(to_native_str("No such file: %s" % to_unicode(filename)))
     image = imread(absolute_filename, flags)
     if image is None:
-        raise IOError("Failed to load image: %s" % absolute_filename)
+        raise IOError(to_native_str("Failed to load image: %s" %
+                                    to_unicode(absolute_filename)))
     return image
 
 
@@ -185,8 +186,7 @@ def imread(filename, flags=None):
     else:
         cv2_flags = flags
 
-    img = cv2.imread(text_to_native_str(filename, encoding="utf-8"),
-                     cv2_flags)
+    img = cv2.imread(to_native_str(filename), cv2_flags)
     if img is None:
         return None
 
@@ -295,6 +295,7 @@ def find_user_file(filename):
     #   _load_image's caller (e.g. `match`) so we still need to check until
     #   we're outside of the _stbt directory.
 
+    filename = to_native_str(filename)
     _stbt_dir = os.path.abspath(os.path.dirname(__file__))
     caller = inspect.currentframe()
     try:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -44,8 +44,8 @@ def test_load_image_with_unicode_filename():
     print(sys.getfilesystemencoding())
     shutil.copyfile(_find_file("Rothlisberger.png"),
                     _find_file("Röthlisberger.png"))
-    assert stbt.load_image("Röthlisberger.png") is not None
     assert stbt.load_image(u"Röthlisberger.png") is not None
+    assert stbt.load_image(u"Röthlisberger.png".encode("utf-8")) is not None
     assert stbt.load_image(u"R\xf6thlisberger.png") is not None
 
 


### PR DESCRIPTION
`future.utils.text_to_native_str` only works if the input is unicode. It
does this:

    return unicode(t).encode(encoding)

And the `unicode(t)` is what fails.

It seems that we had tested bytes & unicode in
`test_load_image_with_unicode_filename` at some point in the past, but
not since we added `from __future__ import unicode_literals`.

Note that b"Röthlisberger" is a SyntaxError on Python 3: bytes can only
contain ASCII literal characters.

I had to do some contortions with the IOError exceptions we raise. If
you give it a unicode message on Python 2, it displays like this:
`IOError: <unprintable IOError object>`.