### PR TITLE
Libcec fix

### DIFF
--- a/_stbt/control_gpl.py
+++ b/_stbt/control_gpl.py
@@ -162,7 +162,7 @@ class HdmiCecControl(object):
             device = self.detect_adapter()
             if device is None:
                 raise HdmiCecError("No adapter found")
-        device = to_bytes(device)
+        device = to_bytes(device)  # Don't execute
         if not self.lib.Open(device):
             raise HdmiCecError("Failed to open a connection to the CEC adapter")
         debug("Connection to CEC adapter opened")

--- a/_stbt/control_gpl.py
+++ b/_stbt/control_gpl.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 from textwrap import dedent
 
 from .logging import debug
-from .utils import to_bytes
+from .utils import to_bytes, to_native_str
 
 
 class HdmiCecError(Exception):
@@ -149,7 +149,7 @@ class HdmiCecControl(object):
             destination = int(destination, 16)
 
         self.cecconfig = cec.libcec_configuration()
-        self.cecconfig.strDeviceName = b"stb-tester"
+        self.cecconfig.strDeviceName = to_native_str("stb-tester")
         self.cecconfig.bActivateSource = 0
         self.cecconfig.deviceTypes.Add(cec.CEC_DEVICE_TYPE_RECORDING_DEVICE)
         self.cecconfig.clientVersion = cec.LIBCEC_VERSION_CURRENT
@@ -162,7 +162,7 @@ class HdmiCecControl(object):
             device = self.detect_adapter()
             if device is None:
                 raise HdmiCecError("No adapter found")
-        device = to_bytes(device)  # Don't execute
+        device = to_native_str(device)
         if not self.lib.Open(device):
             raise HdmiCecError("Failed to open a connection to the CEC adapter")
         debug("Connection to CEC adapter opened")
@@ -261,11 +261,11 @@ class HdmiCecControl(object):
 
     def keydown_command(self, key):
         keycode = self.get_keycode(key)
-        keydown_str = b"%X%X:44:%02X" % (self.source, self.destination, keycode)
+        keydown_str = to_native_str("%X%X:44:%02X") % (self.source, self.destination, keycode)
         return self.lib.CommandFromString(keydown_str)
 
     def keyup_command(self):
-        keyup_str = b"%X%X:45" % (self.source, self.destination)
+        keyup_str = to_native_str("%X%X:45") % (self.source, self.destination)
         return self.lib.CommandFromString(keyup_str)
 
     def get_keycode(self, key):

--- a/_stbt/control_gpl.py
+++ b/_stbt/control_gpl.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 from textwrap import dedent
 
 from .logging import debug
-from .utils import to_bytes, to_native_str
+from .utils import to_native_str
 
 
 class HdmiCecError(Exception):


### PR DESCRIPTION
Bug fix for allowing cec to function with Python 3 under Ubuntu 20.04 and libcec 4.0.4

Tested and verified in the above environment + with Python 2.7 under Ubuntu 18.04
I have NOT been able to test with Python 2 under Ubuntu 20.04