### PR TITLE
FrameObject: Fix __eq__, remove ordering operators

### DIFF
--- a/_stbt/frameobject.py
+++ b/_stbt/frameobject.py
@@ -215,31 +215,11 @@ class FrameObject(metaclass=_FrameObjectMeta):
         the values of all the public properties match, even if the underlying
         frame is different. All falsey FrameObjects of the same type are equal.
         """
-        return self.__cmp__(other) == 0
-
-    def __ne__(self, other):
-        return self.__cmp__(other) != 0
-
-    def __lt__(self, other):
-        return self.__cmp__(other) < 0
-
-    def __le__(self, other):
-        return self.__cmp__(other) <= 0
-
-    def __gt__(self, other):
-        return self.__cmp__(other) > 0
-
-    def __ge__(self, other):
-        return self.__cmp__(other) >= 0
-
-    def __cmp__(self, other):
         if isinstance(other, self.__class__):
             for s, o in zip_longest(self._iter_fields(), other._iter_fields()):
-                if s[1] < o[1]:
-                    return -1
-                elif s[1] > o[1]:
-                    return 1
-            return 0
+                if s != o:
+                    return False
+            return True
         else:
             return NotImplemented
 

--- a/tests/test_frameobject.py
+++ b/tests/test_frameobject.py
@@ -87,41 +87,6 @@ class FrameObjectThatCallsItsOwnProperties(stbt.FrameObject):
         return 6
 
 
-class OrderedFrameObject(stbt.FrameObject):
-    """
-    FrameObject defines a default sort order based on the values of the
-    public properties (in lexicographical order by property name; that is, in
-    this example the `color` value is compared before `size`):
-
-    >>> import numpy
-    >>> red = OrderedFrameObject(numpy.array([[[0, 0, 255]]]))
-    >>> bigred = OrderedFrameObject(numpy.array([[[0, 0, 255], [0, 0, 255]]]))
-    >>> green = OrderedFrameObject(numpy.array([[[0, 255, 0]]]))
-    >>> blue = OrderedFrameObject(numpy.array([[[255, 0, 0]]]))
-    >>> print(sorted([red, green, blue, bigred]))
-    [...'blue'..., ...'green'..., ...'red', size=1..., ...'red', size=2)]
-    """
-
-    @property
-    def is_visible(self):
-        return True
-
-    @property
-    def size(self):
-        return self._frame.shape[0] * self._frame.shape[1]
-
-    @property
-    def color(self):
-        if self._frame[0, 0, 0] == 255:
-            return "blue"
-        elif self._frame[0, 0, 1] == 255:
-            return "green"
-        elif self._frame[0, 0, 2] == 255:
-            return "red"
-        else:
-            return "grey?"
-
-
 class PrintingFrameObject(stbt.FrameObject):
     """
     This is a very naughty FrameObject.  It's properties cause side-effects so
@@ -491,19 +456,11 @@ class G(stbt.FrameObject):
 ])
 def test_frameobject_comparison_equal(f1, f2):
     # pylint:disable=comparison-with-itself,unneeded-not
-    assert not f1 < f2
-    assert not f2 < f1
-    assert f1 <= f2
-    assert f2 <= f1
     assert f1 == f1
     assert f1 == f2
     assert f2 == f1
     assert not f1 != f2
     assert not f2 != f1
-    assert not f1 > f2
-    assert not f2 > f1
-    assert f1 >= f2
-    assert f2 >= f1
 
 
 @pytest.mark.parametrize("f1,f2", [
@@ -517,62 +474,13 @@ def test_frameobject_comparison_equal(f1, f2):
 
     # Subclass with additional property.
     (F(frame1, True, a=1, b=2), FFF(frame1, True, a=1, b=2)),
+
+    # Different (unrelated) types.
+    (F(frame1, True, a=1, b=2), G(frame2, True, a=1, b=2)),
 ])
-def test_frameobject_comparison_not_equal_same_type(f1, f2):
+def test_frameobject_comparison_not_equal(f1, f2):
     # pylint:disable=unneeded-not
     assert not f1 == f2
     assert not f2 == f1
     assert f1 != f2
     assert f2 != f1
-
-
-def test_frameobject_comparison_not_equal_different_type():
-    # pylint:disable=unneeded-not
-
-    f1 = F(frame1, True, a=1, b=2)
-    f2 = G(frame2, True, a=1, b=2)
-
-    with pytest.raises(TypeError):
-        assert not f1 < f2
-    with pytest.raises(TypeError):
-        assert not f2 < f1
-    with pytest.raises(TypeError):
-        assert not f1 <= f2
-    with pytest.raises(TypeError):
-        assert not f2 <= f1
-    assert not f1 == f2
-    assert not f2 == f1
-    assert f1 != f2
-    assert f2 != f1
-    with pytest.raises(TypeError):
-        assert not f1 > f2
-    with pytest.raises(TypeError):
-        assert not f2 > f1
-    with pytest.raises(TypeError):
-        assert not f1 >= f2
-    with pytest.raises(TypeError):
-        assert not f2 >= f1
-
-
-@pytest.mark.parametrize("f1,f2", [
-    # FrameObject defines a default sort order based on the values of the
-    # public properties (in lexicographical order by property name).
-    (F(frame1, True, a=1, b=2), F(frame1, True, a=1, b=3)),
-
-    # Regression test: `None` properties don't raise TypeError.
-    (F(frame1, True, a=None, b=2), F(frame1, True, a=None, b=3)),
-])
-def test_frameobject_comparison_less_and_greater(f1, f2):
-    # pylint:disable=unneeded-not
-    assert f1 < f2
-    assert not f2 < f1
-    assert f1 <= f2
-    assert not f2 <= f1
-    assert not f1 == f2
-    assert not f2 == f1
-    assert f1 != f2
-    assert f2 != f1
-    assert not f1 > f2
-    assert f2 > f1
-    assert not f1 >= f2
-    assert f2 >= f1


### PR DESCRIPTION
The bugs in `__eq__` and `__ne__` were:

- If one of the properties returned `None`, `__cmp__` would raise `TypeError: '<' not supported between instances of 'NoneType' and '<type of other.property>'`.

  One way to trigger this was to call `wait_until(MyFrameObjectClass, stable_secs=1)`. Because of `stable_secs` we compare the return value of successive calls and if one of the properties was None it would raise `TypeError: '>' not supported between instances of 'NoneType' and 'NoneType'`.

- If comparing an instance of F vs. an instance of FF, where FF is a subclass of F, if you put the subclass first you could get incorrect results (i.e. `f == ff` worked, but `ff == f` didn't). This is because `__cmp__` would return `NotImplemented` and we'd end up comparing `NotImplemented` against 0 (which returns False for `NotImplemented == 0`, True for `NotImplemented != 0`, and raises TypeError for `<`, `<=`, `>`, `>=`).


- If comparing an instance of F vs. an instance of FF, where FF is a subclass of F, and the subclass has additional properties, `zip_longest` returns `None` for the shorter list once it is exhausted. So `__eq__` would raise `TypeError: 'NoneType' object is not subscriptable`. These values (from `FrameObject._iter_fields`) are tuples (property_name, property_value) so we can compare them directly.

We don't support Python 2 any more so we don't need to implement `__cmp__` (Python 3 doesn't have the `cmp` builtin and doesn't support the `__cmp__` method).

There are too many bugs in the ordering operators (`<`, `<=`, `>`, `>=`) so I have removed support for them. They suffered from all of the above bugs, plus how do we define a sort order compared to a subclass with more properties, given the way that `FrameObject._iter_fields` sorts fields. I don't know if it even makes sense for FrameObjects to have an order.
