### PR TITLE
Pass regions and the inverse as mask= parameters

### DIFF
--- a/_stbt/black.py
+++ b/_stbt/black.py
@@ -11,7 +11,7 @@ https://github.com/stb-tester/stb-tester/blob/master/LICENSE for details).
 import cv2
 
 from .config import get_config
-from .imgutils import (crop, _frame_repr, load_image, pixel_bounding_box,
+from .imgutils import (crop, _frame_repr, load_mask, pixel_bounding_box,
                        _validate_region)
 from .logging import debug, ImageLogger
 from .types import Region
@@ -64,10 +64,9 @@ def is_screen_black(frame=None, mask=None, threshold=None, region=Region.ALL):
         from stbt_core import get_frame
         frame = get_frame()
 
-    if mask is not None:
-        mask = load_image(mask, color_channels=1)
-
     region = _validate_region(frame, region)
+    if mask is not None:
+        mask = load_mask(mask, shape=(region.height, region.width, 1))
 
     imglog = ImageLogger("is_screen_black", region=region, threshold=threshold)
     imglog.imwrite("source", frame)

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -388,37 +388,26 @@ def mask_out(mask):
         return ~load_image(mask, color_channels=(1, 3))  # pylint:disable=invalid-unary-operand-type
 
 
-def preload_mask(mask, color_channels=(1, 3)):
-    """load_mask requires a shape.  We may not know the shape, but still want
-    to load an image from disk to save from doing it later.  This function does
-    this.
-
-    This should be used by our internal functions, rather than test-scripts
-    """
-    if mask is None or isinstance(mask, (Region, NotRegion)):
-        return mask
-    elif isinstance(mask, (str, numpy.ndarray)):
-        return load_image(mask, color_channels=color_channels)
-    else:
-        raise TypeError("Don't know how to make mask from %r" % (mask,))
-
-
 def load_mask(mask, shape):
     """Used to load a mask from disk, or to convert it from a stbt.Region.
 
     This should be used by image processing functions, not by test-scripts
     """
-    mask = preload_mask(mask, color_channels=shape[2])
-    if isinstance(mask, numpy.ndarray):
-        if mask.shape != shape:
-            raise ValueError(
-                "Loaded mask %r has wrong shape: %r. Expected: %r" % (
-                    mask.relative_filename, mask.shape, shape))
-        return mask
-    elif isinstance(mask, Region):
+    if isinstance(mask, Region):
         return _to_ndarray_mask(mask, shape=shape)
     elif isinstance(mask, NotRegion):
         return _to_ndarray_mask(mask, shape=shape, invert=True)
+    elif isinstance(mask, (str, numpy.ndarray)):
+        if shape is None:
+            color_channels = (1, 3)
+        else:
+            color_channels = shape[2]
+        mask = load_image(mask, color_channels=color_channels)
+        if shape is not None and mask.shape != shape:
+            raise ValueError(
+                "Mask %r has wrong shape %r. Expected %r" % (
+                    mask.relative_filename, mask.shape, shape))
+        return mask
     else:
         raise TypeError("Don't know how to make mask from %r" % (mask,))
 

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -397,7 +397,7 @@ def preload_mask(mask, color_channels=(1, 3)):
     """
     if mask is None or isinstance(mask, (Region, NotRegion)):
         return mask
-    elif isinstance(mask, (str, unicode, numpy.ndarray)):
+    elif isinstance(mask, (str, numpy.ndarray)):
         return load_image(mask, color_channels=color_channels)
     else:
         raise TypeError("Don't know how to make mask from %r" % (mask,))

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -194,7 +194,7 @@ def _image_region(image):
     return Region(0, 0, s[1], s[0])
 
 
-def load_image(filename, flags=None, color_channels=None):
+def load_image(filename, flags=None, color_channels=None) -> Image:
     """Find & read an image from disk.
 
     If given a relative filename, this will search in the directory of the
@@ -385,7 +385,7 @@ def mask_out(mask):
     elif isinstance(mask, NotRegion):
         return mask.region
     else:
-        return ~load_image(mask, color_channels=(1, 3))
+        return ~load_image(mask, color_channels=(1, 3))  # pylint:disable=invalid-unary-operand-type
 
 
 def preload_mask(mask, color_channels=(1, 3)):

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -366,8 +366,8 @@ class NotRegion(namedtuple("NotRegion", "region")):
     parameter to our image processing functions.  Create instances of this type
     with:
 
-    >>> mask_out(stbt.Region(34, 433, right=44, bottom=444))
-    NotRegion(stbt.Region(34, 433, right=44, bottom=444))
+    >>> mask_out(Region(34, 433, right=44, bottom=444))
+    NotRegion(region=Region(x=34, y=433, right=44, bottom=444))
     """
     pass
 

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -393,6 +393,8 @@ def load_mask(mask, shape):
 
     This should be used by image processing functions, not by test-scripts
     """
+    if mask is None:
+        return None
     if isinstance(mask, Region):
         return _to_ndarray_mask(mask, shape=shape)
     elif isinstance(mask, NotRegion):

--- a/_stbt/keyboard.py
+++ b/_stbt/keyboard.py
@@ -7,7 +7,7 @@ from logging import getLogger
 
 from attr import attrs, attrib
 from _stbt.grid import Grid
-from _stbt.imgutils import preload_mask
+from _stbt.imgutils import load_mask
 from _stbt.transition import TransitionStatus
 from _stbt.types import Region
 
@@ -197,7 +197,7 @@ class Keyboard():
         self.G_ = None  # navigation without shift transitions that type text
         self.modes = set()
 
-        self.mask = preload_mask(mask)
+        self.mask = load_mask(mask, shape=None)
         self.navigate_timeout = navigate_timeout
 
         self.symmetrical_keys = {

--- a/_stbt/keyboard.py
+++ b/_stbt/keyboard.py
@@ -5,10 +5,9 @@ import re
 import time
 from logging import getLogger
 
-import numpy
 from attr import attrs, attrib
 from _stbt.grid import Grid
-from _stbt.imgutils import load_image
+from _stbt.imgutils import preload_mask
 from _stbt.transition import TransitionStatus
 from _stbt.types import Region
 
@@ -198,12 +197,7 @@ class Keyboard():
         self.G_ = None  # navigation without shift transitions that type text
         self.modes = set()
 
-        self.mask = None
-        if isinstance(mask, numpy.ndarray):
-            self.mask = mask
-        elif mask:
-            self.mask = load_image(mask, color_channels=1)
-
+        self.mask = preload_mask(mask)
         self.navigate_timeout = navigate_timeout
 
         self.symmetrical_keys = {

--- a/_stbt/motion.py
+++ b/_stbt/motion.py
@@ -4,7 +4,7 @@ from collections import deque
 
 from .config import ConfigurationError, get_config
 from .diff import MotionDiff
-from .imgutils import limit_time, load_image
+from .imgutils import limit_time
 from .logging import debug, draw_on
 from .types import Region, UITestFailure
 
@@ -70,8 +70,7 @@ def detect_motion(timeout_secs=10, noise_threshold=None, mask=None,
     debug("Searching for motion")
 
     if mask is not None:
-        mask = load_image(mask, color_channels=1)
-        debug("Using mask %s" % (mask.relative_filename or "<Image>"))
+        debug("Using mask %s" % (mask,))
 
     try:
         frame = next(frames)
@@ -149,8 +148,7 @@ def wait_for_motion(
         motion_frames, considered_frames))
 
     if mask is not None:
-        mask = load_image(mask, color_channels=1)
-        debug("Using mask %s" % (mask.relative_filename or "<Image>"))
+        debug("Using mask %s" % (mask or "<Image>",))
 
     matches = deque(maxlen=considered_frames)
     motion_count = 0
@@ -172,9 +170,7 @@ def wait_for_motion(
                            "should never be reached")
         last_frame = res.frame
 
-    raise MotionTimeout(last_frame,
-                        None if mask is None else mask.relative_filename,
-                        timeout_secs)
+    raise MotionTimeout(last_frame, mask, timeout_secs)
 
 
 class MotionTimeout(UITestFailure):

--- a/_stbt/motion.py
+++ b/_stbt/motion.py
@@ -4,7 +4,7 @@ from collections import deque
 
 from .config import ConfigurationError, get_config
 from .diff import MotionDiff
-from .imgutils import limit_time
+from .imgutils import limit_time, load_mask
 from .logging import debug, draw_on
 from .types import Region, UITestFailure
 
@@ -70,7 +70,8 @@ def detect_motion(timeout_secs=10, noise_threshold=None, mask=None,
     debug("Searching for motion")
 
     if mask is not None:
-        debug("Using mask %s" % (mask,))
+        mask = load_mask(mask, shape=None)
+        debug("Using mask %s" % (mask.relative_filename or "<Image>"))
 
     try:
         frame = next(frames)
@@ -148,7 +149,8 @@ def wait_for_motion(
         motion_frames, considered_frames))
 
     if mask is not None:
-        debug("Using mask %s" % (mask or "<Image>",))
+        mask = load_mask(mask, shape=None)
+        debug("Using mask %s" % (mask.relative_filename or "<Image>"))
 
     matches = deque(maxlen=considered_frames)
     motion_count = 0

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -23,7 +23,6 @@ from .imgutils import (
     crop,
     load_mask,
     pixel_bounding_box,
-    preload_mask,
     _validate_region)
 from .logging import ddebug, debug, draw_on
 from .types import Region
@@ -156,7 +155,7 @@ def wait_for_transition_to_end(
 class _Transition():
     def __init__(self, region, mask, timeout_secs, stable_secs, min_size, dut):
         self.region = region
-        self.mask = preload_mask(mask)
+        self.mask = load_mask(mask, shape=None)
 
         self.timeout_secs = timeout_secs
         self.stable_secs = stable_secs

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -19,7 +19,12 @@ import cv2
 import numpy
 
 from .diff import FrameDiffer, MotionDiff, MotionResult
-from .imgutils import crop, load_image, pixel_bounding_box
+from .imgutils import (
+    crop,
+    load_mask,
+    pixel_bounding_box,
+    preload_mask,
+    _validate_region)
 from .logging import ddebug, debug, draw_on
 from .types import Region
 
@@ -151,9 +156,7 @@ def wait_for_transition_to_end(
 class _Transition():
     def __init__(self, region, mask, timeout_secs, stable_secs, min_size, dut):
         self.region = region
-        self.mask = None
-        if mask is not None:
-            self.mask = load_image(mask, color_channels=1)
+        self.mask = preload_mask(mask)
 
         self.timeout_secs = timeout_secs
         self.stable_secs = stable_secs
@@ -241,10 +244,14 @@ class StrictDiff(FrameDiffer):
 
     def __init__(self, initial_frame, region=Region.ALL, mask=None,
                  min_size=None):
-        super().__init__(initial_frame, region, mask, min_size)
-        if self.mask is not None:
-            # We need 3 channels to match `frame`.
-            self.mask = cv2.cvtColor(self.mask, cv2.COLOR_GRAY2BGR)
+        self.prev_frame = initial_frame
+        self.region = _validate_region(self.prev_frame, region)
+        self.min_size = min_size
+
+        if mask is not None:
+            mask = load_mask(mask,
+                             shape=(self.region.height, self.region.width, 3))
+        self.mask = mask
 
     def diff(self, frame):
         absdiff = cv2.absdiff(crop(self.prev_frame, self.region),

--- a/extra/pylint.sh
+++ b/extra/pylint.sh
@@ -10,7 +10,7 @@
 
 ret=0
 
-if pep8 --version &>/dev/null; then
+if pycodestyle --version &>/dev/null; then
     # E124: closing bracket does not match visual indentation
     # E203: whitespace before ':'
     # E241: multiple spaces after ',' (because pylint does it)
@@ -23,9 +23,9 @@ if pep8 --version &>/dev/null; then
     # E741: do not use variables named ‘l’, ‘O’, or ‘I’
     # W291: trailing whitespace (because pylint does it)
     # W504: line break after binary operator
-    pep8 --ignore=E124,E203,E241,E305,E402,E501,E721,E722,E731,E741,W291,W504 "$@" || ret=1
+    pycodestyle --ignore=E124,E203,E241,E305,E402,E501,E721,E722,E731,E741,W291,W504 "$@" || ret=1
 else
-    echo "warning: pep8 not installed; skipping pep8 and only running pylint" >&2
+    echo "warning: pycodestyle not installed; skipping pycodestyle and only running pylint" >&2
 fi
 
 $PYLINT --version

--- a/stbt_core/__init__.py
+++ b/stbt_core/__init__.py
@@ -30,6 +30,7 @@ from _stbt.imgutils import (
     Frame,
     Image,
     load_image,
+    mask_out,
     save_frame)
 from _stbt.keyboard import (
     Keyboard)
@@ -98,6 +99,7 @@ __all__ = [
     "Keyboard",
     "last_keypress",
     "load_image",
+    "mask_out",
     "match",
     "match_all",
     "match_text",

--- a/tests/test-irnetbox.sh
+++ b/tests/test-irnetbox.sh
@@ -106,5 +106,6 @@ test_that_press_times_out_when_irnetbox_doesnt_reply() {
     ! stbt run -v \
         --control irnetbox:localhost:$irnetbox_port:1:"$testdir"/irnetbox.conf \
         test.py || fail "Expected 'press' to raise exception"
-    cat log | grep -q TimeoutError || fail "Didn't raise TimeoutError"
+    cat log | grep -Eq 'socket.timeout|TimeoutError' ||
+        fail "Didn't raise TimeoutError"
 }


### PR DESCRIPTION
This enables:

```python
    SPINNER = stbt.Region(34, 433, right=44, bottom=444)
    stbt.wait_for_motion(mask=mask_out(SPINNER))
```

There is an interesting overlap here with #624.  Conceptually `mask_out(Region.ALL)` is `Region.NONE`.

**TODO:**

- [ ] Tests for `load_mask`
- [ ] Tests for `preload_mask`
- Tests for passing `region and `mask_out(Region)` to
    - [ ] `is_screen_black`
    - [ ] `wait_for_motion`
    - [ ] `press_and_wait`
- [ ] Update documentation to say that we can pass a region
- [ ] Document `mask_out`
- [ ] Change `repr(NotRegion(r))` to read `mask_out(r)`?