### PR TITLE
pip package: Make networkx an optional dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,6 @@ check-pythonpackage:
 	    tests/test_config.py \
 	    tests/test_core.py \
 	    tests/test_grid.py \
-	    tests/test_keyboard.py \
 	    tests/test_match.py \
 	    tests/test_motion.py \
 	    tests/test_transition.py && \

--- a/_stbt/keyboard.py
+++ b/_stbt/keyboard.py
@@ -11,7 +11,6 @@ import re
 import time
 from logging import getLogger
 
-import networkx as nx
 import numpy
 from attr import attrs, attrib
 from _stbt.grid import Grid
@@ -187,11 +186,13 @@ class Keyboard(object):
     '''
 
     def __init__(self, graph=None, mask=None, navigate_timeout=20):
+        from networkx import DiGraph
+
         if graph is not None:
             raise ValueError(
                 "The `graph` parameter of `stbt.Keyboard` constructor is "
                 "deprecated. See the API documentation for details.")
-        self.G = nx.DiGraph()
+        self.G = DiGraph()
         self.G_ = None  # navigation without shift transitions that type text
         self.modes = set()
 
@@ -691,13 +692,15 @@ def _minimal_query(query):
 
 
 def _keys_to_press(G, source, targets):
+    from networkx import shortest_path
+
     paths = sorted(
-        [nx.shortest_path(G, source=source, target=t, weight="weight")
+        [shortest_path(G, source=source, target=t, weight="weight")
          for t in targets],
         key=len)
     path = paths[0]
-    # nx.shortest_path(G, "A", "V") -> ["A", "H", "O", "V"]
-    # nx.shortest_path(G, "A", "A") -> ["A"]
+    # shortest_path(G, "A", "V") -> ["A", "H", "O", "V"]
+    # shortest_path(G, "A", "A") -> ["A"]
     if len(path) == 1:
         return
     for s, t in zip(path[:-1], path[1:]):
@@ -732,7 +735,9 @@ def _add_weight(G, source, key):
 
 
 def _strip_shift_transitions(G):
-    G_ = nx.DiGraph()
+    from networkx import DiGraph
+
+    G_ = DiGraph()
     for node in G.nodes():
         G_.add_node(node)
     for u, v, data in G.edges(data=True):

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ This package doesn't bundle the Tesseract OCR engine, so `ocr()` and
 
 setuptools.setup(
     name="stbt_core",
-    version="32.0.2",
+    version="33.0.0",
     author="Stb-tester.com Ltd.",
     author_email="support@stb-tester.com",
     description="Automated GUI testing for Set-Top Boxes",
@@ -59,12 +59,12 @@ setuptools.setup(
     extras_require={
         "ocr": ["lxml==4.2"],
         "debug": ["Jinja2==2.10.1"],
+        "keyboard": ["networkx==1.11"],
     },
     install_requires=[
         "astroid==1.6.0",
         "attrs==20.2.0",
         "future==0.15.2",
-        "networkx==1.11",
         "opencv-python~=3.2",
         "pylint==1.8.3",
     ],


### PR DESCRIPTION
I've had a little difficulty with it on Windows.  It's not necessary
for pylint to work as it's no-longer exposed in our APIs.