### PR TITLE
TransitionResult: Add started/complete/stable properties

### DIFF
--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -76,9 +76,18 @@ def press_and_wait(
         * **key** (*str*) – The name of the key that was pressed.
         * **frame** (`stbt.Frame`) – If successful, the first video frame when
           the transition completed; if timed out, the last frame seen.
-        * **status** (`stbt.TransitionStatus`) – Either ``START_TIMEOUT``,
-          ``STABLE_TIMEOUT``, or ``COMPLETE``. If it's ``COMPLETE``, the whole
+        * **status** (`stbt.TransitionStatus`) – Either ``START_TIMEOUT`` (the
+          transition didn't start – nothing moved), ``STABLE_TIMEOUT`` (the
+          transition didn't end – movement didn't stop), or ``COMPLETE`` (the
+          transition started and then stopped). If it's ``COMPLETE``, the whole
           object will evaluate as true.
+        * **started** (*bool*) – The transition started (movement was seen
+          after the keypress). Implies that ``status`` is either ``COMPLETE``
+          or ``STABLE_TIMEOUT``.
+        * **complete** (*bool*) – The transition completed (movement started
+          and then stopped). Implies that ``status`` is ``COMPLETE``.
+        * **stable** (*bool*) – The screen is stable (no movement). Implies
+          ``complete or not started``.
         * **press_time** (*float*) – When the key-press completed.
         * **animation_start_time** (*float*) – When animation started after the
           key-press (or ``None`` if timed out).
@@ -353,6 +362,19 @@ class _TransitionResult():
         if self.end_time is None or self.animation_start_time is None:
             return None
         return self.end_time - self.animation_start_time
+
+    @property
+    def started(self):
+        return self.status != TransitionStatus.START_TIMEOUT
+
+    @property
+    def complete(self):
+        return self.status == TransitionStatus.COMPLETE
+
+    @property
+    def stable(self):
+        return self.status in (TransitionStatus.START_TIMEOUT,
+                               TransitionStatus.COMPLETE)
 
 
 class TransitionStatus(enum.Enum):

--- a/tests/test_transition.py
+++ b/tests/test_transition.py
@@ -6,7 +6,7 @@ import pytest
 from numpy import isclose
 
 import stbt_core as stbt
-from _stbt.transition import StrictDiff
+from _stbt.transition import StrictDiff, _TransitionResult
 
 
 class FakeDeviceUnderTest():
@@ -174,3 +174,17 @@ def test_that_strictdiff_ignores_a_few_scattered_small_differences():
     differ = StrictDiff(initial_frame=stbt.load_image("2px-different-1.png"),
                         region=stbt.Region.ALL, mask=None)
     assert not differ.diff(stbt.load_image("2px-different-2.png"))
+
+
+@pytest.mark.parametrize("status,          started,complete,stable", [
+    # pylint:disable=bad-whitespace
+    (stbt.TransitionStatus.START_TIMEOUT,  False,  False,   True),
+    (stbt.TransitionStatus.STABLE_TIMEOUT, True,   False,   False),
+    (stbt.TransitionStatus.COMPLETE,       True,   True,    True),
+])
+def test_transitionresult_properties(status, started, complete, stable):
+    t = _TransitionResult(key="KEY_OK", frame=None, status=status,
+                          press_time=0, animation_start_time=0, end_time=0)
+    assert t.started == started
+    assert t.complete == complete
+    assert t.stable == stable


### PR DESCRIPTION
This allows us to write:

    transition = stbt.press_and_wait(...)
    assert transition.stable

or even this:

    assert stbt.press_and_wait(...).stable

instead of this, which is cumbersome:

    assert transition.status != stbt.TransitionStatus.STABLE_TIMEOUT

Another useful example is:

    if not transition.started:        
        # reached the end of the menu
        ...

...to detect if we've reached the end of a menu because the keypress had no effect. `assert stbt.press_and_wait(...)` isn't suitable because it would fail due to START_TIMEOUT. For example see bc46fcc.

TODO:

- [x] Docstrings.
- [x] Tests.
- [ ] Is there a better name than `stable`? It means never started or started and then stabilised.