### PR TITLE
pip package: Make lxml and Jinja optional dependencies

### DIFF
--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -333,7 +333,6 @@ def match_text(text, frame=None, region=Region.ALL,
     | Added in v30: The ``engine`` parameter and support for Tesseract v4.
     | Added in v31: The ``char_whitelist`` parameter.
     """
-    import lxml.etree
     if frame is None:
         from stbt_core import get_frame
         frame = get_frame()
@@ -355,6 +354,7 @@ def match_text(text, frame=None, region=Region.ALL,
         hocr = None
         result = TextMatchResult(rts, False, None, frame, text)
     else:
+        import lxml.etree
         hocr = lxml.etree.fromstring(xml.encode('utf-8'))
         p = _hocr_find_phrase(hocr, to_unicode(text).split(), case_sensitive)
         if p:

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ This package doesn't bundle the Tesseract OCR engine, so `ocr()` and
 
 setuptools.setup(
     name="stbt_core",
-    version="32.0.1",
+    version="32.0.2",
     author="Stb-tester.com Ltd.",
     author_email="support@stb-tester.com",
     description="Automated GUI testing for Set-Top Boxes",
@@ -56,12 +56,14 @@ setuptools.setup(
     ],
     # I have only tested Python 2.7 & 3.6
     python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*",
+    extras_require={
+        "ocr": ["lxml==4.2"],
+        "debug": ["Jinja2==2.10.1"],
+    },
     install_requires=[
         "astroid==1.6.0",
         "attrs==20.2.0",
         "future==0.15.2",
-        "Jinja2==2.10.1",
-        "lxml==4.2",
         "networkx==1.11",
         "opencv-python~=3.2",
         "pylint==1.8.3",


### PR DESCRIPTION
Saves having to download and install `libxml2` with pip.  We usually
can't use ocr with pip installed package anyway as we can't express
a dependency on tesseract.