### PR TITLE
WIP stbt.Keyboard and stbt.press_and_wait: `mask` accepts a Region

### DIFF
--- a/_stbt/keyboard.py
+++ b/_stbt/keyboard.py
@@ -70,8 +70,8 @@ class Keyboard(object):
         `add_transition`, `add_edgelist`, and `add_grid` to build the model of
         the keyboard.
 
-    :type mask: str or `numpy.ndarray`
-    :param str mask:
+    :type mask: str or `numpy.ndarray` or `stbt.Region`
+    :param mask:
         A mask to use when calling `stbt.press_and_wait` to determine when the
         current selection has finished moving. If the search page has a
         blinking cursor you need to mask out the region where the cursor can
@@ -203,7 +203,7 @@ class Keyboard(object):
         self.modes = set()
 
         self.mask = None
-        if isinstance(mask, numpy.ndarray):
+        if isinstance(mask, (numpy.ndarray, Region)):
             self.mask = mask
         elif mask:
             self.mask = load_image(mask)

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -46,10 +46,11 @@ def press_and_wait(
     :param stbt.Region region: Only look at the specified region of the video
         frame.
 
-    :param str mask: The filename of a black & white image that specifies which
+    :param mask: The filename of a black & white image that specifies which
         part of the video frame to look at. White pixels select the area to
         analyse; black pixels select the area to ignore. You can't specify
         ``region`` and ``mask`` at the same time.
+    :type mask: str or `stbt.Image` or `stbt.Region`
 
     :param timeout_secs: A timeout in seconds. This function will return a
         falsey value if the transition didn't complete within this number of


### PR DESCRIPTION
TODO:

- Implement it.
- Other functions probably need this too.
- Sometimes we want a mask with 1 channel, sometimes with 3? Depends on
  the function, e.g. is it operating on greyscale or not.