### PR TITLE
core: Fix frame timestamps drawn on output video

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -486,7 +486,8 @@ class SinkPipeline(object):
         img = array_from_sample(sample, readwrite=True)
         # Text:
         _draw_text(
-            img, datetime.datetime.now().strftime("%H:%M:%S.%f")[:-4],
+            img,
+            datetime.datetime.fromtimestamp(now).strftime("%H:%M:%S.%f")[:-4],
             (10, 30), (255, 255, 255))
         for i, x in enumerate(reversed(current_texts)):
             origin = (10, (i + 2) * 30)


### PR DESCRIPTION
It should be the frame's time, not the current wall-clock time.
SinkPipeline buffers half a second of frames to give the user code
enough time to draw annotations on them before they are pushed to the
video encoder -- so these timestamps were all wrong by half a second.