### PR TITLE
Pipeline: Fix error on `GST_ELEMENT_WARNING`

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -399,8 +399,9 @@ class SinkPipeline(object):
 
     def _on_warning(self, _bus, message):
         assert message.type == Gst.MessageType.WARNING
-        Gst.debug_bin_to_dot_file_with_ts(
-            self.sink_pipeline, Gst.DebugGraphDetails.ALL, "WARNING")
+        if self.sink_pipeline is not None:
+            Gst.debug_bin_to_dot_file_with_ts(
+                self.sink_pipeline, Gst.DebugGraphDetails.ALL, "WARNING")
         err, dbg = message.parse_warning()
         warn("%s: %s\n%s\n" % (err, err.message, dbg))
 
@@ -708,8 +709,10 @@ class Display(object):
 
     def on_warning(self, _bus, message):
         assert message.type == Gst.MessageType.WARNING
-        Gst.debug_bin_to_dot_file_with_ts(
-            self.source_pipeline, Gst.DebugGraphDetails.ALL, "WARNING")
+        pipeline = self.source_pipeline
+        if pipeline is not None:
+            Gst.debug_bin_to_dot_file_with_ts(
+                pipeline, Gst.DebugGraphDetails.ALL, "WARNING")
         err, dbg = message.parse_warning()
         warn("%s: %s\n%s\n" % (err, err.message, dbg))
 


### PR DESCRIPTION
Error was:

    Traceback (most recent call last):
      File "/usr/lib/python3/dist-packages/_stbt/core.py", line 1009, in on_warning
        self.source_pipeline, Gst.DebugGraphDetails.ALL, "WARNING")
    TypeError: Argument 0 does not allow None as a value