### PR TITLE
stbt.FrameObject: Rename `_frame` member to `frame`

### DIFF
--- a/_stbt/frameobject.py
+++ b/_stbt/frameobject.py
@@ -151,7 +151,7 @@ class FrameObject(with_metaclass(_FrameObjectMeta, object)):
       from the frame.
     * Inside each property, when you call an image-processing function (like
       `stbt.match` or `stbt.ocr`) you must specify the parameter
-      ``frame=self._frame``.
+      ``frame=self.frame``.
 
     The following behaviours are provided automatically by the FrameObject
     base class:
@@ -196,6 +196,7 @@ class FrameObject(with_metaclass(_FrameObjectMeta, object)):
             frame = get_frame()
         self.__frame_object_cache = {}
         self.__local = threading.local()
+        self.frame = frame
         self._frame = frame
 
     def __repr__(self):

--- a/_stbt/keyboard.py
+++ b/_stbt/keyboard.py
@@ -213,7 +213,7 @@ class Keyboard(object):
 
                 @property
                 def selection(self):
-                    m = stbt.match("keyboard-selection.png", frame=self._frame)
+                    m = stbt.match("keyboard-selection.png", frame=self.frame)
                     if not m:
                         return stbt.Keyboard.Selection(None, None)
                     try:

--- a/stbt_core/pylint_plugin.py
+++ b/stbt_core/pylint_plugin.py
@@ -48,17 +48,17 @@ class StbtChecker(BaseChecker):
                   '(such as a function or a lambda expression).'),
         'E7004': ('"%s" missing "frame" argument',
                   'stbt-frame-object-missing-frame',
-                  'FrameObject properties must always provide "self._frame" as '
+                  'FrameObject properties must always provide "self.frame" as '
                   'the "frame" parameter to functions such as "stbt.match".'),
         'E7005': ('Image "%s" not committed to git',
                   'stbt-uncommitted-image',
                   'The image path given to "stbt.match" '
                   '(and similar functions) exists on disk, '
                   "but isn't committed to git."),
-        'E7006': ('FrameObject properties must use "self._frame", not '
+        'E7006': ('FrameObject properties must use "self.frame", not '
                   '"get_frame()"',
                   'stbt-frame-object-get-frame',
-                  'FrameObject properties must use "self._frame", not '
+                  'FrameObject properties must use "self.frame", not '
                   '"stbt.get_frame()".'),
         'E7007': ('FrameObject properties must not use "%s"',
                   'stbt-frame-object-property-press',

--- a/stbt_lint.py
+++ b/stbt_lint.py
@@ -16,11 +16,11 @@
   use "assert").
 * E7003: The argument given to "wait_until" must be a callable (such as
   a function or lambda expression).
-* E7004: FrameObject properties must always provide "self._frame" as the
+* E7004: FrameObject properties must always provide "self.frame" as the
   "frame" parameter to functions such as "stbt.match".
 * E7005: The image path given to "stbt.match" (and similar functions)
   exists on disk, but isn't committed to git.
-* E7006: FrameObject properties must use "self._frame", not
+* E7006: FrameObject properties must use "self.frame", not
   "stbt.get_frame()".
 * E7007: FrameObject properties must not have side-effects that change
   the state of the device-under-test by calling "stbt.press()" or

--- a/tests/test-stbt-lint.sh
+++ b/tests/test-stbt-lint.sh
@@ -240,16 +240,16 @@ test_that_stbt_lint_checks_frameobjects() {
 	class Good(stbt.FrameObject):
 	    @property
 	    def is_visible(self):
-	        return find_boxes(self._frame) and Button(self._frame)
+	        return find_boxes(self.frame) and Button(self.frame)
 	
 	    @property
 	    def property1(self):
-	        return bool(stbt.match("videotestsrc-redblue.png", self._frame))
+	        return bool(stbt.match("videotestsrc-redblue.png", self.frame))
 	
 	    @property
 	    def property2(self):
 	        return bool(stbt.match("videotestsrc-redblue.png",
-	                               frame=self._frame))
+	                               frame=self.frame))
 	
 	    def not_a_property(self):
 	        if not bool(stbt.match("videotestsrc-redblue.png")):
@@ -273,9 +273,9 @@ test_that_stbt_lint_checks_frameobjects() {
 	E: 24,15: "stbt.ocr()" missing "frame" argument (stbt-frame-object-missing-frame)
 	E: 28,15: FrameObject properties must not use "stbt.press_and_wait" (stbt-frame-object-property-press)
 	E: 29, 8: FrameObject properties must not use "stbt.press" (stbt-frame-object-property-press)
-	E: 30,12: FrameObject properties must use "self._frame", not "get_frame()" (stbt-frame-object-get-frame)
-	E: 34,38: FrameObject properties must use "self._frame", not "get_frame()" (stbt-frame-object-get-frame)
-	E: 36,32: FrameObject properties must use "self._frame", not "get_frame()" (stbt-frame-object-get-frame)
+	E: 30,12: FrameObject properties must use "self.frame", not "get_frame()" (stbt-frame-object-get-frame)
+	E: 34,38: FrameObject properties must use "self.frame", not "get_frame()" (stbt-frame-object-get-frame)
+	E: 36,32: FrameObject properties must use "self.frame", not "get_frame()" (stbt-frame-object-get-frame)
 	EOF
     assert_lint_log < expected.log
 

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -367,8 +367,8 @@ test_that_frames_are_read_only() {
 	    pass
 	f = F()
 	try:
-	    f._frame[0,0,0] = 0
-	    assert False, "stbt.FrameObject._frame is writeable"
+	    f.frame[0,0,0] = 0
+	    assert False, "stbt.FrameObject.frame is writeable"
 	except (ValueError, RuntimeError):
 	    pass
 	

--- a/tests/test_frameobject.py
+++ b/tests/test_frameobject.py
@@ -111,15 +111,15 @@ class OrderedFrameObject(stbt.FrameObject):
 
     @property
     def size(self):
-        return self._frame.shape[0] * self._frame.shape[1]
+        return self.frame.shape[0] * self.frame.shape[1]
 
     @property
     def color(self):
-        if self._frame[0, 0, 0] == 255:
+        if self.frame[0, 0, 0] == 255:
             return "blue"
-        elif self._frame[0, 0, 1] == 255:
+        elif self.frame[0, 0, 1] == 255:
             return "green"
-        elif self._frame[0, 0, 2] == 255:
+        elif self.frame[0, 0, 2] == 255:
             return "red"
         else:
             return "grey?"
@@ -352,7 +352,7 @@ class Dialog(stbt.FrameObject):
     @property
     def title(self):
         """
-        The base class provides a ``self._frame`` member. Here we're using
+        The base class provides a ``self.frame`` member. Here we're using
         `stbt.ocr` to extract the dialog's title text from this frame. This is
         the basic form that many Frame Object properties will take.
 
@@ -371,13 +371,13 @@ class Dialog(stbt.FrameObject):
         only need to update the implementation of ``Dialog.title``; you won't
         need to change any of your testcases.
 
-        When defining Frame Objects you must take care to pass ``self._frame``
+        When defining Frame Objects you must take care to pass ``self.frame``
         into every call to an image processing function (like our ``title``
         property does when it calls ``ocr``, above). Otherwise the return
         values won't correspond to the frame you were expecting.
         """
         return stbt.ocr(region=stbt.Region(396, 249, 500, 50),
-                        frame=self._frame)
+                        frame=self.frame)
 
     @property
     def message(self):
@@ -392,7 +392,7 @@ class Dialog(stbt.FrameObject):
         right_of_info = stbt.Region(
             x=self._info.region.right, y=self._info.region.y,
             width=390, height=self._info.region.height)
-        return stbt.ocr(region=right_of_info, frame=self._frame) \
+        return stbt.ocr(region=right_of_info, frame=self.frame) \
                    .replace('\n', ' ')
 
     @property
@@ -408,4 +408,4 @@ class Dialog(stbt.FrameObject):
         You wouldn't want this to be a public property because it returns a
         `MatchResult` which includes the entire frame passed into `match`.
         """
-        return stbt.match('tests/info.png', frame=self._frame)
+        return stbt.match('tests/info.png', frame=self.frame)


### PR DESCRIPTION
Because I'm tired of writing `# pylint:disable=protected-access` all over the place. Surely it's not that uncommon or magical for a base class to provide members of its own.

We still keep `_frame` as an alias for backward compatibility.