### PR TITLE
Add stbt.MultiPress: Enter text using a numeric keypad

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ INSTALL_PYLIB_FILES = \
     _stbt/logging.py \
     _stbt/match.py \
     _stbt/motion.py \
+    _stbt/multipress.py \
     _stbt/ocr.py \
     _stbt/precondition.py \
     _stbt/power.py \
@@ -233,6 +234,7 @@ check-pythonpackage:
 	    tests/test_grid.py \
 	    tests/test_match.py \
 	    tests/test_motion.py \
+	    tests/test_multipress.py \
 	    tests/test_transition.py && \
 	stbt_lint="pylint --load-plugins=stbt_core.pylint_plugin" \
 	    tests/run-tests.sh -i tests/test-stbt-lint.sh

--- a/_stbt/multipress.py
+++ b/_stbt/multipress.py
@@ -34,18 +34,18 @@ class MultiPress(object):
     :param dict key_mapping:
         The mapping from number keys to letters. The default mapping is::
 
-        {
-            "KEY_0": " 0",
-            "KEY_1": "1.,",
-            "KEY_2": "abc2",
-            "KEY_3": "def3",
-            "KEY_4": "ghi4",
-            "KEY_5": "jkl5",
-            "KEY_6": "mno6",
-            "KEY_7": "pqrs7",
-            "KEY_8": "tuv8",
-            "KEY_9": "wxyz9",
-        }
+            {
+                "KEY_0": " 0",
+                "KEY_1": "1.,",
+                "KEY_2": "abc2",
+                "KEY_3": "def3",
+                "KEY_4": "ghi4",
+                "KEY_5": "jkl5",
+                "KEY_6": "mno6",
+                "KEY_7": "pqrs7",
+                "KEY_8": "tuv8",
+                "KEY_9": "wxyz9",
+            }
 
         This matches the arrangement of digits A-Z from ITU E.161 / ISO 9995-8.
 
@@ -121,11 +121,11 @@ def _parse_mapping_from_docstring(s):
     code = []
     in_mapping = False
     for line in s.split("\n"):
-        if re.match(r"^        {", line):
+        if re.match(r"^            {", line):
             in_mapping = True
         if in_mapping:
             code.append(line)
-        if re.match(r"^        }", line):
+        if re.match(r"^            }", line):
             break
     return eval("\n".join(code))
 

--- a/_stbt/multipress.py
+++ b/_stbt/multipress.py
@@ -132,12 +132,12 @@ def _parse_mapping_from_docstring(s):
 
 def _letters_to_keys(keys_to_letters):
     """
-    >>> _letters_to_keys({'KEY_1': '1', 'KEY_2': 'abc2'})
-    {'1': ('KEY_1', 1),
-     'a': ('KEY_2', 1),
-     'b': ('KEY_2', 2),
-     'c': ('KEY_2', 3),
-     '2': ('KEY_2', 4)}
+    >>> sorted(_letters_to_keys({'KEY_1': '1', 'KEY_2': 'abc2'}).items())
+    [('1', ('KEY_1', 1)),
+     ('2', ('KEY_2', 4)),
+     ('a', ('KEY_2', 1)),
+     ('b', ('KEY_2', 2)),
+     ('c', ('KEY_2', 3))]
     """
     out = {}
     for key, letters in keys_to_letters.items():

--- a/_stbt/multipress.py
+++ b/_stbt/multipress.py
@@ -1,0 +1,146 @@
+# coding: utf-8
+"""Copyright 2020 Stb-tester.com Ltd."""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+
+import re
+import time
+
+
+class MultiPress(object):
+    """Helper for entering text using `multi-press`_ on a numeric keypad.
+
+    In some apps, the search page allows entering text by pressing the keys on
+    the remote control's numeric keypad: press the number "2" once for "A",
+    twice for "B", etc.::
+
+        1.,     ABC2    DEF3
+        GHI4    JKL5    MNO6
+        PQRS7   TUV8    WXYZ9
+              [space]0
+
+    To enter text with this mechanism, create an instance of this class and
+    call its ``enter_text`` method. For example::
+
+        multipress = stbt.MultiPress()
+        multipress.enter_text("teletubbies")
+
+    The constructor takes the following parameters:
+
+    :param dict key_mapping:
+        The mapping from number keys to letters. The default mapping is::
+
+        {
+            "KEY_0": " 0",
+            "KEY_1": "1.,",
+            "KEY_2": "abc2",
+            "KEY_3": "def3",
+            "KEY_4": "ghi4",
+            "KEY_5": "jkl5",
+            "KEY_6": "mno6",
+            "KEY_7": "pqrs7",
+            "KEY_8": "tuv8",
+            "KEY_9": "wxyz9",
+        }
+
+        This matches the arrangement of digits A-Z from ITU E.161 / ISO 9995-8.
+
+        The value you pass in this parameter is merged with the default mapping.
+        For example to override the punctuation characters you can specify
+        ``key_mapping={"KEY_1": "@1.,-_"}``.
+
+        The dict's key names must match the remote-control key names accepted
+        by `stbt.press`. The dict's values are a string or sequence of the
+        corresponding letters, in the order that they are entered when pressing
+        that key.
+
+    :param float interpress_delay_secs:
+        The time to wait between every key-press, in seconds. This defaults to
+        0.3, the same default as `stbt.press`.
+
+    :param float interletter_delay_secs:
+        The time to wait between letters on the same key, in seconds. For
+        example, to enter "AB" you need to press key "2" once, then wait, then
+        press it again twice. If you don't wait, the device-under-test would
+        see three consecutive keypresses which mean the letter "C".
+
+    .. _multi-press: https://en.wikipedia.org/wiki/Multi-tap
+    """
+
+    def __init__(self, key_mapping=None, interpress_delay_secs=None,
+                 interletter_delay_secs=1):
+
+        mapping = _parse_mapping_from_docstring(MultiPress.__doc__)
+        if key_mapping is not None:
+            mapping.update(key_mapping)
+        self.keys = _letters_to_keys(mapping)
+
+        self.interpress_delay_secs = interpress_delay_secs
+        self.interletter_delay_secs = interletter_delay_secs
+
+    def enter_text(self, text):
+        """Enter the specified text using multi-press on the numeric keypad.
+
+        :param str text:
+            The text to enter. The case doesn't matter (uppercase and lowercase
+            are treated the same).
+        """
+
+        from stbt_core import debug, press
+
+        text = text.lower()
+
+        # Raise exception early, so we don't enter half the text
+        for c in text:
+            if c not in self.keys:
+                raise ValueError("Don't know how to enter %r" % (c,))
+
+        debug("MultiPress.enter_text: %r" % (text,))
+
+        prev_key = None
+        for c in text:
+            key, n = self.keys[c]
+            if prev_key == key:
+                time.sleep(self.interletter_delay_secs)
+            for _ in range(n):
+                press(key, interpress_delay_secs=self.interpress_delay_secs)
+            prev_key = key
+
+
+def _parse_mapping_from_docstring(s):
+    """
+    >>> _parse_mapping_from_docstring(MultiPress.__doc__)['KEY_0']
+    ' 0'
+    >>> _parse_mapping_from_docstring(MultiPress.__doc__)['KEY_9']
+    'wxyz9'
+    """
+    code = []
+    in_mapping = False
+    for line in s.split("\n"):
+        if re.match(r"^        {", line):
+            in_mapping = True
+        if in_mapping:
+            code.append(line)
+        if re.match(r"^        }", line):
+            break
+    return eval("\n".join(code))
+
+
+def _letters_to_keys(keys_to_letters):
+    """
+    >>> _letters_to_keys({'KEY_1': '1', 'KEY_2': 'abc2'})
+    {'1': ('KEY_1', 1),
+     'a': ('KEY_2', 1),
+     'b': ('KEY_2', 2),
+     'c': ('KEY_2', 3),
+     '2': ('KEY_2', 4)}
+    """
+    out = {}
+    for key, letters in keys_to_letters.items():
+        for n, letter in enumerate(letters, start=1):
+            out[letter] = (key, n)
+    return out

--- a/stbt_core/__init__.py
+++ b/stbt_core/__init__.py
@@ -54,6 +54,8 @@ from _stbt.motion import (
     detect_motion,
     MotionTimeout,
     wait_for_motion)
+from _stbt.multipress import (
+    MultiPress)
 from _stbt.ocr import (
     apply_ocr_corrections,
     match_text,
@@ -113,6 +115,7 @@ __all__ = [to_native_str(x) for x in [
     "MotionDiff",
     "MotionResult",
     "MotionTimeout",
+    "MultiPress",
     "NoVideo",
     "ocr",
     "OcrEngine",

--- a/tests/test_multipress.py
+++ b/tests/test_multipress.py
@@ -1,0 +1,73 @@
+# coding: utf-8
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import *  # pylint:disable=redefined-builtin,unused-wildcard-import,wildcard-import,wrong-import-order
+
+from textwrap import dedent
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock  # Python 2 backport
+
+import stbt_core
+
+
+def test_multipress():
+    out = []
+
+    def press(key, interpress_delay_secs=None):  # pylint:disable=unused-argument
+        out.append("press('%s')" % (key,))
+
+    def sleep(t):
+        out.append("sleep(%s)" % (t,))
+
+    with mock.patch("stbt_core.press", press), mock.patch("time.sleep", sleep):
+        multipress = stbt_core.MultiPress({"KEY_1": "@1.,-_"})
+        multipress.enter_text("abc42@eXaMpLe.com")
+
+    expected = dedent("""\
+        press('KEY_2')  # a
+        sleep(1)
+        press('KEY_2')  # b
+        press('KEY_2')
+        sleep(1)
+        press('KEY_2')  # c
+        press('KEY_2')
+        press('KEY_2')
+        press('KEY_4')  # 4
+        press('KEY_4')
+        press('KEY_4')
+        press('KEY_4')
+        press('KEY_2')  # 2
+        press('KEY_2')
+        press('KEY_2')
+        press('KEY_2')
+        press('KEY_1')  # @
+        press('KEY_3')  # e
+        press('KEY_3')
+        press('KEY_9')  # x
+        press('KEY_9')
+        press('KEY_2')  # a
+        press('KEY_6')  # m
+        press('KEY_7')  # p
+        press('KEY_5')  # l
+        press('KEY_5')
+        press('KEY_5')
+        press('KEY_3')  # e
+        press('KEY_3')
+        press('KEY_1')  # .
+        press('KEY_1')
+        press('KEY_1')
+        press('KEY_2')  # c
+        press('KEY_2')
+        press('KEY_2')
+        press('KEY_6')  # o
+        press('KEY_6')
+        press('KEY_6')
+        sleep(1)
+        press('KEY_6')  # m """)
+    assert [x.split("#")[0].strip() for x in expected.split("\n")] == out


### PR DESCRIPTION
In some apps, the search page allows entering text by pressing the keys
on the remote control's numeric keypad: press the number "2" once for
"A", twice for "B", etc.:

        1.,     ABC2    DEF3
        GHI4    JKL5    MNO6
        PQRS7   TUV8    WXYZ9
              [space]0

This is much easier (and faster) than moving a selection around an
on-screen keyboard.

The keys for A-Z are specified in [ITU E.161]. The standard doesn't
specify where "space" goes, but every implementation I have seen has it
on KEY_0. Punctuation varies across implementations; I have arbitrarily
chosen the behaviour of a Sky HD+ box that I had available for testing,
but you can override this by passing `key_mapping={"KEY_1": "@1.,-_}` to
the `stbt.MultiPress` constructor.

[ITU E.161]: https://www.itu.int/rec/T-REC-E.161