### PR TITLE
stbt.Image, stbt.Frame: Fix IndexError in __repr__

### DIFF
--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -53,8 +53,10 @@ class Frame(numpy.ndarray):
         if len(self.shape) == 3:
             dimensions = "%dx%dx%d" % (
                 self.shape[1], self.shape[0], self.shape[2])
-        else:
+        elif len(self.shape) == 2:
             dimensions = "%dx%d" % (self.shape[1], self.shape[0])
+        else:
+            return super(Frame, self).__repr__()
         return "<Frame(time=%s, dimensions=%s)>" % (
             "None" if self.time is None else "%.3f" % self.time,
             dimensions)
@@ -126,8 +128,10 @@ class Image(numpy.ndarray):
         if len(self.shape) == 3:
             dimensions = "%dx%dx%d" % (
                 self.shape[1], self.shape[0], self.shape[2])
-        else:
+        elif len(self.shape) == 2:
             dimensions = "%dx%d" % (self.shape[1], self.shape[0])
+        else:
+            return super(Image, self).__repr__()
         if (self.relative_filename is None or
                 self.relative_filename.startswith('../')):
             filename = self.absolute_filename

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -140,6 +140,16 @@ def test_that_load_image_with_nonexistent_image_raises_ioerror():
         stbt.load_image("idontexist.png")
 
 
+def test_that_image_and_frame_repr_can_print_numpy_scalar():
+    # Operations like `numpy.max` propagate the type of the input, so its
+    # output is still a `stbt.Image`.
+    f = stbt.Frame(numpy.zeros((720, 1280, 3), dtype=numpy.uint8))
+    assert repr(numpy.max(f)) == "Frame(0, dtype=uint8)"
+
+    img = stbt.load_image("action-panel.png")
+    assert repr(numpy.max(img)) == "Image(255, dtype=uint8)"
+
+
 def test_crop():
     img = stbt.load_image("action-panel.png")
     cropped = stbt.crop(img, stbt.Region(x=1045, y=672, right=1081, bottom=691))


### PR DESCRIPTION
...when the Image or Frame has gone through numpy operations that change
its shape (such as `numpy.max`, which will preserve the `stbt.Image` or
`stbt.Frame` type of its argument).

Fixes #717.