### PR TITLE
stbt.press, stbt.pressing: Support Enum values for the key name

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -114,6 +114,8 @@ class DeviceUnderTest():
         return self._last_keypress
 
     def press(self, key, interpress_delay_secs=None, hold_secs=None):
+        key = str(key)
+
         if hold_secs is not None and hold_secs > 60:
             # You must ensure that lircd's --repeat-max is set high enough.
             raise ValueError("press: hold_secs must be less than 60 seconds")
@@ -137,6 +139,8 @@ class DeviceUnderTest():
 
     @contextmanager
     def pressing(self, key, interpress_delay_secs=None):
+        key = str(key)
+
         with self._interpress_delay(interpress_delay_secs):
             out = _Keypress(key, self._time.time(), None, self.get_frame())
             try:

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -16,6 +16,7 @@ import warnings
 import weakref
 from collections import deque, namedtuple
 from contextlib import contextmanager
+from enum import Enum
 
 import cv2
 import gi
@@ -114,7 +115,8 @@ class DeviceUnderTest():
         return self._last_keypress
 
     def press(self, key, interpress_delay_secs=None, hold_secs=None):
-        key = str(key)
+        if isinstance(key, Enum):
+            key = key.value
 
         if hold_secs is not None and hold_secs > 60:
             # You must ensure that lircd's --repeat-max is set high enough.
@@ -139,7 +141,8 @@ class DeviceUnderTest():
 
     @contextmanager
     def pressing(self, key, interpress_delay_secs=None):
-        key = str(key)
+        if isinstance(key, Enum):
+            key = key.value
 
         with self._interpress_delay(interpress_delay_secs):
             out = _Keypress(key, self._time.time(), None, self.get_frame())

--- a/stbt_core/__init__.py
+++ b/stbt_core/__init__.py
@@ -193,8 +193,8 @@ def press(key, interpress_delay_secs=None, hold_secs=None):
     * Added in v29: The ``hold_secs`` parameter.
     * Changed in v30: Returns an object with keypress timings, instead of
       ``None``.
-    * Changed in v33: The ``key`` argument will be converted to a string (using
-      `str`) if it isn't one, to support user-defined Enums for the key names.
+    * Changed in v33: The ``key`` argument can be an Enum (we'll use the Enum's
+      value, which must be a string).
     """
     return _dut.press(key, interpress_delay_secs, hold_secs)
 

--- a/stbt_core/__init__.py
+++ b/stbt_core/__init__.py
@@ -191,8 +191,10 @@ def press(key, interpress_delay_secs=None, hold_secs=None):
           the keypress.
 
     * Added in v29: The ``hold_secs`` parameter.
-    * Added in v30: Returns an object with keypress timings, instead of
+    * Changed in v30: Returns an object with keypress timings, instead of
       ``None``.
+    * Changed in v33: The ``key`` argument will be converted to a string (using
+      `str`) if it isn't one, to support user-defined Enums for the key names.
     """
     return _dut.press(key, interpress_delay_secs, hold_secs)
 

--- a/tests/test-lirc.sh
+++ b/tests/test-lirc.sh
@@ -27,6 +27,27 @@ test_press_with_lirc() {
         fail "fake-lircd didn't receive 2 SEND_ONCE messages"
 }
 
+test_press_with_lirc_using_enum_for_key_name() {
+    start_fake_lircd
+
+    cat > test.py <<-EOF &&
+	from enum import Enum
+	import stbt_core as stbt
+	
+	class Keys(Enum):
+	    KEY_MENU = "KEY_MENU"
+	    KEY_OK = "KEY_OK"
+	
+	stbt.press(Keys.KEY_MENU)
+	stbt.press(Keys.KEY_OK)
+	EOF
+    stbt run -v --control lirc:$lircd_socket:test test.py || return
+    cat fake-lircd.log
+    grep -Eq "fake-lircd: Received: b?'?SEND_ONCE test KEY_MENU" fake-lircd.log &&
+    grep -Eq "fake-lircd: Received: b?'?SEND_ONCE test KEY_OK" fake-lircd.log ||
+        fail "fake-lircd didn't receive 2 SEND_ONCE messages"
+}
+
 test_that_press_fails_on_lircd_error() {
     start_fake_lircd
 


### PR DESCRIPTION
To support user-defined enums like this:

    class Keys(enum.Enum):
        KEY_0 = "KEY_0"
        KEY_1 = "KEY_1"
        ...

    stbt.press(Keys.KEY_0)

Defining such an enum (it can be auto-generated from your lircd.conf file) allows your IDE to provide linting & auto-complete suggestions.
