### PR TITLE
stbt.Keyboard: More robust for slow/buggy keyboards

### DIFF
--- a/_stbt/android.py
+++ b/_stbt/android.py
@@ -154,7 +154,7 @@ class AdbDevice(object):
 
         if _config is None:
             import _stbt.config
-            _config = _stbt.config._config_init()  # pylint:disable=protected-access
+            _config = _stbt.config._config_init()
 
         self.adb_server = adb_server or _config.get("android", "adb_server",
                                                     fallback=None)

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -678,7 +678,7 @@ class Display(object):
         frame.flags.writeable = False
 
         # See also: logging.draw_on
-        frame._draw_sink = weakref.ref(self._sink_pipeline)  # pylint: disable=protected-access
+        frame._draw_sink = weakref.ref(self._sink_pipeline)
         self.tell_user_thread(frame)
         self._sink_pipeline.on_sample(sample)
         return Gst.FlowReturn.OK

--- a/_stbt/frameobject.py
+++ b/_stbt/frameobject.py
@@ -55,7 +55,6 @@ def for_object_repository(cls=None):
 def _memoize_property_fn(fn):
     @functools.wraps(fn)
     def inner(self):
-        # pylint: disable=protected-access
         if fn not in self._FrameObject__frame_object_cache:
             self._FrameObject__frame_object_cache[fn] = fn(self)
         return self._FrameObject__frame_object_cache[fn]
@@ -65,7 +64,6 @@ def _memoize_property_fn(fn):
 def _mark_in_is_visible(fn):
     @functools.wraps(fn)
     def inner(self):
-        # pylint: disable=protected-access
         try:
             self._FrameObject__local.in_is_visible += 1
         except AttributeError:
@@ -80,7 +78,6 @@ def _mark_in_is_visible(fn):
 def _noneify_property_fn(fn):
     @functools.wraps(fn)
     def inner(self):
-        # pylint: disable=protected-access
         if (getattr(self._FrameObject__local, "in_is_visible", 0) or
                 self.is_visible):
             return fn(self)
@@ -243,7 +240,6 @@ class FrameObject(with_metaclass(_FrameObjectMeta, object)):
         return self.__cmp__(other) >= 0
 
     def __cmp__(self, other):
-        # pylint: disable=protected-access
         if isinstance(other, self.__class__):
             for s, o in zip_longest(self._iter_fields(), other._iter_fields()):
                 v = cmp(s[1], o[1])

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -40,7 +40,7 @@ class Frame(numpy.ndarray):
             obj.time = array.time
         else:
             obj.time = time
-        obj._draw_sink = _draw_sink or (i and array._draw_sink) or None  # pylint: disable=protected-access
+        obj._draw_sink = _draw_sink or (i and array._draw_sink) or None
         return obj
 
     def __array_finalize__(self, obj):

--- a/_stbt/keyboard.py
+++ b/_stbt/keyboard.py
@@ -170,6 +170,7 @@ class Keyboard(object):
     * Tries to recover from missed or double keypresses. To disable this
       behaviour specify ``retries=0`` when calling `enter_text` or
       `navigate_to`.
+    * Increased default ``navigate_timeout`` from 20 to 60 seconds.
 
     .. _Page Object: https://stb-tester.com/manual/object-repository#what-is-a-page-object
     .. _Directed Graph: https://en.wikipedia.org/wiki/Directed_graph
@@ -192,7 +193,7 @@ class Keyboard(object):
         region = attrib(default=None, type=Region)
         mode = attrib(default=None, type=text_type)
 
-    def __init__(self, graph=None, mask=None, navigate_timeout=20):
+    def __init__(self, graph=None, mask=None, navigate_timeout=60):
         from networkx import DiGraph
 
         if graph is not None:

--- a/_stbt/keyboard.py
+++ b/_stbt/keyboard.py
@@ -687,6 +687,14 @@ class Keyboard(object):
                 page = page.refresh()
                 assert page, "%s page isn't visible" % type(page).__name__
                 current = page.selection
+                if (current not in immediate_targets and
+                        not verify_every_keypress):
+                    # Wait a bit longer for selection to reach the target
+                    assert self.wait_for_transition_to_end(
+                        initial_frame=page._frame, stable_secs=2)
+                    page = page.refresh()
+                    assert page, "%s page isn't visible" % type(page).__name__
+                    current = page.selection
                 if current not in immediate_targets:
                     message = (
                         "Expected to see %s after pressing %s, but saw %r."
@@ -706,10 +714,16 @@ class Keyboard(object):
 
     def press_and_wait(self, key, timeout_secs=10, stable_secs=1):
         import stbt_core as stbt
-
         return stbt.press_and_wait(key, mask=self.mask,
                                    timeout_secs=timeout_secs,
                                    stable_secs=stable_secs)
+
+    def wait_for_transition_to_end(self, initial_frame=None, timeout_secs=10,
+                                   stable_secs=1):
+        import stbt_core as stbt
+        return stbt.wait_for_transition_to_end(initial_frame, mask=self.mask,
+                                               timeout_secs=timeout_secs,
+                                               stable_secs=stable_secs)
 
 
 def _minimal_query(query):

--- a/_stbt/keyboard.py
+++ b/_stbt/keyboard.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-"""Copyright 2019 Stb-tester.com Ltd."""
+"""Copyright 2019-2020 Stb-tester.com Ltd."""
 
 from __future__ import unicode_literals
 from __future__ import print_function
@@ -167,6 +167,9 @@ class Keyboard(object):
     * Moved private class ``Key`` (the type returned from `find_key`) to be a
       public API `stbt.Keyboard.Key`, so that you can use it in type
       annotations for your Page Object's `selection` property.
+    * Tries to recover from missed or double keypresses. To disable this
+      behaviour specify ``retries=0`` when calling `enter_text` or
+      `navigate_to`.
 
     .. _Page Object: https://stb-tester.com/manual/object-repository#what-is-a-page-object
     .. _Directed Graph: https://en.wikipedia.org/wiki/Directed_graph
@@ -574,7 +577,7 @@ class Keyboard(object):
             region=grid.region,
             data=_reshape_array(keys, cols=grid.cols, rows=grid.rows))
 
-    def enter_text(self, text, page, verify_every_keypress=False):
+    def enter_text(self, text, page, verify_every_keypress=False, retries=2):
         """Enter the specified text using the on-screen keyboard.
 
         :param str text: The text to enter. If your keyboard only supports a
@@ -604,6 +607,15 @@ class Keyboard(object):
             Set this to True to help debug your model if ``enter_text`` is
             behaving incorrectly.
 
+        :param int retries:
+            Number of recovery attempts if a keypress doesn't have the expected
+            effect according to the model. Allows recovering from missed
+            keypresses and double keypresses.
+
+        :returns: A new FrameObject instance of the same type as ``page``,
+            reflecting the device-under-test's new state after the keyboard
+            navigation completed.
+
         Typically your FrameObject will provide its own ``enter_text`` method,
         so your test scripts won't call this ``Keyboard`` class directly. See
         the :ref:`example above <keyboard-example>`.
@@ -616,7 +628,7 @@ class Keyboard(object):
 
         for letter in text:
             page = self.navigate_to({"text": letter},
-                                    page, verify_every_keypress)
+                                    page, verify_every_keypress, retries)
             self.press_and_wait("KEY_OK", stable_secs=0.5, timeout_secs=1)  # pylint:disable=stbt-unused-return-value
             page = page.refresh()
             log.debug("Keyboard: Entered %r; the selection is now on %r",
@@ -624,7 +636,7 @@ class Keyboard(object):
         log.info("Keyboard: Entered %r", text)
         return page
 
-    def navigate_to(self, target, page, verify_every_keypress=False):
+    def navigate_to(self, target, page, verify_every_keypress=False, retries=2):
         """Move the selection to the specified key.
 
         This won't press *KEY_OK* on the target; it only moves the selection
@@ -638,10 +650,11 @@ class Keyboard(object):
             convenience, a single string is treated as "name".
         :param stbt.FrameObject page: See `enter_text`.
         :param bool verify_every_keypress: See `enter_text`.
+        :param int retries: See `enter_text`.
 
         :returns: A new FrameObject instance of the same type as ``page``,
-            reflecting the device-under-test's new state after the navigation
-            completed.
+            reflecting the device-under-test's new state after the keyboard
+            navigation completed.
         """
 
         import stbt_core as stbt
@@ -668,18 +681,26 @@ class Keyboard(object):
                 for k, _ in keys[:-1]:
                     stbt.press(k)
                 keys = keys[-1:]  # only verify the last one
-            for key, possible_targets in keys:
+            for key, immediate_targets in keys:
                 assert self.press_and_wait(key, stable_secs=0.5)
                 page = page.refresh()
                 assert page, "%s page isn't visible" % type(page).__name__
                 current = page.selection
-                assert current in possible_targets, \
-                    "Expected to see %s after pressing %s, but saw %r" % (
-                        _join_with_commas(
-                            [repr(x) for x in sorted(possible_targets)],
+                if current not in immediate_targets:
+                    message = (
+                        "Expected to see %s after pressing %s, but saw %r."
+                        % (_join_with_commas(
+                            [repr(x) for x in sorted(immediate_targets)],
                             last_one=" or "),
-                        key,
-                        current)
+                           key,
+                           current))
+                    if retries == 0:
+                        assert False, message
+                    else:
+                        log.debug(message +
+                                  (" Retrying %d more times." % (retries,)))
+                        retries -= 1
+                        break  # to outer loop
         return page
 
     def press_and_wait(self, key, timeout_secs=10, stable_secs=1):

--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -891,7 +891,7 @@ def _log_match_image_debug(imglog):
     for i, result in enumerate(imglog.data["matches"]):
         imglog.imwrite(
             "match%d-source_with_match" % i, imglog.images["source"],
-            result.region, _Annotation.MATCHED if result._first_pass_matched  # pylint:disable=protected-access
+            result.region, _Annotation.MATCHED if result._first_pass_matched
             else _Annotation.NO_MATCH)
 
     imglog.imwrite(
@@ -1063,6 +1063,6 @@ def _log_match_image_debug(imglog):
         link=link,
         MatchMethod=MatchMethod,
         show_second_pass=any(
-            x._first_pass_matched for x in imglog.data["matches"]),  # pylint:disable=protected-access
+            x._first_pass_matched for x in imglog.data["matches"]),
         title=title,
     )

--- a/_stbt/pylint_plugin.py
+++ b/_stbt/pylint_plugin.py
@@ -138,7 +138,7 @@ class StbtChecker(BaseChecker):
 
         if isinstance(node.func, Attribute) and node.func.attrname == "refresh":
             for c in _infer(node.func.expr):
-                if _is_frameobject(c._proxied):  # pylint:disable=protected-access
+                if _is_frameobject(c._proxied):
                     if isinstance(node.parent, Expr):  # not an assignment
                         self.add_message('E7009', node=node,
                                          args=node.func.expr.as_string())

--- a/_stbt/stbt_run.py
+++ b/_stbt/stbt_run.py
@@ -21,10 +21,10 @@ def _save_screenshot(dut, result_dir, exception, save_jpg, save_png):
         return
 
     screenshot = getattr(exception, "screenshot", None)
-    if screenshot is None and dut._display:  # pylint: disable=protected-access
-        screenshot = dut._display.last_used_frame  # pylint: disable=protected-access
+    if screenshot is None and dut._display:
+        screenshot = dut._display.last_used_frame
     if screenshot is None:
-        screenshot = dut.get_frame()  # pylint: disable=protected-access
+        screenshot = dut.get_frame()
 
     if save_png:
         cv2.imwrite(os.path.join(result_dir, "screenshot.png"), screenshot)
@@ -143,7 +143,7 @@ if sys.version_info.major == 2:  # Python 2
             #
             # It's not thread-safe, but will only be called at the end of
             # execution:
-            traceback._some_str = to_bytes  # pylint: disable=protected-access
+            traceback._some_str = to_bytes
             traceback.print_exc(file=sys.stderr)
 
             if isinstance(e, (UITestFailure, AssertionError)):

--- a/extra/pylint.conf
+++ b/extra/pylint.conf
@@ -28,6 +28,7 @@ disable=
   no-else-return,
   no-init,
   no-self-use,
+  protected-access,
   singleton-comparison,
   too-few-public-methods,
   too-many-ancestors,

--- a/stbt_control_relay.py
+++ b/stbt_control_relay.py
@@ -64,7 +64,7 @@ def main(argv):
         level=logging.DEBUG if args.verbose else logging.INFO)
 
     if args.verbose:
-        _stbt.logging._debug_level = 1  # pylint:disable=protected-access
+        _stbt.logging._debug_level = 1
 
     signal.signal(signal.SIGTERM, lambda _signo, _stack_frame: sys.exit(0))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,4 +3,4 @@
 import _stbt.logging
 
 
-_stbt.logging._debug_level = 1  # pylint:disable=protected-access
+_stbt.logging._debug_level = 1

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -147,7 +147,7 @@ def temporary_config(config):
             yield
         finally:
             os.environ["STBT_CONFIG_FILE"] = original_env
-            _stbt.config._config_init(force=True)  # pylint:disable=protected-access
+            _stbt.config._config_init(force=True)
 
 
 @requires_tesseract
@@ -179,7 +179,6 @@ def test_that_setting_config_options_has_an_effect():
     r'\d\*.\d\*.\d\*.\d\*',
 ])
 def test_tesseract_user_patterns(patterns):
-    # pylint:disable=protected-access
     if _tesseract_version() < LooseVersion('3.03'):
         raise SkipTest('tesseract is too old')
 
@@ -423,7 +422,6 @@ def _test_that_cache_speeds_up_ocr():
     def ocr():
         return stbt.ocr(frame=frame)
 
-    # pylint:disable=protected-access
     _cache = imgproc_cache._cache
     imgproc_cache._cache = None
     uncached_result = ocr()

--- a/tests/test_stbt_debug.py
+++ b/tests/test_stbt_debug.py
@@ -17,7 +17,7 @@ from stbt_core import MatchParameters as mp
 def test_match_debug():
     # So that the output directory name doesn't depend on how many tests
     # were run before this one.
-    ImageLogger._frame_number = itertools.count(1)  # pylint:disable=protected-access
+    ImageLogger._frame_number = itertools.count(1)
 
     with scoped_curdir(), scoped_debug_level(2):
         # First pass gives no matches:
@@ -329,7 +329,7 @@ def test_match_debug():
 def test_motion_debug():
     # So that the output directory name doesn't depend on how many tests
     # were run before this one.
-    ImageLogger._frame_number = itertools.count(1)  # pylint:disable=protected-access
+    ImageLogger._frame_number = itertools.count(1)
 
     def fake_frames():
         for i, f in enumerate(["box-00001.png",
@@ -411,7 +411,7 @@ def test_motion_debug():
 def test_ocr_debug():
     # So that the output directory name doesn't depend on how many tests
     # were run before this one.
-    ImageLogger._frame_number = itertools.count(1)  # pylint:disable=protected-access
+    ImageLogger._frame_number = itertools.count(1)
 
     f = stbt.load_image("action-panel.png")
     r = stbt.Region(0, 370, right=1280, bottom=410)
@@ -475,7 +475,7 @@ def test_ocr_debug():
 def test_is_screen_black_debug():
     # So that the output directory name doesn't depend on how many tests
     # were run before this one.
-    ImageLogger._frame_number = itertools.count(1)  # pylint:disable=protected-access
+    ImageLogger._frame_number = itertools.count(1)
 
     f = stbt.load_image("videotestsrc-full-frame.png")
 


### PR DESCRIPTION
I was testing the Search keyboard on a Comcast Xfinity box. This has the keys in a single line A - Z so there can be a lot of keypresses to get to the next letter. When `verify_every_keypress=False`, the selection can settle on one of the intermediate letters for long enough to trick our `stable_secs=0.5`, causing the test to fail. After the test failed, the selection carried on moving and did reach the expected target.

I tried increasing stable_secs to 1. This made it fail less often, but it still happens sometimes. Setting `verify_every_keypress=True` fixes this problem but makes it intolerably slow. I don't want to increase stable_secs for every letter because this would slow it down unnecessarily in the usual, successful case.