### PR TITLE
stbt.wait_until: Allow the callable to take an optional "frame" parameter

### DIFF
--- a/_stbt/wait.py
+++ b/_stbt/wait.py
@@ -110,8 +110,11 @@ def wait_until(callable_, timeout_secs=10, interval_secs=0, predicate=None,
     if predicate is None:
         predicate = lambda x: x
 
-    if (inspect.isfunction(callable_) and
-            "frame" in getargspec(callable_).args):  # pylint:disable=deprecated-method
+    if ((inspect.isfunction(callable_) and
+            "frame" in getargspec(callable_).args) or  # pylint:disable=deprecated-method
+        (inspect.isclass(callable_) and
+            "frame" in getargspec(callable_.__init__).args)  # pylint:disable=deprecated-method
+    ):
         import stbt
         frames = stbt.frames()
         f = callable_

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -18,9 +18,18 @@ open-source project, or update [test_pack.stbt_version] if you're using the
 [license]: https://github.com/stb-tester/stb-tester/blob/master/LICENSE
 
 
-#### Unreleased
+#### v32
 
- * Support for OpenCV4
+UNRELEASED.
+
+##### Major new features
+
+##### Breaking changes since v31
+
+##### Minor additions, bugfixes & improvements
+
+* Support for OpenCV4
+
 
 #### v31
 
@@ -106,6 +115,7 @@ open-source project, or update [test_pack.stbt_version] if you're using the
 * stbt.wait_for_motion: More sensitive to slow motion (such as a slow fade to
   black) by comparing against the last frame since significant differences were
   seen, instead of always comparing against the previous frame.
+
 
 #### v30
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -28,6 +28,14 @@ UNRELEASED.
 
 ##### Minor additions, bugfixes & improvements
 
+* `stbt.wait_until`'s first parameter (the function to call) can now,
+  optionally, take a single parameter called "frame". This allows the code in
+  the following example to guarantee that both of the calls to `stbt.match` are
+  operating on the same frame of video:
+
+        wait_until(lambda frame: stbt.match("image1.png", frame) or
+                                 stbt.match("image2.png", frame))
+
 * Support for OpenCV4
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -347,12 +347,22 @@ def test_wait_until_with_function_that_takes_a_frame():
         for i in range(10):
             yield numpy.ones((1, 1), dtype=numpy.uint8) * i
 
-    def m(frame):
+    def f(frame):
         print(frame)
         return frame[0, 0] == 5
 
+    class PageObject(stbt.FrameObject):
+        @property
+        def is_visible(self):
+            return self._frame[0, 0] == 5
+
+    class NormalClass(object):
+        pass
+
     with mock.patch("stbt.frames", _frames):
-        assert wait_until(lambda frame, other=None: m(frame) and m(frame))
+        assert wait_until(lambda frame, other=None: f(frame) and f(frame))
+        assert wait_until(PageObject)
+        assert wait_until(NormalClass)
 
 
 def _find_file(path, root=os.path.dirname(os.path.abspath(__file__))):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -342,5 +342,18 @@ def test_that_wait_until_doesnt_compare_return_values(mock_time):
         result = wait_until(MR, stable_secs=2)
 
 
+def test_wait_until_with_function_that_takes_a_frame():
+    def _frames():
+        for i in range(10):
+            yield numpy.ones((1, 1), dtype=numpy.uint8) * i
+
+    def m(frame):
+        print(frame)
+        return frame[0, 0] == 5
+
+    with mock.patch("stbt.frames", _frames):
+        assert wait_until(lambda frame, other=None: m(frame) and m(frame))
+
+
 def _find_file(path, root=os.path.dirname(os.path.abspath(__file__))):
     return os.path.join(root, path)


### PR DESCRIPTION
Previously, you might write code like this:

    assert wait_until(lambda: stbt.match("image1.png") or
                              stbt.match("image2.png"))

Since we're not specifying `frame`, `stbt.match` will call
`stbt.get_frame`. Two different undesirable things can happen:

1. `stbt.match("image1.png")` and `stbt.match("image2.png")` might end
   up operating on different frames.

2. Since `stbt.get_frame` can return the same frame multiple times,
   several iterations of the `wait_until` loop might end up operating on
   the same frame.

By iterating over `stbt.frames()` instead, we guarantee that in a single
iteration of `wait_until`'s loop we see the same frame[1]; and we
guarantee that the next iteration of `wait_until`'s loop will block (if
necessary) until the next frame is available.

I've been meaning to implement this for a while, though I do wonder if
the "undesirable thing # 1" above would really happen in practice,
considering that you really should be using a PageObject property for
complicated matching like this. Still, # 2 above might be reason enough
to implement this.

[1] To really guarantee this you have to write your lambda function to
    pass `frame` through correctly.
