### PR TITLE
Fix OCR corrections bug: Complete string doesn't match if it ends in non-word character

### DIFF
--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -399,26 +399,22 @@ def apply_ocr_corrections(text, corrections=None):
 def _apply_ocr_corrections(text, corrections):
 
     def replace_string(matchobj):
-        old = matchobj.group(0)
+        old = matchobj.group(2)
         new = corrections[old]
         debug("ocr corrections: %r -> %r" % (old, new))
-        return new
+        return matchobj.group(1) + new + matchobj.group(3)
 
     def replace_regex(matchobj):
         new = corrections[matchobj.re]
         debug("ocr corrections: /%s/ -> %r" % (matchobj.re.pattern, new))
         return new
 
-    # Match plain strings at word boundaries:
-    pattern = "|".join(r"\b(" + re.escape(k) + r")\b"
-                       for k in corrections
-                       if isinstance(k, str))
-    if pattern:
-        text = re.sub(pattern, replace_string, text)
-
-    # Match regexes:
     for k in corrections:
-        if isinstance(k, PatternType):
+        if isinstance(k, str):
+            # Match plain strings at word boundaries
+            text = re.sub(r"(^|\s)(" + re.escape(k) + r")(\s|$)",
+                          replace_string, text)
+        elif isinstance(k, PatternType):
             text = re.sub(k, replace_regex, text)
     return text
 

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -286,8 +286,8 @@ def test_that_text_location_is_recognised():
         if multiline:
             continue
 
-        yield (test, text, region, True)
-        yield (test, text, region, False)
+        test(text, region, True)
+        test(text, region, False)
 
 
 @requires_tesseract


### PR DESCRIPTION
    >>> stbt.apply_ocr_corrections("itv+", {"itv+": "Apple tv+"})
    itv+ 

The above should return `"Apple tv+"` but it doesn't change the input text at all. Something to do with word boundaries? Plain strings are supposed to match whole words or phrases but not be interpreted as regexes.

- [x] Add failing testcase.
- [x] Fix it.