### PR TITLE
stbt.crop: Implicitly crop at edge of frame, instead of raising

### DIFF
--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -145,10 +145,11 @@ def crop(frame, region):
       of the source frame. This is a view onto the original data, so if you
       want to modify the cropped image call its ``copy()`` method first.
     """
-    if not _image_region(frame).contains(region):
-        raise ValueError("frame with dimensions %r doesn't contain %r"
-                         % (frame.shape, region))
-    return frame[region.y:region.bottom, region.x:region.right]
+    r = Region.intersect(region, _image_region(frame))
+    if r is None:
+        raise ValueError("%r is outside of frame dimensions %ix%i"
+                         % (region, frame.shape[1], frame.shape[0]))
+    return frame[r.y:r.bottom, r.x:r.right]
 
 
 def _image_region(image):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -101,16 +101,27 @@ def test_crop():
 
     # It's a view onto the same memory:
     assert cropped[0, 0, 0] == img[672, 1045, 0]
+    assert img[672, 1045, 0] != 0
     cropped[0, 0, 0] = 0
-    assert cropped[0, 0, 0] == img[672, 1045, 0]
+    assert img[672, 1045, 0] == 0
 
     assert img.filename == "action-panel.png"
     assert cropped.filename == img.filename
 
-    # Region must be inside the frame (unfortunately this means that you can't
-    # use stbt.Region.ALL):
+    # Region is clipped to the frame boundaries:
+    assert numpy.array_equal(
+        stbt.crop(img, stbt.Region(x=1045, y=672, right=1280, bottom=720)),
+        stbt.crop(img, stbt.Region(x=1045, y=672, right=1281, bottom=721)))
+    assert numpy.array_equal(
+        stbt.crop(img, stbt.Region(x=0, y=0, right=10, bottom=10)),
+        stbt.crop(img, stbt.Region(x=float("-inf"), y=float("-inf"),
+                                   right=10, bottom=10)))
+
+    # But a region entirely outside the frame is not allowed:
     with pytest.raises(ValueError):
-        stbt.crop(img, stbt.Region(x=1045, y=672, right=1281, bottom=721))
+        stbt.crop(img, None)
+    with pytest.raises(ValueError):
+        stbt.crop(img, stbt.Region(x=-10, y=-10, right=0, bottom=0))
 
 
 def test_region_intersect():


### PR DESCRIPTION
This seems like more useful behaviour. We can call `crop` with `Region.ALL`, or with regions from `above/below/right_of/left_of` which might have an infinite height/width.

We do still raise for an empty region. I considered returning an empty slice, but what purpose would that serve? And at what position do we return it -- `frame[0:0, 0:0]`? Note that the previous implementation would also raise: `r.contains(None)` => False.