### PR TITLE
stbt.Image: Add `width` and `height` properties

### DIFF
--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -130,6 +130,14 @@ class Image(numpy.ndarray):
     def __str__(self):
         return repr(self)
 
+    @property
+    def width(self):
+        return self.shape[1]
+
+    @property
+    def height(self):
+        return self.shape[0]
+
 
 def _frame_repr(frame):
     if frame is None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -85,6 +85,8 @@ def test_load_image_with_numpy_array():
     assert img.filename is None
     assert img.relative_filename is None
     assert img.absolute_filename is None
+    assert img.width == 1280
+    assert img.height == 720
 
     a = numpy.zeros((720, 1280), dtype=numpy.uint8)
     b = numpy.zeros((720, 1280, 1), dtype=numpy.uint8)


### PR DESCRIPTION
Recently I had a reference image that I wanted to anchor to the left edge of the frame like this:

    image = stbt.load_image(...)
    stbt.match(image, region=stbt.Region(x=0, width=image.shape[1], ...))

...so that if I had to update the reference image in future I wouldn't have to update the Python code to match the new width.

By providing `width` and `height` properties, we don't have to expose the numpy details of `shape` and its unintuitive coordinate order.