### PR TITLE
core: Don't restart source pipeline on EOS

### DIFF
--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -86,7 +86,7 @@ test_that_frames_doesnt_time_out() {
     [ $ret -eq $timedout ] || fail "Unexpected exit status '$ret'"
 }
 
-test_that_frames_raises_NoVideo() {
+test_that_frames_raises_NoVideo_on_underrun() {
     cat > test.py <<-EOF
 	import stbt_core as stbt
 	for _ in stbt.frames():
@@ -94,6 +94,19 @@ test_that_frames_raises_NoVideo() {
 	EOF
     stbt run -v \
         --source-pipeline "videotestsrc ! identity sleep-time=12000000" \
+        test.py &> stbt-run.log
+    grep NoVideo stbt-run.log ||
+        fail "'stbt.frames' didn't raise 'NoVideo' exception"
+}
+
+test_that_frames_raises_NoVideo_on_eos() {
+    cat > test.py <<-EOF
+	import stbt_core as stbt
+	for _ in stbt.frames():
+	    pass
+	EOF
+    stbt run -v \
+        --source-pipeline "videotestsrc num-buffers=1" \
         test.py &> stbt-run.log
     grep NoVideo stbt-run.log ||
         fail "'stbt.frames' didn't raise 'NoVideo' exception"


### PR DESCRIPTION
This behaviour was introduced to handle the VidiU's H.264 encoder restart (see commit 6b7ba0a "stbt.py: Handle VidiU H.264 encoder restart"). As far as we know, the only VidiU user (YouView) had some kind of repeater / HDMI doctor in between the STB and the VidiU, which provided a continuous signal even when the STB rebooted or changed mode, thus avoiding this behaviour from the VidiU.

I'm removing it because:

- It isn't used (as per the previous paragraph).
- It complicates the implementation.
- It obscures real problems with the source pipeline.
- It interacts poorly with the sink pipeline: the recorded video ends up corrupted, with wrong timestamps, or huge gaps, with lots of errors in the logs.

Now we ignore the EOS; `get_frame` will soon time out and raise `NoVideo`.