### PR TITLE
wait_until: Don't run `predicate` if `value` is falsey

### DIFF
--- a/_stbt/wait.py
+++ b/_stbt/wait.py
@@ -109,7 +109,10 @@ def wait_until(callable_, timeout_secs=10, interval_secs=0, predicate=None,
     while True:
         t = time.time()
         value = callable_()
-        predicate_value = predicate(value)
+        if value:
+            predicate_value = predicate(value)
+        else:
+            predicate_value = None
 
         if stable_secs:
             if predicate_value != stable_predicate_value:


### PR DESCRIPTION
This avoids having to write awkward code like:

    wait_until(MyPageObject, predicate p: p and p.some_property.something)

...where we need the `p and` to guard against falsey FrameObjects where
`p.some_property` will be `None`.

TODO:

- [ ] Decide if this is a good idea.
- [ ] Tests.
- [ ] Documentation.