### PR TITLE
Remove useless pylint annotations

### DIFF
--- a/.circleci/ubuntu2004.dockerfile
+++ b/.circleci/ubuntu2004.dockerfile
@@ -29,6 +29,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         pylint3 \
         python3-docutils \
         python3-gi \
+        python3-ipython \
         python3-jinja2 \
         python3-lmdb \
         python3-lxml \

--- a/_stbt/android.py
+++ b/_stbt/android.py
@@ -45,8 +45,6 @@ from _stbt.logging import debug
 
 
 class CoordinateSystem(Enum):
-    # pylint:disable=pointless-string-statement
-
     """How to translate coordinates from the video-frames processed by your
     test script, to the coordinates expected by ADB for tap & swipe events.
 
@@ -165,12 +163,12 @@ class AdbDevice():
         if coordinate_system is None:
             name = _config.get("android", "coordinate_system",
                                fallback="ADB_NATIVE")
-            if name not in CoordinateSystem.__members__:  # pylint:disable=no-member
+            if name not in CoordinateSystem.__members__:
                 raise ValueError(
                     "Invalid value '%s' for android.coordinate_system in "
                     "config file. Valid values are %s."
                     % (name, ", ".join("'%s'" % k for k in
-                                       CoordinateSystem.__members__)))  # pylint:disable=no-member
+                                       CoordinateSystem.__members__)))
             coordinate_system = CoordinateSystem[name]
         self.coordinate_system = coordinate_system
 

--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -109,7 +109,7 @@ class ErrorControl(RemoteControl):
             message = "No remote control configured"
         self.message = message
 
-    def press(self, key):  # pylint:disable=unused-argument
+    def press(self, key):
         raise RuntimeError(self.message)
 
     def keydown(self, key):
@@ -447,7 +447,7 @@ class IRNetBoxControl(RemoteControl):
 
     """
 
-    def __init__(self, hostname, port, output, config):  # pylint:disable=redefined-outer-name
+    def __init__(self, hostname, port, output, config):
         self.hostname = hostname
         self.port = int(port or 10001)
         self.output = int(output)

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -151,7 +151,7 @@ class DeviceUnderTest():
                 self.draw_text("Holding %s" % key, duration_secs=3)
                 self._last_keypress = out
                 yield out
-            except:  # pylint:disable=bare-except
+            except:
                 exc_info = sys.exc_info()
                 try:
                     self._control.keyup(key)

--- a/_stbt/cv2_compat.py
+++ b/_stbt/cv2_compat.py
@@ -9,7 +9,7 @@ import cv2
 version = LooseVersion(cv2.__version__).version
 
 if version >= [3, 2, 0]:
-    def find_contour_boxes(image, mode, method):  # pylint:disable=redefined-outer-name
+    def find_contour_boxes(image, mode, method):
         contours = cv2.findContours(image=image, mode=mode, method=method)
 
         # In OpenCV 4, the behavior of find findContours changes from returning
@@ -26,7 +26,7 @@ else:
         x, y, w, h = r
         return (x - 1, y - 1, w + 2, h + 2)
 
-    def find_contour_boxes(image, mode, method):  # pylint:disable=redefined-outer-name
+    def find_contour_boxes(image, mode, method):
         # In v3.0.0 cv2.findContours started returning
         # (img, contours, hierarchy) rather than (contours, hierarchy).
         # Index -2 selects contours on both versions:
@@ -35,8 +35,8 @@ else:
 
 # We prefer the v3 names here rather than the v2.4 names:
 if version >= [3, 0, 0]:
-    FILLED = cv2.FILLED  # pylint: disable=c-extension-no-member
-    LINE_AA = cv2.LINE_AA  # pylint: disable=c-extension-no-member
+    FILLED = cv2.FILLED
+    LINE_AA = cv2.LINE_AA
 else:
-    FILLED = cv2.cv.CV_FILLED  # pylint: disable=c-extension-no-member,no-member
+    FILLED = cv2.cv.CV_FILLED  # pylint: disable=c-extension-no-member
     LINE_AA = cv2.CV_AA  # pylint: disable=c-extension-no-member

--- a/_stbt/frameobject.py
+++ b/_stbt/frameobject.py
@@ -114,7 +114,6 @@ class _FrameObjectMeta(type):
 
 
 class FrameObject(metaclass=_FrameObjectMeta):
-    # pylint: disable=line-too-long
     r'''Base class for user-defined Page Objects.
 
     FrameObjects are Stb-tester's implementation of the *Page Object* pattern.

--- a/_stbt/grid.py
+++ b/_stbt/grid.py
@@ -164,7 +164,7 @@ class Grid():
             return self.get(data=key)
 
     def __iter__(self):
-        for i in range(len(self)):  # pylint:disable=consider-using-enumerate
+        for i in range(len(self)):
             yield self[i]
 
     def __len__(self):

--- a/_stbt/gst_hacks.py
+++ b/_stbt/gst_hacks.py
@@ -6,7 +6,7 @@ from os.path import dirname
 import gi
 
 gi.require_version("Gst", "1.0")
-from gi.repository import Gst  # pylint:disable=wrong-import-order
+from gi.repository import Gst
 
 # Here we are using ctypes to call `gst_buffer_map` and `gst_buffer_unmap`
 # because PyGObject does not properly expose struct GstMapInfo (see
@@ -125,7 +125,6 @@ def test_map_sample_without_buffer():
 
     sample = Gst.Sample.new(None, None, None, None)
     try:
-        # pylint:disable=no-value-for-parameter
         with map_gst_sample(sample, Gst.MapFlags.READ):
             assert False
     except ValueError:

--- a/_stbt/gst_utils.py
+++ b/_stbt/gst_utils.py
@@ -1,6 +1,6 @@
 import ctypes
 import sys
-from functools import reduce  # pylint:disable=redefined-builtin
+from functools import reduce
 
 import gi
 

--- a/_stbt/imgproc_cache.py
+++ b/_stbt/imgproc_cache.py
@@ -69,7 +69,7 @@ def setup_cache(filename=None):
     if filename is None:
         filename = default_filename
     mkdir_p(os.path.dirname(filename) or ".")
-    with lmdb.open(filename, map_size=MAX_CACHE_SIZE_BYTES) as db:  # pylint: disable=no-member
+    with lmdb.open(filename, map_size=MAX_CACHE_SIZE_BYTES) as db:
         assert _cache is None
         try:
             _cache = db
@@ -215,7 +215,7 @@ def _cache_put(key, value):
     with _cache.begin(write=True) as txn:
         try:
             txn.put(key, json.dumps(value).encode("utf-8"))
-        except lmdb.MapFullError:  # pylint: disable=no-member
+        except lmdb.MapFullError:
             global _cache_full_warning
             if not _cache_full_warning:
                 sys.stderr.write(

--- a/_stbt/irnetbox.py
+++ b/_stbt/irnetbox.py
@@ -330,7 +330,6 @@ def test_that_read_responses_doesnt_hang_on_incomplete_data():
 def test_that_parse_config_understands_redrat_format():
     import io
 
-    # pylint:disable=line-too-long
     f = io.BytesIO(
         re.sub(
             b"^ +", b"", flags=re.MULTILINE,

--- a/_stbt/keyboard.py
+++ b/_stbt/keyboard.py
@@ -381,7 +381,7 @@ class Keyboard():
                              "other keys in the keyboard do" % (spec,))
         self.G.add_node(node)
         self.G_ = None
-        if node.region is None:  # pylint:disable=simplifiable-if-statement
+        if node.region is None:
             self._any_without_region = True
         else:
             self._any_with_region = True

--- a/_stbt/logging.py
+++ b/_stbt/logging.py
@@ -86,7 +86,7 @@ def imshow(img, regions=None):
         for r in regions:
             cv2.rectangle(img, (r.x, r.y), (r.right, r.bottom), (32, 0, 255))
 
-    from IPython.core.display import Image, display  # pylint:disable=import-error
+    from IPython.core.display import Image, display
     if isinstance(img, str):
         display(Image(img))
     else:
@@ -202,7 +202,7 @@ class ImageLogger():
                     .render())
 
         if self.jupyter:
-            from IPython.display import display, IFrame  # pylint:disable=import-error
+            from IPython.display import display, IFrame
             display(IFrame(src=index_html, width=974, height=600))
 
     def _draw(self, region, source_size, css_class, title=None):

--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -373,7 +373,6 @@ def _match_all(image, frame, match_parameters, region):
         template_name=t.filename or "<Image>",
         input_region=input_region)
 
-    # pylint:disable=undefined-loop-variable
     try:
         for (matched, match_region, first_pass_matched,
              first_pass_certainty) in _find_matches(
@@ -449,7 +448,7 @@ def wait_for_match(image, timeout_secs=10, consecutive_matches=1,
             debug("Matched " + (image.relative_filename or "<Image>"))
             return res
 
-    raise MatchTimeout(res.frame, image.relative_filename, timeout_secs)  # pylint:disable=undefined-loop-variable
+    raise MatchTimeout(res.frame, image.relative_filename, timeout_secs)
 
 
 class MatchTimeout(UITestFailure):
@@ -492,7 +491,6 @@ def _find_matches(image, template, match_parameters, imglog):
         mask = template[:, :, 3]
         mask[mask < 255] = 0
 
-    # pylint:disable=undefined-loop-variable
     for i, first_pass_matched, region, first_pass_certainty in \
             _find_candidate_matches(image, template, match_parameters, imglog):
         confirmed = (
@@ -526,7 +524,7 @@ def _find_candidate_matches(image, template, match_parameters, imglog):
 
     ddebug("Original image %s, template %s" % (image.shape, template.shape))
 
-    method = {  # pylint:disable=redefined-outer-name
+    method = {
         MatchMethod.SQDIFF: cv2.TM_SQDIFF,
         MatchMethod.SQDIFF_NORMED: cv2.TM_SQDIFF_NORMED,
         MatchMethod.CCORR_NORMED: cv2.TM_CCORR_NORMED,
@@ -637,7 +635,7 @@ def _find_candidate_matches(image, template, match_parameters, imglog):
                         width=template.shape[1], height=template.shape[0])
 
 
-def _match_template(image, template, mask, method, roi_mask, level, imwrite):  # pylint:disable=redefined-outer-name
+def _match_template(image, template, mask, method, roi_mask, level, imwrite):
 
     ddebug("Level %d: image %s, template %s" % (
         level, image.shape, template.shape))

--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -124,7 +124,6 @@ class TextMatchResult():
         self.frame = frame
         self.text = text
 
-    # pylint:disable=no-member
     def __bool__(self):
         return self.match
 

--- a/_stbt/pylint_plugin.py
+++ b/_stbt/pylint_plugin.py
@@ -205,7 +205,7 @@ def _get_argnames(node):
     if isinstance(node, FunctionDef):
         return node.argnames()
     if isinstance(node, ClassDef) and node.newstyle:
-        for method in node.methods():  # pylint:disable=redefined-outer-name
+        for method in node.methods():
             if method.name == "__init__":
                 return method.argnames()[1:]
     return []

--- a/_stbt/stbt_run.py
+++ b/_stbt/stbt_run.py
@@ -39,7 +39,7 @@ def video(args, dut):
     with _set_dut_singleton(dut), dut:
         try:
             yield
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as e:
             try:
                 _save_screenshot(dut, result_dir, exception=e,
                                  save_jpg=(args.save_thumbnail != 'never'),

--- a/_stbt/utils.py
+++ b/_stbt/utils.py
@@ -35,7 +35,7 @@ def rm_f(filename):
 
 @contextmanager
 def named_temporary_directory(
-        suffix='', prefix='tmp', dir=None):  # pylint:disable=redefined-builtin,redefined-outer-name
+        suffix='', prefix='tmp', dir=None):  # pylint:disable=redefined-builtin
     dirname = tempfile.mkdtemp(suffix, prefix, dir)
     try:
         yield dirname

--- a/stbt_core/__init__.py
+++ b/stbt_core/__init__.py
@@ -317,7 +317,6 @@ def get_frame():
 # ===========================================================================
 
 class UnconfiguredDeviceUnderTest():
-    # pylint:disable=unused-argument
     def last_keypress(self):
         return None
 

--- a/tests/test_lirc_control.py
+++ b/tests/test_lirc_control.py
@@ -34,7 +34,7 @@ def lircd():
 def test_press(lircd, key):
     logfile = open(lircd.logfile)
 
-    print("key = %r (%s)" % (key, type(key)))  # pylint: disable=superfluous-parens
+    print("key = %r (%s)" % (key, type(key)))
     control = uri_to_control("lirc:%s:Apple_TV" % lircd.socket)
     control.press(key)
     lircd_output = logfile.read()

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -445,7 +445,7 @@ def test_that_build_pyramid_relaxes_mask():
     downsampled = mask_pyramid[1]
     cv2.imwrite("/tmp/dave2.png", downsampled)
     assert downsampled.shape == (98, 8, 3)
-    print(downsampled[:, :, 0])  # pylint:disable=unsubscriptable-object
+    print(downsampled[:, :, 0])
     # pylint:disable=bad-whitespace
     expected = \
         [[255, 255, 255, 255, 255, 255, 255, 255],
@@ -454,7 +454,7 @@ def test_that_build_pyramid_relaxes_mask():
          [255,   0,   0,   0,   0, 255, 255, 255],
          [255,   0,   0,   0,   0, 255, 255, 255]] + \
         [[255, 255, 255, 255, 255, 255, 255, 255]] * 93
-    assert numpy.all(downsampled[:, :, 0] == expected)  # pylint:disable=unsubscriptable-object
+    assert numpy.all(downsampled[:, :, 0] == expected)
 
 
 @requires_opencv_3

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -279,7 +279,7 @@ def test_that_text_location_is_recognised():
     def test(text, region, upsample):
         result = stbt.match_text(text, frame=frame, upsample=upsample)
         assert result
-        assert region.contains(result.region)  # pylint:disable=no-member
+        assert region.contains(result.region)
 
     for text, region, multiline in iterate_menu():
         # Don't currently support multi-line comments

--- a/tests/test_stbt_control_relay.py
+++ b/tests/test_stbt_control_relay.py
@@ -89,7 +89,7 @@ def socket_passing_setup(socket):
         os.environ['LISTEN_PID'] = str(os.getpid())
         if fd != 3:
             os.dup2(fd, 3)
-        os.set_inheritable(3, True)  # pylint:disable=no-member
+        os.set_inheritable(3, True)
         os.closerange(4, 100)
 
     return preexec_fn

--- a/tests/vstb-example-html5/tests/rotate.py
+++ b/tests/vstb-example-html5/tests/rotate.py
@@ -1,4 +1,3 @@
-# pylint: disable=F0401
 from stbt_core import press, wait_for_match
 
 


### PR DESCRIPTION
I found these by running pylint with `--enable=useless-suppression`.

I learned of this in the pylint documentation:
https://pylint.pycqa.org/en/latest/user_guide/message-control.html#detecting-useless-disables

> As pylint gets better and false positives are removed, disables that became useless can accumulate and clutter the code. In order to clean them you can enable the useless-suppression warning.

I haven't enabled `useless-suppression` permanently in pylint.conf because it says that the `line-too-long` annotations in `tests/test_keyboard.py` are useless, but if I remove the annotations then pylint complains that the lines are too long.

Tested with Ubuntu 20.04's pylint which is what we use in CI:

    ❯ pylint --version
    pylint 2.4.4
    astroid 2.3.3