### PR TITLE
sink pipeline: Avoid filling up RAM if something goes wrong

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -350,6 +350,9 @@ class SinkPipeline(object):
         self._time = _time
         self._sample_count = 0
 
+        # Just used for logging:
+        self._appsrc_was_full = False
+
         # The test script can draw on the video, but this happens in a different
         # thread.  We don't know when they're finished drawing so we just give
         # them 0.5s instead.
@@ -501,6 +504,19 @@ class SinkPipeline(object):
         # Regions:
         for annotation in annotations:
             _draw_annotation(img, annotation)
+
+        APPSRC_LIMIT_BYTES = 100 * 1024 * 1024  # 100MB
+        if self.appsrc.props.current_level_bytes > APPSRC_LIMIT_BYTES:
+            # appsrc is backed-up, perhaps something's gone wrong.  We don't
+            # want to use up all RAM, so let's drop the buffer on the floor.
+            if not self._appsrc_was_full:
+                warn("sink pipeline appsrc is full, dropping buffers from now "
+                     "on")
+                self._appsrc_was_full = True
+            return
+        elif self._appsrc_was_full:
+            debug("sink pipeline appsrc no longer full, pushing buffers again")
+            self._appsrc_was_full = False
 
         self.appsrc.props.caps = sample.get_caps()
         self.appsrc.emit("push-buffer", sample.get_buffer())


### PR DESCRIPTION
`appsrc` does its own buffering, and won't reject frames even if the sink
pipeline isn't running or is in an error state.  This can lead to memory
exhaustion.  This will at least avoid OOM, even if the sink pipeline will
have to be fixed seperately.

100MB is 1.4s at 720p25.

TODO:

- [x] Test with `identity`