### PR TITLE
_stbt.control: Make HTTP timeouts configurable

### DIFF
--- a/_stbt/stbt.conf
+++ b/_stbt/stbt.conf
@@ -30,6 +30,7 @@ text_color_threshold = 25
 
 [press]
 interpress_delay_secs = 0.3
+http_timeout_secs = 3
 
 [press_until_match]
 interval_secs = 3


### PR DESCRIPTION
...for RokuHttpControl and RedRatHttpControl.

The motivation is that we occasionally see the RedRat Server take 4-5
seconds to respond, when there are multiple clients sending requests
to the same RedRat Server / the same RedRat-X.