### PR TITLE
stbt.Keyboard: Better error message when page.selection is None

### DIFF
--- a/_stbt/keyboard.py
+++ b/_stbt/keyboard.py
@@ -663,6 +663,8 @@ class Keyboard():
             self.G_ = _strip_shift_transitions(self.G)
 
         assert page, "%s page isn't visible" % type(page).__name__
+        assert page.selection in self.G_, \
+            "page.selection (%r) isn't in the keyboard" % (page.selection,)
         deadline = time.time() + self.navigate_timeout
         current = page.selection
         while current not in targets:


### PR DESCRIPTION
If your Page Object is buggy, and it returns `is_visible=True` but `selection=None` we'd get an inscrutable TypeError from the depths of our implementation:

      File "_stbt/keyboard.py", line 707, in _keys_to_press
        for s, t in zip(path[:-1], path[1:]):
    TypeError: unhashable type: 'slice'

This is because we call `networkx.shortest_path(G, source, target)`. Normally it returns a list, but when `source` is None it returns a dict (with the shortest path for each node in the graph to `target`, keyed by the starting node).