### PR TITLE
ImageLogger: Allow disabling image logging in Jupyter Notebook

### DIFF
--- a/_stbt/logging.py
+++ b/_stbt/logging.py
@@ -19,6 +19,9 @@ from .utils import mkdir_p
 
 _debug_level = None
 
+# Running in a Jupyter Notebook:
+_jupyter_logging_enabled = "JPY_PARENT_PID" in os.environ
+
 
 def debug(msg):
     """Print the given string to stderr if stbt run `--verbose` was given."""
@@ -81,7 +84,7 @@ class ImageLogger(object):
     _frame_number = itertools.count(1)
 
     def __init__(self, name, **kwargs):
-        self.jupyter = "JPY_PARENT_PID" in os.environ  # in a Jupyter Notebook
+        self.jupyter = _jupyter_logging_enabled
         self.enabled = get_debug_level() > 1 or self.jupyter
         if not self.enabled:
             return


### PR DESCRIPTION
You might have a notebook that does its own visualisation, and you don't
want every `stbt.match` (etc) to be logging tons of debug. In that case
you can put `_stbt.logging._jupyter_logging_enabled = False` at the top
of your notebook.