### PR TITLE
Add Color type

### DIFF
--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -186,21 +186,36 @@ class Color:
     @overload
     def __init__(self, bgr: Tuple[int, int, int]) -> None:
         ...
-    def __init__(self, *args):
-        self.array: numpy.ndarray = None  # BGR with shape (1, 1, 3) or BGRA
-        if len(args) == 1:
-            if isinstance(args[0], Color):
-                self.array = args[0].array
-            elif isinstance(args[0], str):
-                self.array = Color._from_string(args[0])
-            elif (isinstance(args[0], (list, tuple, numpy.ndarray)) and
-                    len(args[0]) in (3, 4)):
-                self.array = Color._from_sequence(*args[0])
+    def __init__(self, *args,
+                 hexstring: str = None,
+                 blue: int = None, green: int = None, red: int = None,
+                 bgr: Tuple[int, int, int] = None):
+
+        self.array: numpy.ndarray  # BGR with shape (1, 1, 3) or BGRA
+
+        if len(args) == 1 and isinstance(args[0], Color):
+            self.array = args[0].array
+
+        elif len(args) == 1 and isinstance(args[0], str):
+            self.array = Color._from_string(args[0])
+        elif not args and hexstring is not None:
+            self.array = Color._from_string(hexstring)
+
+        elif (len(args) == 1 and
+                isinstance(args[0], (list, tuple, numpy.ndarray)) and
+                len(args[0]) in (3, 4)):
+            self.array = Color._from_sequence(*args[0])
         elif len(args) in (3, 4):
             self.array = Color._from_sequence(*args)  # pylint:disable=no-value-for-parameter
-        if self.array is None:
+        elif not args and bgr is not None:
+            self.array = Color._from_sequence(*bgr)
+        elif not args and all(x is not None for x in (blue, green, red)):
+            self.array = Color._from_sequence(blue, green, red)
+
+        else:
             raise TypeError("Color: __init__() expected a Color, '#rrggbb' "
                             "string, or 3 integers in Blue-Green-Red order. ")
+
         self.hexstring = (
             "#{0:02x}{1:02x}{2:02x}{3}".format(
                 self.array[0][0][2], self.array[0][0][1], self.array[0][0][0],

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -193,7 +193,8 @@ class Color:
                 self.array = args[0].array
             elif isinstance(args[0], str):
                 self.array = Color._from_string(args[0])
-            elif isinstance(args[0], (list, tuple)) and len(args[0]) in (3, 4):
+            elif (isinstance(args[0], (list, tuple, numpy.ndarray)) and
+                    len(args[0]) in (3, 4)):
                 self.array = Color._from_sequence(*args[0])
         elif len(args) in (3, 4):
             self.array = Color._from_sequence(*args)  # pylint:disable=no-value-for-parameter

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -177,7 +177,7 @@ class Color:
     way OpenCV stores colors.
     """
     def __init__(self, *args):
-        self.array = None
+        self.array: numpy.ndarray = None  # BGR with shape (1, 1, 3) or BGRA
         if len(args) == 1:
             if isinstance(args[0], Color):
                 self.array = args[0].array
@@ -192,8 +192,9 @@ class Color:
                             "string, or 3 integers in Blue-Green-Red order. ")
         self.hexstring = (
             "#{0:02x}{1:02x}{2:02x}{3}".format(
-                self.array[2], self.array[1], self.array[0],
-                "" if len(self.array) == 3 else f"{self.array[3]:02x}"))
+                self.array[0][0][2], self.array[0][0][1], self.array[0][0][0],
+                ("" if self.array.shape[2] == 3
+                 else f"{self.array[0][0][3]:02x}")))
 
     @staticmethod
     def _from_string(s):
@@ -225,11 +226,11 @@ class Color:
 
     @staticmethod
     def _from_sequence(b, g, r, a=None):
-        elements = [b, g, r]
+        channels = [b, g, r]
         if a is not None:
-            elements.append(a)
+            channels.append(a)
         out = []
-        for x in elements:
+        for x in channels:
             if isinstance(x, str):
                 x = int(x, 16)
             else:
@@ -238,7 +239,8 @@ class Color:
                 raise ValueError(f"Color: __init__ expected a value between 0 "
                                  f"and 255: Got {x}")
             out.append(x)
-        return out
+        return (numpy.asarray(out, dtype=numpy.uint8)
+                     .reshape((1, 1, len(channels))))
 
     def __repr__(self):
         return f"Color('{self.hexstring}')"

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -5,6 +5,7 @@ import os
 import re
 import warnings
 from collections import namedtuple
+from typing import overload, Tuple
 
 import cv2
 import numpy
@@ -176,6 +177,15 @@ class Color:
     opposite of the HTML-style RGB order. This is for compatibility with the
     way OpenCV stores colors.
     """
+    @overload
+    def __init__(self, hexstring: str) -> None:
+        ...
+    @overload
+    def __init__(self, blue: int, green: int, red: int) -> None:
+        ...
+    @overload
+    def __init__(self, bgr: Tuple[int, int, int]) -> None:
+        ...
     def __init__(self, *args):
         self.array: numpy.ndarray = None  # BGR with shape (1, 1, 3) or BGRA
         if len(args) == 1:

--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -13,7 +13,7 @@ import numpy
 
 from . import imgproc_cache
 from .config import get_config
-from .imgutils import crop, _frame_repr, _validate_region
+from .imgutils import Color, crop, _frame_repr, _validate_region
 from .logging import debug, ImageLogger, warn
 from .types import Region
 from .utils import LooseVersion, named_temporary_directory, to_unicode
@@ -206,12 +206,11 @@ def ocr(frame=None, region=Region.ALL,
         you should only disable it if you are doing your own pre-processing on
         the image.
 
-    :type text_color: 3-element tuple of integers between 0 and 255, BGR order
-    :param text_color:
+    :param Color text_color:
         Color of the text. Specifying this can improve OCR results when
         tesseract's default thresholding algorithm doesn't detect the text,
         for example white text on a light-colored background or text on a
-        translucent overlay.
+        translucent overlay with dynamic content underneath.
 
     :param int text_color_threshold:
         The threshold to use with ``text_color``, between 0 and 255. Defaults
@@ -520,7 +519,7 @@ def _tesseract(frame, region, mode, lang, _config, user_patterns, user_words,
 
         # Calculate distance of each pixel from `text_color`, then discard
         # everything further than `text_color_threshold` distance away.
-        diff = numpy.subtract(frame, text_color, dtype=numpy.int32)
+        diff = numpy.subtract(frame, Color(text_color).array, dtype=numpy.int32)
         frame = numpy.sqrt((diff[:, :, 0] ** 2 +
                             diff[:, :, 1] ** 2 +
                             diff[:, :, 2] ** 2) // 3) \

--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -149,16 +149,14 @@ def ocr(frame=None, region=Region.ALL,
     Perform OCR (Optical Character Recognition) using the "Tesseract"
     open-source OCR engine.
 
-    :param frame:
+    :param Frame frame:
       If this is specified it is used as the video frame to process; otherwise
-      a new frame is grabbed from the device-under-test. This is an image in
-      OpenCV format (for example as returned by `frames` and `get_frame`).
+      a new frame is grabbed from the device-under-test.
 
-    :param region: Only search within the specified region of the video frame.
-    :type region: `Region`
+    :param Region region:
+      Only search within the specified region of the video frame.
 
-    :param mode: Tesseract's layout analysis mode.
-    :type mode: `OcrMode`
+    :param OcrMode mode: Tesseract's layout analysis mode.
 
     :param str lang:
         The three-letter
@@ -220,14 +218,12 @@ def ocr(frame=None, region=Region.ALL,
         to 25. You can override the global default value by setting
         ``text_color_threshold`` in the ``[ocr]`` section of :ref:`.stbt.conf`.
 
-    :param engine:
+    :param OcrEngine engine:
         The OCR engine to use. Defaults to ``OcrEngine.TESSERACT``. You can
         override the global default value by setting ``engine`` in the ``[ocr]``
         section of :ref:`.stbt.conf`.
-    :type engine: `OcrEngine`
 
-    :type char_whitelist: unicode string
-    :param char_whitelist:
+    :param str char_whitelist:
         String of characters that are allowed. Useful when you know that the
         text is only going to contain numbers or IP addresses, for example so
         that tesseract won't think that a zero is the letter o.

--- a/extra/pylint.sh
+++ b/extra/pylint.sh
@@ -14,6 +14,7 @@ if pycodestyle --version &>/dev/null; then
     # E124: closing bracket does not match visual indentation
     # E203: whitespace before ':'
     # E241: multiple spaces after ',' (because pylint does it)
+    # E301: expected 1 blank line (because pylint does it)
     # E305: expected 2 blank lines after class or function definition (pylint)
     # E402: module level import not at top of file (because pylint does it)
     # E501: line too long > 80 chars (because pylint does it)
@@ -23,7 +24,7 @@ if pycodestyle --version &>/dev/null; then
     # E741: do not use variables named ‘l’, ‘O’, or ‘I’
     # W291: trailing whitespace (because pylint does it)
     # W504: line break after binary operator
-    pycodestyle --ignore=E124,E203,E241,E305,E402,E501,E721,E722,E731,E741,W291,W504 "$@" || ret=1
+    pycodestyle --ignore=E124,E203,E241,E301,E305,E402,E501,E721,E722,E731,E741,W291,W504 "$@" || ret=1
 else
     echo "warning: pycodestyle not installed; skipping pycodestyle and only running pylint" >&2
 fi

--- a/stbt_core/__init__.py
+++ b/stbt_core/__init__.py
@@ -26,6 +26,7 @@ from _stbt.frameobject import (
 from _stbt.grid import (
     Grid)
 from _stbt.imgutils import (
+    Color,
     crop,
     Frame,
     Image,
@@ -80,6 +81,7 @@ from _stbt.wait import (
 __all__ = [
     "apply_ocr_corrections",
     "as_precondition",
+    "Color",
     "ConfigurationError",
     "ConfirmMethod",
     "crop",

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -465,8 +465,9 @@ test_draw_text() {
 	sleep(60)
 	EOF
     cat > verify-draw-text.py <<-EOF &&
-	import stbt_core as stbt
-	stbt.wait_for_match("$testdir/draw-text.png")
+	import os, stbt_core as stbt
+	stbt.wait_for_match("$testdir/draw-text.png",
+	    timeout_secs=60 if "CIRCLECI" in os.environ else 10)
 	EOF
     mkfifo fifo || fail "Initial test setup failed"
 

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -145,7 +145,7 @@ test_using_frames_to_measure_black_screen() {
 }
 
 test_that_frames_doesnt_deadlock() {
-    cat > test.py <<-EOF &&
+    cat > test.py <<-EOF
 	import stbt_core as stbt
 	for frame in stbt.frames():
 	    print(frame.time)
@@ -160,10 +160,9 @@ test_that_frames_doesnt_deadlock() {
 	frames3 = stbt.frames()
 	frame3 = next(frames3)  # old 'frames' still holds lock
 	EOF
-    timeout 20 stbt run -v test.py &&
-
-    cat > test2.py <<-EOF
-EOF
+    local t
+    [[ -v CIRCLECI ]] && t=60 || t=5
+    timeout $t stbt run -v test.py
 }
 
 test_that_is_screen_black_reads_default_threshold_from_stbt_conf() {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -176,6 +176,46 @@ def test_crop():
         stbt.crop(img, stbt.Region(x=-10, y=-10, right=0, bottom=0))
 
 
+@pytest.mark.parametrize("args,expected", [
+    (["#f77f00"], "#f77f00"),
+    (["#F77F00"], "#f77f00"),
+    (["f77f00"], "#f77f00"),
+    (["f77f00"], "#f77f00"),
+    (["f77f00ff"], "#f77f00ff"),
+    (["#0a3"], "#00aa33"),
+    (["#0A3"], "#00aa33"),
+    (["#111"], "#111111"),
+    (["#12345"], ValueError),
+    (["#1234567"], ValueError),
+    (["#12345g"], ValueError),
+    ([(0, 127, 247)], "#f77f00"),  # a 3-tuple, BGR
+    ([(0, 127, 247, 255)], "#f77f00ff"),  # a 4-tuple, BGRA
+    ([0, 127, 247], "#f77f00"),  # 3 separate arguments, BGR
+    ([0, 127, 247, 255], "#f77f00ff"),  # 4 separate arguments, BGRA
+    ([0, 127, 256], ValueError),  # range 0-255
+    ([0, -127, 247], ValueError),  # range 0-255
+    ([0, 127], TypeError),
+    ([stbt.Color("#000")], "#000000"),  # constructing from another Color
+])
+def test_color_constructor(args, expected):
+    if isinstance(expected, type):
+        with pytest.raises(expected):
+            print(stbt.Color(*args))
+    else:
+        assert expected == stbt.Color(*args).hexstring
+
+
+def test_color_equality_and_hash():
+    c1 = stbt.Color("#000")
+    c2 = stbt.Color(0, 0, 0)
+    assert c1 is not c2
+    assert c1 == c2
+    assert c1 != stbt.Color("#001")
+    d = {c1: 1}
+    d[c2] = 2
+    assert d == {c2: 2}
+
+
 def test_region_intersect():
     r1 = stbt.Region(0, 0, right=20, bottom=10)
     r2 = stbt.Region(5, 5, right=25, bottom=15)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -176,35 +176,41 @@ def test_crop():
         stbt.crop(img, stbt.Region(x=-10, y=-10, right=0, bottom=0))
 
 
-@pytest.mark.parametrize("args,expected", [
-    (["#f77f00"], "#f77f00"),
-    (["#F77F00"], "#f77f00"),
-    (["f77f00"], "#f77f00"),
-    (["f77f00"], "#f77f00"),
-    (["f77f00ff"], "#f77f00ff"),
-    (["#0a3"], "#00aa33"),
-    (["#0A3"], "#00aa33"),
-    (["#111"], "#111111"),
-    (["#12345"], ValueError),
-    (["#1234567"], ValueError),
-    (["#12345g"], ValueError),
-    ([(0, 127, 247)], "#f77f00"),  # a 3-tuple, BGR
-    ([(0, 127, 247, 255)], "#f77f00ff"),  # a 4-tuple, BGRA
-    ([0, 127, 247], "#f77f00"),  # 3 separate arguments, BGR
-    ([0, 127, 247, 255], "#f77f00ff"),  # 4 separate arguments, BGRA
-    ([0, 127, 256], ValueError),  # range 0-255
-    ([0, -127, 247], ValueError),  # range 0-255
-    ([0, 127], TypeError),
-    ([stbt.Color("#000")], "#000000"),  # constructing from another Color
-    ([stbt.load_image("button.png")[3, 65]], "#ff1443"),  # from a pixel
-    ([stbt.load_image("button.png", color_channels=4)[3, 65]], "#ff1443ff"),
+@pytest.mark.parametrize("args,kwargs,expected", [
+    (["#f77f00"], {}, "#f77f00"),
+    (["#F77F00"], {}, "#f77f00"),
+    (["f77f00"], {}, "#f77f00"),
+    (["f77f00"], {}, "#f77f00"),
+    (["f77f00ff"], {}, "#f77f00ff"),
+    (["#0a3"], {}, "#00aa33"),
+    (["#0A3"], {}, "#00aa33"),
+    (["#111"], {}, "#111111"),
+    (["#12345"], {}, ValueError),
+    (["#1234567"], {}, ValueError),
+    (["#12345g"], {}, ValueError),
+    ([], {"hexstring": "#f77f00"}, "#f77f00"),
+    ([(0, 127, 247)], {}, "#f77f00"),  # a 3-tuple, BGR
+    ([], {"bgr": (0, 127, 247)}, "#f77f00"),
+    ([], {"bgr": (0, 127, 247, 255)}, "#f77f00ff"),  # a 4-tuple, BGRA
+    ([0, 127, 247], {}, "#f77f00"),  # 3 separate arguments, BGR
+    ([], {"blue": 0, "green": 127, "red": 247}, "#f77f00"),
+    ([0, 127, 247, 255], {}, "#f77f00ff"),  # 4 separate arguments, BGRA
+    ([0, 127, 256], {}, ValueError),  # range 0-255
+    ([0, -127, 247], {}, ValueError),  # range 0-255
+    ([0, 127], {}, TypeError),
+    ([], {}, TypeError),
+    ([], {"blue": 0, "green": 127}, TypeError),
+    ([stbt.Color("#000")], {}, "#000000"),  # constructing from another Color
+    ([stbt.load_image("button.png")[3, 65]], {}, "#ff1443"),  # from a pixel
+    ([stbt.load_image("button.png", color_channels=4)[3, 65]], {}, "#ff1443ff"),
+    ([], {"bgr": stbt.load_image("button.png")[3, 65]}, "#ff1443"),
 ])
-def test_color_constructor(args, expected):
+def test_color_constructor(args, kwargs, expected):
     if isinstance(expected, type):
         with pytest.raises(expected):
-            print(stbt.Color(*args))
+            print(stbt.Color(*args, **kwargs))
     else:
-        assert expected == stbt.Color(*args).hexstring
+        assert expected == stbt.Color(*args, **kwargs).hexstring
 
 
 def test_color_equality_and_hash():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -196,6 +196,8 @@ def test_crop():
     ([0, -127, 247], ValueError),  # range 0-255
     ([0, 127], TypeError),
     ([stbt.Color("#000")], "#000000"),  # constructing from another Color
+    ([stbt.load_image("button.png")[3, 65]], "#ff1443"),  # from a pixel
+    ([stbt.load_image("button.png", color_channels=4)[3, 65]], "#ff1443ff"),
 ])
 def test_color_constructor(args, expected):
     if isinstance(expected, type):

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -361,6 +361,7 @@ def test_ocr_on_text_next_to_image_match():
     # unselected buttons "Details" and "More Episodes" (light grey on black).
     # Without specifying text_color, OCR only sees the latter two.
     ("ocr/Summary.png", (235, 235, 235), "Summary"),
+    ("ocr/Summary.png", "#ebebeb", "Summary"),
 
     # This is a light "8" on a dark background. Without the context of any
     # other surrounding text, OCR reads it as ":" or ";"! Presumably tesseract

--- a/tests/test_stbt_debug.py
+++ b/tests/test_stbt_debug.py
@@ -437,11 +437,11 @@ def test_ocr_debug():
             stbt-debug/00002/tessinput.png
             stbt-debug/00002/upsampled.png
             stbt-debug/00003
+            stbt-debug/00003/binarized.png
+            stbt-debug/00003/diff.png
             stbt-debug/00003/index.html
             stbt-debug/00003/source.png
             stbt-debug/00003/tessinput.png
-            stbt-debug/00003/text_color_difference.png
-            stbt-debug/00003/text_color_threshold.png
             stbt-debug/00003/upsampled.png
             stbt-debug/00004
             stbt-debug/00004/index.html
@@ -454,11 +454,11 @@ def test_ocr_debug():
             stbt-debug/00005/tessinput.png
             stbt-debug/00005/upsampled.png
             stbt-debug/00006
+            stbt-debug/00006/binarized.png
+            stbt-debug/00006/diff.png
             stbt-debug/00006/index.html
             stbt-debug/00006/source.png
             stbt-debug/00006/tessinput.png
-            stbt-debug/00006/text_color_difference.png
-            stbt-debug/00006/text_color_threshold.png
             stbt-debug/00006/upsampled.png
             """)
 


### PR DESCRIPTION
So far we have been specifying colors as (blue, green, red) tuples. This supports that same format, but also supports the more user-friendly and familiar "#rrggbb" format in a string.

TODO:

- [x] Decide what to do about the type annotations: ~Remove them or~ accept keyword args with those names & types in the actual implementation.
