### PR TITLE
stbt.Frame, stbt.Image: Allow indexing by a stbt.Region 

### DIFF
--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -145,10 +145,11 @@ def crop(frame, region):
       of the source frame. This is a view onto the original data, so if you
       want to modify the cropped image call its ``copy()`` method first.
     """
-    if not _image_region(frame).contains(region):
-        raise ValueError("frame with dimensions %r doesn't contain %r"
-                         % (frame.shape, region))
-    return frame[region.y:region.bottom, region.x:region.right]
+    r = Region.intersect(region, _image_region(frame))
+    if r is None:
+        raise ValueError("%r is outside of frame dimensions %ix%i"
+                         % (region, frame.shape[1], frame.shape[0]))
+    return frame[r.y:r.bottom, r.x:r.right]
 
 
 def _image_region(image):

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -48,6 +48,12 @@ class Frame(numpy.ndarray):
         self.time = getattr(obj, 'time', None)  # pylint: disable=attribute-defined-outside-init
         self._draw_sink = getattr(obj, '_draw_sink', None)  # pylint: disable=attribute-defined-outside-init
 
+    def __getitem__(self, key):
+        if isinstance(key, Region):
+            return crop(self, key)
+        else:
+            return super(Frame, self).__getitem__(key)
+
     def __repr__(self):
         if len(self.shape) == 3:
             dimensions = "%dx%dx%d" % (
@@ -109,6 +115,12 @@ class Image(numpy.ndarray):
         self.filename = getattr(obj, "filename", None)
         self.relative_filename = getattr(obj, "relative_filename", None)
         self.absolute_filename = getattr(obj, "absolute_filename", None)
+
+    def __getitem__(self, key):
+        if isinstance(key, Region):
+            return crop(self, key)
+        else:
+            return super(Image, self).__getitem__(key)
 
     def __repr__(self):
         if len(self.shape) == 3:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -101,16 +101,27 @@ def test_crop():
 
     # It's a view onto the same memory:
     assert cropped[0, 0, 0] == img[672, 1045, 0]
+    assert img[672, 1045, 0] != 0
     cropped[0, 0, 0] = 0
-    assert cropped[0, 0, 0] == img[672, 1045, 0]
+    assert img[672, 1045, 0] == 0
 
     assert img.filename == "action-panel.png"
     assert cropped.filename == img.filename
 
-    # Region must be inside the frame (unfortunately this means that you can't
-    # use stbt.Region.ALL):
+    # Region is clipped to the frame boundaries:
+    assert numpy.array_equal(
+        stbt.crop(img, stbt.Region(x=1045, y=672, right=1280, bottom=720)),
+        stbt.crop(img, stbt.Region(x=1045, y=672, right=1281, bottom=721)))
+    assert numpy.array_equal(
+        stbt.crop(img, stbt.Region(x=0, y=0, right=10, bottom=10)),
+        stbt.crop(img, stbt.Region(x=float("-inf"), y=float("-inf"),
+                                   right=10, bottom=10)))
+
+    # But a region entirely outside the frame is not allowed:
     with pytest.raises(ValueError):
-        stbt.crop(img, stbt.Region(x=1045, y=672, right=1281, bottom=721))
+        stbt.crop(img, None)
+    with pytest.raises(ValueError):
+        stbt.crop(img, stbt.Region(x=-10, y=-10, right=0, bottom=0))
 
 
 def test_region_intersect():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -50,6 +50,15 @@ def test_that_slicing_a_Frame_is_still_a_Frame():
     assert f4.time == 1234
 
 
+@pytest.mark.parametrize("C", [stbt.Frame, stbt.Image])
+def test_slicing_a_frame_by_region(C):
+    f = C(numpy.zeros((720, 1280, 3), dtype=numpy.uint8))
+    f[5:10, 5:10] = 1
+
+    r = stbt.Region(x=8, y=2, right=12, bottom=15)
+    assert numpy.array_equal(f[r], f[2:15, 8:12])
+
+
 def test_that_load_image_looks_in_callers_directory():
     # See also the test with the same name in
     # ./subdirectory/test_load_image_from_subdirectory.py


### PR DESCRIPTION
> stbt.Frame, stbt.Image: Allow indexing by a stbt.Region 

This sounds convenient but it might not be worth the confusion because you can't do it with a native numpy array (for example after calling `cv2.cvtColor` or any other image processing). On the other hand, do we really expect user code to be using cv2 / numpy directly?

> stbt.crop: Implicitly crop at edge of frame, instead of raising

I think this will be worth merging, at least.