### PR TITLE
Add stbt.last_keypress()

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -118,6 +118,9 @@ class DeviceUnderTest(object):
             self._mainloop.__exit__(exc_type, exc_value, tb)
         self._control = None
 
+    def last_keypress(self):
+        return self._last_keypress
+
     def press(self, key, interpress_delay_secs=None, hold_secs=None):
         if hold_secs is not None and hold_secs > 60:
             # You must ensure that lircd's --repeat-max is set high enough.

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -90,6 +90,7 @@ __all__ = [
     "grid_to_navigation_graph",
     "is_screen_black",
     "Keyboard",
+    "last_keypress",
     "load_image",
     "match",
     "match_all",
@@ -123,6 +124,15 @@ __all__ = [
 
 # Functions available to stbt scripts
 # ===========================================================================
+
+
+def last_keypress():
+    """Returns information about the last key-press sent to the device under
+    test.
+
+    See the return type of `stbt.press`.
+    """
+    return _dut.last_keypress()
 
 
 def press(key, interpress_delay_secs=None, hold_secs=None):
@@ -279,6 +289,9 @@ def get_frame():
 
 class UnconfiguredDeviceUnderTest(object):
     # pylint:disable=unused-argument
+    def last_keypress(self):
+        return None
+
     def press(self, *args, **kwargs):
         raise RuntimeError(
             "stbt.press isn't configured to run on your hardware")

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -600,29 +600,29 @@ test_that_press_returns_a_pressresult() {
 	import time
 	
 	before = time.time()
-	result = stbt.press("KEY_MENU")
+	result1 = stbt.press("KEY_MENU")
 	after = time.time()
 
-	assert before < result.start_time < result.end_time < after
-	assert result.key == "KEY_MENU"
-	assert isinstance(result.frame_before, stbt.Frame)
+	assert before < result1.start_time < result1.end_time < after
+	assert result1.key == "KEY_MENU"
+	assert isinstance(result1.frame_before, stbt.Frame)
 
 	before = time.time()
-	result = stbt.press("KEY_HOME", hold_secs=0.001)
+	result2 = stbt.press("KEY_HOME", hold_secs=0.001)
 	after = time.time()
 
-	assert before < result.start_time < result.end_time < after
-	assert result.key == "KEY_HOME"
-	assert isinstance(result.frame_before, stbt.Frame)
+	assert before < result2.start_time < result2.end_time < after
+	assert result2.key == "KEY_HOME"
+	assert isinstance(result2.frame_before, stbt.Frame)
 
 	before = time.time()
-	with stbt.pressing("KEY_VOLUMEUP") as result:
-	    assert before < result.start_time
-	    assert result.end_time is None
-	    assert result.key == "KEY_VOLUMEUP"
-	    assert isinstance(result.frame_before, stbt.Frame)
+	with stbt.pressing("KEY_VOLUMEUP") as result3:
+	    assert before < result3.start_time
+	    assert result3.end_time is None
+	    assert result3.key == "KEY_VOLUMEUP"
+	    assert isinstance(result3.frame_before, stbt.Frame)
 	after = time.time()
-	assert result.start_time < result.end_time < after
+	assert result3.start_time < result3.end_time < after
 	EOF
     stbt run -vv --control=none test.py || fail "Incorrect press() behaviour"
 }

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -599,6 +599,8 @@ test_that_press_returns_a_pressresult() {
     cat > test.py <<-EOF &&
 	import time
 	
+	assert stbt.last_keypress() is None
+
 	before = time.time()
 	result1 = stbt.press("KEY_MENU")
 	after = time.time()
@@ -606,6 +608,7 @@ test_that_press_returns_a_pressresult() {
 	assert before < result1.start_time < result1.end_time < after
 	assert result1.key == "KEY_MENU"
 	assert isinstance(result1.frame_before, stbt.Frame)
+	assert stbt.last_keypress() == result1
 
 	before = time.time()
 	result2 = stbt.press("KEY_HOME", hold_secs=0.001)
@@ -614,6 +617,7 @@ test_that_press_returns_a_pressresult() {
 	assert before < result2.start_time < result2.end_time < after
 	assert result2.key == "KEY_HOME"
 	assert isinstance(result2.frame_before, stbt.Frame)
+	assert stbt.last_keypress() == result2
 
 	before = time.time()
 	with stbt.pressing("KEY_VOLUMEUP") as result3:
@@ -621,8 +625,10 @@ test_that_press_returns_a_pressresult() {
 	    assert result3.end_time is None
 	    assert result3.key == "KEY_VOLUMEUP"
 	    assert isinstance(result3.frame_before, stbt.Frame)
+	    assert stbt.last_keypress() == result3
 	after = time.time()
 	assert result3.start_time < result3.end_time < after
+	assert stbt.last_keypress() == result3
 	EOF
     stbt run -vv --control=none test.py || fail "Incorrect press() behaviour"
 }


### PR DESCRIPTION
We already set `_stbt.core.DeviceUnderTest._last_keypress`, but we don't expose it in a public API. 