### PR TITLE
HdmiCecControl: Re-scan CEC bus if transmit fails

### DIFF
--- a/_stbt/control_gpl.py
+++ b/_stbt/control_gpl.py
@@ -210,11 +210,11 @@ class HdmiCecControl(object):
             if self.press_and_holding:
                 raise HdmiCecError(
                     "Can't call 'keydown' while holding another key")
-            self.press_and_holding = True
 
             if not self.lib.Transmit(self.keydown_command(key)):
                 raise HdmiCecError("Failed to send keydown for %s" % key)
 
+            self.press_and_holding = True
             self.press_and_hold_thread = threading.Thread(
                 target=self.send_keydowns, args=(key,))
             self.press_and_hold_thread.daemon = True

--- a/_stbt/control_gpl.py
+++ b/_stbt/control_gpl.py
@@ -34,9 +34,11 @@ class HdmiCecControl(object):
         "KEY_LEFT_UP": 7,
         "KEY_LEFT_DOWN": 8,
         "KEY_ROOT_MENU": 9,
-        "KEY_MENU": 9,
+        "KEY_MENU": 9,  # Alias
+        "KEY_HOME": 9,  # Alias for Amazon Fire
         "KEY_SETUP": 10,
         "KEY_CONTENTS_MENU": 11,  # <- not in input-event-codes.h
+        "KEY_OPTIONS": 11,  # Alias for Amazon Fire
         "KEY_FAVORITE_MENU": 12,  # <- not in input-event-codes.h
         "KEY_BACK": 13,
 

--- a/_stbt/control_gpl.py
+++ b/_stbt/control_gpl.py
@@ -168,20 +168,11 @@ class HdmiCecControl(object):
         debug("Connection to CEC adapter opened")
 
         if destination is None:
-            ds = list(self._list_active_devices())
-            debug("HDMI-CEC scan complete.  Found %r" % ds)
-            if len(ds) == 0:
-                raise HdmiCecError(
-                    "Failed to find a device on the CEC bus to talk to.")
-            # Choose the last one, the first one is likely to be a TV if there's
-            # one plugged in
-            destination = ds[-1]
-            debug("HDMI-CEC: Chose to talk to device %i %r" % (
-                destination, self.lib.GetDeviceOSDName(destination)))
+            self.rescan()
+        else:
+            self.destination = destination
 
         self.source = source
-        self.destination = destination
-
         self.press_and_hold_thread = None
         self.press_and_holding = False
         self.lock = threading.Condition()
@@ -192,7 +183,10 @@ class HdmiCecControl(object):
                 raise HdmiCecError(
                     "Can't call 'press' while holding another key")
 
+            if self.destination is None:
+                self.rescan()
             if not self.lib.Transmit(self.keydown_command(key)):
+                self.destination = None
                 raise HdmiCecError("Failed to send keydown for %s" % key)
             if not self.lib.Transmit(self.keyup_command()):
                 raise HdmiCecError("Failed to send keyup for %s" % key)
@@ -211,7 +205,10 @@ class HdmiCecControl(object):
                 raise HdmiCecError(
                     "Can't call 'keydown' while holding another key")
 
+            if self.destination is None:
+                self.rescan()
             if not self.lib.Transmit(self.keydown_command(key)):
+                self.destination = None
                 raise HdmiCecError("Failed to send keydown for %s" % key)
 
             self.press_and_holding = True
@@ -233,7 +230,8 @@ class HdmiCecControl(object):
         thread.join()
 
         with self.lock:
-            if not self.lib.Transmit(self.keyup_command()):
+            if (self.destination is None or
+                    not self.lib.Transmit(self.keyup_command())):
                 raise HdmiCecError("Failed to send keyup for %s" % key)
         debug("Released %s" % key)
 
@@ -249,6 +247,9 @@ class HdmiCecControl(object):
             while True:
                 self.lock.wait(max(0, next_press_deadline - time.time()))
                 if not self.press_and_holding:
+                    return
+                if self.destination is None:
+                    self.press_and_holding = False
                     return
                 if time.time() > end_time:
                     debug("cec: Warning: Releasing %s as I've been holding it "
@@ -299,6 +300,19 @@ class HdmiCecControl(object):
                 (adapter.strComName, adapter.iVendorId, adapter.iProductId))
             retval = adapter.strComName
         return retval
+
+    def rescan(self):
+        ds = list(self._list_active_devices())
+        debug("HDMI-CEC scan complete.  Found %r" % ds)
+        if len(ds) == 0:
+            raise HdmiCecError(
+                "Failed to find a device on the CEC bus to talk to.")
+        # Choose the last one, the first one is likely to be a TV if there's
+        # one plugged in
+        destination = ds[-1]
+        debug("HDMI-CEC: Chose to talk to device %i %r" % (
+            destination, self.lib.GetDeviceOSDName(destination)))
+        self.destination = destination
 
     def _list_active_devices(self):
         self.lib.RescanActiveDevices()

--- a/stbt_control_relay.py
+++ b/stbt_control_relay.py
@@ -40,6 +40,7 @@ import signal
 import socket
 import sys
 
+import _stbt.logging
 from _stbt.control import uri_to_control
 from _stbt.utils import to_bytes
 
@@ -58,6 +59,9 @@ def main(argv):
     logging.basicConfig(
         format="%(levelname)s: %(message)s",
         level=logging.DEBUG if args.verbose else logging.INFO)
+
+    if args.verbose:
+        _stbt.logging._debug_level = 1  # pylint:disable=protected-access
 
     signal.signal(signal.SIGTERM, lambda _signo, _stack_frame: sys.exit(0))
 

--- a/stbt_control_relay.py
+++ b/stbt_control_relay.py
@@ -100,7 +100,7 @@ def main(argv):
                 elif action == b"SEND_STOP":
                     control.keyup(key)
             except Exception as e:  # pylint: disable=broad-except
-                logging.error("Error pressing key %r: %s", key, e,
+                logging.error("Error pressing or releasing key %r: %s", key, e,
                               exc_info=True)
                 send_response(conn, cmd, success=False, data=to_bytes(str(e)))
                 continue


### PR DESCRIPTION
To handle cases where the destination device disappears and then reappears with a different number.