### PR TITLE
stbt.Keyboard: Allow key names with "#" in them

### DIFF
--- a/stbt/keyboard.py
+++ b/stbt/keyboard.py
@@ -319,9 +319,11 @@ class Keyboard(object):
         :param str graph: See the `Keyboard` constructor.
         :returns: A new `networkx.DiGraph` instance.
         """
-        return nx.parse_edgelist(graph.split("\n"),
-                                 create_using=nx.DiGraph(),
-                                 data=[("key", text_type)])
+        return nx.parse_edgelist(
+            graph.split("\n"),
+            comments="LCYG2RXNHIXJGPLLMQQIJ7VECIYURYEQTPNGBNUQCPQW34PMO5NQETM",
+            create_using=nx.DiGraph(),
+            data=[("key", text_type)])
 
 
 def _selection_to_text(selection):

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -437,3 +437,26 @@ def test_composing_complex_keyboards():
     K2 = stbt.Keyboard(G2)
 
     assert sorted(K0.G.edges(data=True)) == sorted(K2.G.edges(data=True))
+
+
+def test_keyboard_with_hash_sign():
+    """Regression test. `networkx.parse_edgelist` treats "#" as a comment."""
+    kb = stbt.Keyboard("""
+        @hotmail.com !#$ KEY_DOWN
+        @hotmail.com @ KEY_DOWN
+        @ # KEY_RIGHT
+        # @ KEY_LEFT
+        L K KEY_LEFT
+        K L KEY_RIGHT
+    """)
+    keys = list(_keys_to_press(kb.G, "@hotmail.com", "@"))
+    assert keys == [('KEY_DOWN', {'@', '!#$'})]
+
+    assert list(_keys_to_press(kb.G, "@", "#")) == [('KEY_RIGHT', {'#'})]
+    assert list(_keys_to_press(kb.G, "#", "@")) == [('KEY_LEFT', {'@'})]
+
+    # L is the first character of the random comments delimiter in
+    # `Keyboard.parse_edgelist`. Check that networkx uses the whole string, not
+    # just the first character.
+    assert list(_keys_to_press(kb.G, "K", "L")) == [('KEY_RIGHT', {'L'})]
+    assert list(_keys_to_press(kb.G, "L", "K")) == [('KEY_LEFT', {'K'})]


### PR DESCRIPTION
`networkx.parse_edgelist` treats "#" as a comment by default.

If I do `comments=None` or `comments=False` I get a TypeError. If I do
`comments=""` I get a graph without any nodes at all. So I have used a
long random string as the comment marker.