### PR TITLE
stbt.Frame: Add `width` and `height` properties

### DIFF
--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -62,6 +62,14 @@ class Frame(numpy.ndarray):
     def __str__(self):
         return repr(self)
 
+    @property
+    def width(self):
+        return self.shape[1]
+
+    @property
+    def height(self):
+        return self.shape[0]
+
 
 class Image(numpy.ndarray):
     """An image, possibly loaded from disk.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -31,23 +31,34 @@ from stbt_core import wait_until
 def test_that_slicing_a_Frame_is_still_a_Frame():
     f = stbt.Frame(numpy.zeros((720, 1280, 3), dtype=numpy.uint8),
                    time=1234)
+    assert f.time == 1234
+    assert f.width == 1280
+    assert f.height == 720
 
     f1 = f[10:20, 10:, 0]
     assert isinstance(f1, stbt.Frame)
     assert f1.time == 1234
+    assert f1.width == 1270
+    assert f1.height == 10
 
     f2 = stbt.crop(f, stbt.Region(10, 10, 20, 20))
     assert isinstance(f2, stbt.Frame)
     assert f2.time == 1234
+    assert f2.width == 20
+    assert f2.height == 20
 
     f3 = f.copy()
     assert isinstance(f3, stbt.Frame)
     assert f3.time == 1234
+    assert f3.width == 1280
+    assert f3.height == 720
     assert (f.__array_interface__["data"][0] !=
             f3.__array_interface__["data"][0])
 
     f4 = stbt.Frame(f)
     assert f4.time == 1234
+    assert f4.width == 1280
+    assert f4.height == 720
 
 
 def test_that_load_image_looks_in_callers_directory():


### PR DESCRIPTION
Similar to the recent commit 656a59f2d3a4 "stbt.Image: Add `width` and
`height` properties", but for `stbt.Frame`.

Recently I was checking for the width of a region obtained with
`right_of`. But this region has infinite width, so I needed to intersect
it with the size of the frame, but this isn't currently possible without
reaching into `shape` which is numpy-specific and has unintuitive
coordinate order. Now I can do something like
`r.right_of().replace(right=self._frame.right)`.

Note that the current documentation of `right_of` is incorrect, or at
least misleading: "Returns: A new region to the right of the current
region, extending **to the right edge of the frame** (or to the
specified width)" -- emphasis mine.