### PR TITLE
Fix importing stbt_core when libstbt.so isn't built/installed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,8 +67,8 @@ commands:
             rm -rf stbt_core _stbt &&
             python3 -m venv build_env &&
             source build_env/bin/activate &&
-            pip3 install pytest==4.6.9 pylint==2.4.4 astroid==2.3.3 &&
-            pip3 install dist/*.tar.gz &&
+            pip install pytest==4.6.9 pylint==2.4.4 astroid==2.3.3 &&
+            pip install dist/*.tar.gz &&
             make check-pythonpackage PYTEST=pytest
 
 workflows:

--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -27,13 +27,9 @@ from .imgutils import (crop, _frame_repr, _image_region, limit_time, load_image,
                        _validate_region)
 from .logging import (_Annotation, ddebug, debug, draw_on, get_debug_level,
                       ImageLogger)
+from .sqdiff import sqdiff
 from .types import Position, Region, UITestFailure
 from .utils import native_str, to_native_str
-
-try:
-    from .sqdiff import sqdiff
-except ImportError:
-    sqdiff = None
 
 
 class MatchMethod(enum.Enum):

--- a/tests/test-stbt-lint.sh
+++ b/tests/test-stbt-lint.sh
@@ -120,8 +120,8 @@ test_that_stbt_lint_reports_uncommitted_images() {
 test_pylint_plugin_on_itself() {
     # It should work on arbitrary python files, so that you can just enable it
     # as a pylint plugin across your entire project, not just for stbt scripts.
-    [ -f "$srcdir"/stbt/pylint_plugin.py ] || skip 'Running outside $srcdir'
-    $stbt_lint --errors-only "$srcdir"/stbt/pylint_plugin.py
+    [ -f "$srcdir"/stbt_core/pylint_plugin.py ] || skip 'Running outside $srcdir'
+    $stbt_lint --errors-only "$srcdir"/stbt_core/pylint_plugin.py
 }
 
 test_that_stbt_lint_checks_uses_of_stbt_return_values() {


### PR DESCRIPTION
In 0eb1f63 ("stbt.match: Make the sqdiff C optimisation optional") we catch ImportError when importing `_stbt.sqdiff`, so that we could publish a pure-python package to PyPI without having to worry about C compilation or binary wheels. However it seems that it never worked:

```
tests/test_match.py:17: in <module>
    import stbt_core as stbt
stbt_core/__init__.py:44: in <module>
    from _stbt.match import (
_stbt/match.py:34: in <module>
    from .sqdiff import sqdiff
_stbt/sqdiff.py:18: in <module>
    _libstbt = ctypes.CDLL(_find_file("libstbt.so"))
/usr/lib/python3.6/ctypes/__init__.py:348: in __init__
    self._handle = _dlopen(self._name, mode)
E   OSError: /home/drothlis/work/stb-tester.com/stb-tester/_stbt/libstbt.so: cannot open shared object file: No such file or directory
```

...which makes me wonder what exactly we are testing in the "python-package" CI job‽

- [x] Fix CI so that it fails.
- [ ] Catch OSError when trying to import `_stbt.sqdiff`.
