### PR TITLE
stbt.press_and_wait: Add min_size parameter

### DIFF
--- a/_stbt/diff.py
+++ b/_stbt/diff.py
@@ -77,16 +77,14 @@ class MotionDiff(FrameDiffer):
         _, thresholded = cv2.threshold(
             absdiff, int((1 - self.noise_threshold) * 255), 255,
             cv2.THRESH_BINARY)
-        eroded = cv2.erode(
-            thresholded,
+        eroded = cv2.morphologyEx(
+            thresholded, cv2.MORPH_OPEN,
             cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (3, 3)))
         imglog.imwrite("absdiff_threshold", thresholded)
         imglog.imwrite("absdiff_threshold_erode", eroded)
 
         out_region = pixel_bounding_box(eroded)
         if out_region:
-            # Undo cv2.erode above:
-            out_region = out_region.extend(x=-1, y=-1)
             # Undo crop:
             out_region = out_region.translate(self.region)
 

--- a/_stbt/diff.py
+++ b/_stbt/diff.py
@@ -99,7 +99,7 @@ class MotionDiff(FrameDiffer):
 
         result = MotionResult(getattr(frame, "time", None), motion,
                               out_region, frame)
-        _log_motion_image_debug(imglog, result)
+        imglog.html(MOTION_HTML, result=result)
         return result
 
 
@@ -140,39 +140,33 @@ class MotionResult(object):
                 self.motion, self.region, _frame_repr(self.frame)))
 
 
-def _log_motion_image_debug(imglog, result):
-    if not imglog.enabled:
-        return
+MOTION_HTML = u"""\
+    <h4>
+      detect_motion:
+      {{ "Found" if result.motion else "Didn't find" }} motion
+    </h4>
 
-    template = u"""\
-        <h4>
-          detect_motion:
-          {{ "Found" if result.motion else "Didn't find" }} motion
-        </h4>
+    {{ annotated_image(result) }}
 
-        {{ annotated_image(result) }}
+    <h5>ROI Gray:</h5>
+    <img src="gray.png" />
 
-        <h5>ROI Gray:</h5>
-        <img src="gray.png" />
+    <h5>Previous frame ROI Gray:</h5>
+    <img src="previous_frame_gray.png" />
 
-        <h5>Previous frame ROI Gray:</h5>
-        <img src="previous_frame_gray.png" />
+    <h5>Absolute difference:</h5>
+    <img src="absdiff.png" />
 
-        <h5>Absolute difference:</h5>
-        <img src="absdiff.png" />
+    {% if "mask" in images %}
+    <h5>Mask:</h5>
+    <img src="mask.png" />
+    <h5>Absolute difference – masked:</h5>
+    <img src="absdiff_masked.png" />
+    {% endif %}
 
-        {% if "mask" in images %}
-        <h5>Mask:</h5>
-        <img src="mask.png" />
-        <h5>Absolute difference – masked:</h5>
-        <img src="absdiff_masked.png" />
-        {% endif %}
+    <h5>Threshold (noise_threshold={{noise_threshold}}):</h5>
+    <img src="absdiff_threshold.png" />
 
-        <h5>Threshold (noise_threshold={{noise_threshold}}):</h5>
-        <img src="absdiff_threshold.png" />
-
-        <h5>Eroded:</h5>
-        <img src="absdiff_threshold_erode.png" />
-    """
-
-    imglog.html(template, result=result)
+    <h5>Eroded:</h5>
+    <img src="absdiff_threshold_erode.png" />
+"""

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -54,7 +54,7 @@ class Frame(numpy.ndarray):
                 self.shape[1], self.shape[0], self.shape[2])
         else:
             dimensions = "%dx%d" % (self.shape[1], self.shape[0])
-        return "<stbt.Frame(time=%s, dimensions=%s)>" % (
+        return "<Frame(time=%s, dimensions=%s)>" % (
             "None" if self.time is None else "%.3f" % self.time,
             dimensions)
 
@@ -116,7 +116,7 @@ class Image(numpy.ndarray):
                 self.shape[1], self.shape[0], self.shape[2])
         else:
             dimensions = "%dx%d" % (self.shape[1], self.shape[0])
-        return "<stbt.Image(filename=%r, dimensions=%s)>" % (
+        return "<Image(filename=%r, dimensions=%s)>" % (
             self.filename, dimensions)
 
 

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -316,8 +316,8 @@ def pixel_bounding_box(img):
         indices = numpy.where(flat)[0]
         if len(indices) == 0:
             return None
-        out[axis] = indices[0]
-        out[axis + 2] = indices[-1] + 1
+        out[axis] = int(indices[0])
+        out[axis + 2] = int(indices[-1] + 1)
 
     return Region.from_extents(*out)
 

--- a/_stbt/motion.py
+++ b/_stbt/motion.py
@@ -86,7 +86,7 @@ def detect_motion(timeout_secs=10, noise_threshold=None, mask=None,
     except StopIteration:
         return
 
-    differ = MotionDiff(frame, region, mask, noise_threshold)
+    differ = MotionDiff(frame, region, mask, noise_threshold=noise_threshold)
     for frame in frames:
         result = differ.diff(frame)
         draw_on(frame, result, label="detect_motion()")

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -42,12 +42,12 @@ def test_that_matchresult_image_matches_template_passed_to_match():
 
 
 def test_that_matchresult_str_image_matches_template_passed_to_match():
-    assert re.search(r"image=<stbt.Image\(filename=u?'black.png'",
+    assert re.search(r"image=<Image\(filename=u?'black.png'",
                      str(stbt.match("black.png", frame=black())))
 
 
 def test_that_matchresult_str_image_matches_template_passed_to_match_custom():
-    assert "image=<stbt.Image(filename=None, dimensions=30x30x3)>" in str(
+    assert "image=<Image(filename=None, dimensions=30x30x3)>" in str(
         stbt.match(black(30, 30), frame=black()))
 
 

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -21,7 +21,7 @@ def test_motionresult_repr():
         == ("MotionResult("
             "time=1466002032.336, motion=True, "
             "region=Region(x=321, y=32, right=334, bottom=42), "
-            "frame=<stbt.Frame(time=1466002032.336, dimensions=1280x720x3)>)")
+            "frame=<Frame(time=1466002032.336, dimensions=1280x720x3)>)")
 
 
 def test_wait_for_motion_half_motion_str_2of4():

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -294,7 +294,7 @@ def test_match_text_stringify_result():
 
     assert re.match(
         r"TextMatchResult\(time=None, match=True, region=Region\(.*\), "
-        r"frame=<stbt.Image\(filename=u?'ocr/menu.png', "
+        r"frame=<Image\(filename=u?'ocr/menu.png', "
         r"dimensions=1280x720x3\)>, text=u?'Onion Bhaji'\)",
         str(result))
 


### PR DESCRIPTION
When testing an Xfinity set-top-box, I think it was, pressing OK on a button caused that button to "blip" briefly for a single frame or 2, then followed by no motion, before actually starting the transition to the new page. Sometimes that period of no motion was longer than 1 second, so it would fool `press_and_wait` into thinking the transition had completed before it had even started.

Setting `stable_secs` to a very large number isn't ideal, as it would slow down all test-runs for the sake of handling this intermittent behaviour.

TODO:

- [x] Implement it.
- [x] Unit tests.