### PR TITLE
stbt.ocr corrections: Fix matching word boundary

### DIFF
--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -411,8 +411,8 @@ def _apply_ocr_corrections(text, corrections):
     for k in corrections:
         if isinstance(k, str):
             # Match plain strings at word boundaries
-            text = re.sub(r"(^|\s)(" + re.escape(k) + r")(\s|$)",
-                          replace_string, text)
+            text = re.sub(r"(^|\W)(" + re.escape(k) + r")(\W|$)",
+                          replace_string, text, re.UNICODE)
         elif isinstance(k, PatternType):
             text = re.sub(k, replace_regex, text)
     return text

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -221,10 +221,13 @@ def test_corrections(corrections, expected):
     "text,corrections,expected",
     # Same test-cases as `test_corrections` above:
     [('OO', c, e) for (c, e) in corrections_test_cases] +
-    # Plain strings match entire words at word boundaries:
+    # Plain strings match entire words at word boundaries, regexes don't:
     [('itv+', {'itv+': 'Apple tv+'}, 'Apple tv+'),
      ('hitv+', {'itv+': 'Apple tv+'}, 'hitv+'),
      ('This is itv+ innit', {'itv+': 'Apple tv+'}, 'This is Apple tv+ innit'),
+     ('the saw said he saws, he saw.',
+      {'he saw': 'HE SAW', re.compile("he", re.IGNORECASE): "ħé"},
+      'tħé saw said ħé saws, ħé SAW.'),
      # Make sure it tries all the patterns:
      ('A B C', {'A': '1', 'B': '2', 'C': '3'}, '1 2 3'),
     ])


### PR DESCRIPTION
Spaces aren't the only word boundaries. This fixes an (unreleased) regression introduced in commit 5ecd51f (#731).
