### PR TITLE
stbt.pylint_plugin: Fix false positive for "wait_until_..."

### DIFF
--- a/stbt/pylint_plugin.py
+++ b/stbt/pylint_plugin.py
@@ -101,7 +101,7 @@ class StbtChecker(BaseChecker):
                         self.add_message(
                             'E7002', node=node, args=node.func.as_string())
 
-        if re.search(r"\bwait_until", node.func.as_string()):
+        if re.search(r"\bwait_until$", node.func.as_string()):
             if node.args:
                 arg = node.args[0]
                 if not _is_callable(arg):


### PR DESCRIPTION
I have started using a convention of a classmethod called
"wait_until_visible" on my Page Objects, like this:

    page = Carousel.wait_until_visible(keypress)

Our pylint plugin thinks this is `stbt.wait_until` and complains:
"wait_until" argument "keypress" isn't callable.