### PR TITLE
stbt.draw_text: Also write text to stderr

### DIFF
--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -200,6 +200,7 @@ def draw_text(text, duration_secs=3):
     :param duration_secs: The number of seconds to display the text.
     :type duration_secs: int or float
     """
+    debug(text)
     return _dut.draw_text(text, duration_secs)
 
 


### PR DESCRIPTION
You'll want to see this message in the logs too, and you don't want to have to write a `stbt.debug(...)` for every `stbt.draw_text(...)` in your test.