### PR TITLE
stbt.load_image: Allow passing an image

### DIFF
--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -124,8 +124,12 @@ def load_image(filename, flags=None):
     * Added in v28.
     * Changed in v30: Include alpha (transparency) channel if the file has
       transparent pixels.
+    * Changed in v32: Allows passing an image (`numpy.ndarray`) in which case
+      this function is a no-op.
     """
 
+    if isinstance(filename, numpy.ndarray):
+        return filename
     absolute_filename = find_user_file(filename)
     if not absolute_filename:
         raise IOError(to_native_str("No such file: %s" % to_unicode(filename)))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -49,6 +49,12 @@ def test_load_image_with_unicode_filename():
     assert stbt.load_image(u"R\xf6thlisberger.png") is not None
 
 
+def test_load_image_with_image():
+    img = numpy.zeros((720, 1280), dtype=numpy.uint8)
+    img2 = stbt.load_image(img)
+    assert img is img2
+
+
 def test_crop():
     f = stbt.load_image("action-panel.png")
     cropped = stbt.crop(f, stbt.Region(x=1045, y=672, right=1081, bottom=691))


### PR DESCRIPTION
This simplifies writing functions like this:

    def my_helper(mask=None):
        if mask:
            mask = stbt.load_image(mask)

...such that `mask` can be a filename, or an image constructed in code
using `numpy.zeros` etc.