### PR TITLE
Add support for OpenCV4

### DIFF
--- a/_stbt/cv2_compat.py
+++ b/_stbt/cv2_compat.py
@@ -1,5 +1,5 @@
 """
-Compatibility so stb-tester will work with both OpenCV 2 and 3.
+Compatibility so stb-tester will work with both OpenCV 2, 3, and 4.
 """
 from __future__ import unicode_literals
 from __future__ import print_function
@@ -15,7 +15,11 @@ version = LooseVersion(cv2.__version__).version
 
 if version >= [3, 2, 0]:
     def find_contour_boxes(image, mode, method):  # pylint:disable=redefined-outer-name
-        contours = cv2.findContours(image=image, mode=mode, method=method)[1]
+        contours = cv2.findContours(image=image, mode=mode, method=method)
+
+        # In OpenCV 4, the behavior of find findContours changes from returning
+        # (img, contours, hierarchy) back to (contours, hierarchy): https://bit.ly/31bWiIP
+        contours = contours[0] if version >= [4, 0, 0] else contours[1]
         return [cv2.boundingRect(x) for x in contours]
 else:
     def _fix_pre_3_2_rects(r):
@@ -27,8 +31,8 @@ else:
         return (x - 1, y - 1, w + 2, h + 2)
 
     def find_contour_boxes(image, mode, method):  # pylint:disable=redefined-outer-name
-        # In v3.0.0 cv2.findContours started returing (img, contours, hierarchy)
-        # rather than (contours, heirarchy).  Index -2 selects contours on both
+        # In v3.0.0 cv2.findContours started returning (img, contours, hierarchy)
+        # rather than (contours, hierarchy).  Index -2 selects contours on both
         # versions:
         contours = cv2.findContours(image=image, mode=mode, method=method)[-2]
         return [_fix_pre_3_2_rects(cv2.boundingRect(x)) for x in contours]

--- a/_stbt/cv2_compat.py
+++ b/_stbt/cv2_compat.py
@@ -18,7 +18,8 @@ if version >= [3, 2, 0]:
         contours = cv2.findContours(image=image, mode=mode, method=method)
 
         # In OpenCV 4, the behavior of find findContours changes from returning
-        # (img, contours, hierarchy) back to (contours, hierarchy): https://bit.ly/31bWiIP
+        # (img, contours, hierarchy) back to (contours, hierarchy):
+        # https://bit.ly/31bWiIP
         contours = contours[0] if version >= [4, 0, 0] else contours[1]
         return [cv2.boundingRect(x) for x in contours]
 else:
@@ -31,9 +32,9 @@ else:
         return (x - 1, y - 1, w + 2, h + 2)
 
     def find_contour_boxes(image, mode, method):  # pylint:disable=redefined-outer-name
-        # In v3.0.0 cv2.findContours started returning (img, contours, hierarchy)
-        # rather than (contours, hierarchy).  Index -2 selects contours on both
-        # versions:
+        # In v3.0.0 cv2.findContours started returning
+        # (img, contours, hierarchy) rather than (contours, hierarchy).
+        # Index -2 selects contours on both versions:
         contours = cv2.findContours(image=image, mode=mode, method=method)[-2]
         return [_fix_pre_3_2_rects(cv2.boundingRect(x)) for x in contours]
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -18,6 +18,10 @@ open-source project, or update [test_pack.stbt_version] if you're using the
 [license]: https://github.com/stb-tester/stb-tester/blob/master/LICENSE
 
 
+#### Unreleased
+
+ * Support for OpenCV4
+
 #### v31
 
 18 September 2019.


### PR DESCRIPTION
This is in regards to #648. Sorry for the delay.

OpenCV4 changed the behavior of `findContours` back to returning
`(contours, hierachy)` instead of `(image, contours, hierachy)`.
However, the `cv2_compat` file is trying to find contours as the second
return value for any version of cv2 >= 3.2.0.

This is a small fix that ensures contours is still selected
on version of openCV >= 4.0.0.