### PR TITLE
MotionDiff: Take color information into account

### DIFF
--- a/_stbt/diff.py
+++ b/_stbt/diff.py
@@ -259,8 +259,7 @@ class GrayscaleDiff(FrameDiffer):
         imglog.imwrite("absdiff_threshold", thresholded)
         if self.kernel is not None:
             thresholded = cv2.morphologyEx(
-                thresholded, cv2.MORPH_OPEN,
-                cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (3, 3)))
+                thresholded, cv2.MORPH_OPEN, self.kernel)
             imglog.imwrite("absdiff_threshold_erode", thresholded)
 
         out_region = pixel_bounding_box(thresholded)

--- a/_stbt/diff.py
+++ b/_stbt/diff.py
@@ -14,6 +14,43 @@ from .logging import ddebug, ImageLogger
 from .types import Region
 
 
+class MotionResult(object):
+    """The result from `detect_motion` and `wait_for_motion`.
+
+    :ivar float time: The time at which the video-frame was captured, in
+        seconds since 1970-01-01T00:00Z. This timestamp can be compared with
+        system time (``time.time()``).
+
+    :ivar bool motion: True if motion was found. This is the same as evaluating
+        ``MotionResult`` as a bool. That is, ``if result:`` will behave the
+        same as ``if result.motion:``.
+
+    :ivar Region region: Bounding box where the motion was found, or ``None``
+        if no motion was found.
+
+    :ivar Frame frame: The video frame in which motion was (or wasn't) found.
+    """
+    _fields = ("time", "motion", "region", "frame")
+
+    def __init__(self, time, motion, region, frame):
+        self.time = time
+        self.motion = motion
+        self.region = region
+        self.frame = frame
+
+    def __bool__(self):
+        return self.motion
+
+    def __nonzero__(self):
+        return self.__bool__()
+
+    def __repr__(self):
+        return (
+            "MotionResult(time=%s, motion=%r, region=%r, frame=%s)" % (
+                "None" if self.time is None else "%.3f" % self.time,
+                self.motion, self.region, _frame_repr(self.frame)))
+
+
 class FrameDiffer(object):
     """Interface for different algorithms for diffing frames in a sequence.
 
@@ -119,43 +156,6 @@ class MotionDiff(FrameDiffer):
         ddebug(str(result))
         imglog.html(MOTION_HTML, result=result)
         return result
-
-
-class MotionResult(object):
-    """The result from `detect_motion` and `wait_for_motion`.
-
-    :ivar float time: The time at which the video-frame was captured, in
-        seconds since 1970-01-01T00:00Z. This timestamp can be compared with
-        system time (``time.time()``).
-
-    :ivar bool motion: True if motion was found. This is the same as evaluating
-        ``MotionResult`` as a bool. That is, ``if result:`` will behave the
-        same as ``if result.motion:``.
-
-    :ivar Region region: Bounding box where the motion was found, or ``None``
-        if no motion was found.
-
-    :ivar Frame frame: The video frame in which motion was (or wasn't) found.
-    """
-    _fields = ("time", "motion", "region", "frame")
-
-    def __init__(self, time, motion, region, frame):
-        self.time = time
-        self.motion = motion
-        self.region = region
-        self.frame = frame
-
-    def __bool__(self):
-        return self.motion
-
-    def __nonzero__(self):
-        return self.__bool__()
-
-    def __repr__(self):
-        return (
-            "MotionResult(time=%s, motion=%r, region=%r, frame=%s)" % (
-                "None" if self.time is None else "%.3f" % self.time,
-                self.motion, self.region, _frame_repr(self.frame)))
 
 
 MOTION_HTML = u"""\

--- a/_stbt/stbt.conf
+++ b/_stbt/stbt.conf
@@ -36,7 +36,7 @@ interval_secs = 3
 max_presses = 10
 
 [motion]
-noise_threshold=0.84
+threshold=25
 consecutive_frames=10/20
 
 [is_screen_black]

--- a/stbt_core/__init__.py
+++ b/stbt_core/__init__.py
@@ -24,6 +24,7 @@ from _stbt.config import (
     get_config)
 from _stbt.diff import (
     FrameDiffer,
+    GrayscaleDiff,
     MotionDiff,
     MotionResult)
 from _stbt.frameobject import (
@@ -97,6 +98,7 @@ __all__ = [to_native_str(x) for x in [
     "frames",
     "get_config",
     "get_frame",
+    "GrayscaleDiff",
     "Grid",
     "Image",
     "is_screen_black",

--- a/tests/stbt.conf
+++ b/tests/stbt.conf
@@ -34,7 +34,7 @@ interval_secs = 3
 max_presses = 10
 
 [motion]
-noise_threshold=0.84
+threshold=25
 consecutive_frames=10/20
 
 [is_screen_black]

--- a/tests/test-motion.sh
+++ b/tests/test-motion.sh
@@ -95,18 +95,18 @@ test_wait_for_motion_with_region_and_mask() {
     stbt run -v test.py
 }
 
-test_wait_for_motion_with_high_noisethreshold_reports_motion() {
+test_wait_for_motion_with_low_noisethreshold_reports_motion() {
     cat > test.py <<-EOF
 	from stbt_core import wait_for_motion
-	wait_for_motion(noise_threshold=1.0)
+	wait_for_motion(threshold=0)
 	EOF
     stbt run -v test.py
 }
 
-test_wait_for_motion_with_low_noisethreshold_does_not_report_motion() {
+test_wait_for_motion_with_high_noisethreshold_does_not_report_motion() {
     cat > test.py <<-EOF
 	from stbt_core import wait_for_motion
-	wait_for_motion(noise_threshold=0.0, timeout_secs=1)
+	wait_for_motion(noise_threshold=255, timeout_secs=1)
 	EOF
     ! stbt run -v test.py
 }


### PR DESCRIPTION
Previously, MotionDiff converts the 2 frames to grayscale before comparing them. This means that it doesn't catch text in 2 different colors, but with similar overall intensity. The new algorithm does a simple color distance calculation (consistent with `find_selection_from_background` and with OCR's `text_color` parameter) before doing the threshold.

Along with this, the parameter name has changed from `noise_threshold` to `threshold` and its range has changed from [1.0, 0.0] to [0, 255].

I have copied the old implementation as `GrayscaleDiff`. This allows existing users to upgrade to v33 while still keeping the old behaviour, by running the following code early, for example at the top level of `tests/__init__.py` (this is similar to what we did for `press_and_wait` when we changed its algorithm in v32):

    stbt.detect_motion.differ = stbt.GrayscaleDiff

TODO:

- [ ] Tests.
- [ ] Check debug html.
- [ ] Validate threshold with real-life use of `wait_for_motion`.