### PR TITLE
Fix stbt-debug rendering in Jupyter Notebooks

### DIFF
--- a/_stbt/logging.py
+++ b/_stbt/logging.py
@@ -190,20 +190,19 @@ class ImageLogger():
 
         index_html = os.path.join(self.outdir, "index.html")
         with open(index_html, "w") as f:
-            f.write(jinja2.Template(_INDEX_HTML_HEADER)
-                    .render(frame_number=self.frame_number,
-                            jupyter=self.jupyter))
+            f.write("<div>")
             f.write(jinja2.Template(dedent(template.lstrip("\n")))
                     .render(annotated_image=self._draw_annotated_image,
                             draw=self._draw,
                             jupyter=self.jupyter,
                             **template_kwargs))
-            f.write(jinja2.Template(_INDEX_HTML_FOOTER)
-                    .render())
+            f.write("</div>")
 
         if self.jupyter:
-            from IPython.display import display, IFrame  # pylint:disable=import-error
-            display(IFrame(src=index_html, width=974, height=600))
+            from IPython.display import display, HTML  # pylint:disable=import-error
+            display(HTML(open(index_html).read()
+                         .replace('src="', 'src="%s/' % (self.outdir))
+                         .replace("src='", "src='%s/" % (self.outdir))))
 
     def _draw(self, region, source_size, css_class, title=None):
         import jinja2


### PR DESCRIPTION
With Jupyter Notebook 6.4.6 running on Ubuntu 20.04, the IFrame with the
stbt-debug index.html doesn't show any of the images. Looking in the
network tab of my browser's developer tools, I can see that the requests
for the images are being redirected to
"login?next=<path to the actual image.png>".

If I right-click the broken image and open it in a new tab, it works;
but it still doesn't display the image in the HTML.

This commit renders correctly in Jupyter but obviously it's a hack
because it breaks the normal index.html when viewed directly.

TODO: Fix it properly.