### PR TITLE
docstrings: Replace "unicode" => "str"

### DIFF
--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -108,8 +108,7 @@ def load_image(filename, flags=None):
     This is the same lookup algorithm used by `stbt.match` and similar
     functions.
 
-    :type filename: str or unicode
-    :param filename: A relative or absolute filename.
+    :param str filename: A relative or absolute filename.
 
     :param flags: Flags to pass to :ocv:pyfunc:`cv2.imread`.
 

--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -120,7 +120,7 @@ class TextMatchResult(object):
     :ivar Frame frame: The video frame that was searched, as given to
         `match_text`.
 
-    :ivar unicode text: The text that was searched for, as given to
+    :ivar str text: The text that was searched for, as given to
         `match_text`.
     """
     _fields = ("time", "match", "region", "frame", "text")
@@ -310,7 +310,7 @@ def match_text(text, frame=None, region=Region.ALL,
     This can be used as an alternative to `match`, searching for text instead
     of an image.
 
-    :param unicode text: The text to search for.
+    :param str text: The text to search for.
     :param frame: See `ocr`.
     :param region: See `ocr`.
     :param mode: See `ocr`.


### PR DESCRIPTION
We still support Python 2 but the docs we publish assume Python 3.