### PR TITLE
match: Show full sized frame in html debug

### DIFF
--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -376,7 +376,8 @@ def _match_all(image, frame, match_parameters, region):
     imglog = ImageLogger(
         "match", match_parameters=match_parameters,
         template_name=t.filename or "<Image>",
-        input_region=input_region)
+        region=input_region)
+    imglog.imwrite("source", frame)
 
     try:
         for (matched, match_region, first_pass_matched,
@@ -521,7 +522,6 @@ def _find_candidate_matches(image, template, match_parameters, imglog):
     http://opencv-code.com/tutorials/fast-template-matching-with-image-pyramid
     """
 
-    imglog.imwrite("source", image)
     imglog.imwrite("template", template)
     imglog.set(template_shape=template.shape)
     if template.shape[2] == 4:
@@ -895,16 +895,10 @@ def _log_match_image_debug(imglog):
             result.region, _Annotation.MATCHED if result._first_pass_matched
             else _Annotation.NO_MATCH)
 
-    imglog.imwrite(
-        "source_with_matches", imglog.images["source"],
-        [x.region for x in imglog.data["matches"]],
-        [_Annotation.MATCHED if x.match else _Annotation.NO_MATCH
-         for x in imglog.data["matches"]])
-
     template = """\
         <h4>{{title}}</h4>
 
-        <img src="source_with_matches.png" />
+        {{ annotated_image(matches) }}
 
         <h5>First pass (find candidate matches):</h5>
 
@@ -916,7 +910,7 @@ def _log_match_image_debug(imglog):
 
         {% if fast_path %}
         <p>Taking fast path - template shape <code>{{ template_shape }}</code>
-        matches size of target region <code>{{ input_region }}</code></p>
+        matches size of target region <code>{{ region }}</code></p>
 
         <table class="table">
         <tr>

--- a/tests/test_stbt_debug.py
+++ b/tests/test_stbt_debug.py
@@ -57,7 +57,6 @@ def test_match_debug():
             stbt-debug/00001/match0-heatmap.png
             stbt-debug/00001/match0-source_with_match.png
             stbt-debug/00001/source.png
-            stbt-debug/00001/source_with_matches.png
             stbt-debug/00001/template.png
             stbt-debug/00002
             stbt-debug/00002/index.html
@@ -142,7 +141,6 @@ def test_match_debug():
             stbt-debug/00002/match6-heatmap.png
             stbt-debug/00002/match6-source_with_match.png
             stbt-debug/00002/source.png
-            stbt-debug/00002/source_with_matches.png
             stbt-debug/00002/template.png
             stbt-debug/00003
             stbt-debug/00003/index.html
@@ -235,7 +233,6 @@ def test_match_debug():
             stbt-debug/00003/match6-heatmap.png
             stbt-debug/00003/match6-source_with_match.png
             stbt-debug/00003/source.png
-            stbt-debug/00003/source_with_matches.png
             stbt-debug/00003/template.png
             stbt-debug/00004
             stbt-debug/00004/index.html
@@ -314,7 +311,6 @@ def test_match_debug():
             stbt-debug/00004/match6-heatmap.png
             stbt-debug/00004/match6-source_with_match.png
             stbt-debug/00004/source.png
-            stbt-debug/00004/source_with_matches.png
             stbt-debug/00004/template.png
             """)
 


### PR DESCRIPTION
...instead of showing only the part that's cropped to `region`.

This fixes the position of the match region drawn onto the frame, if you specified `region`.

Also, use our existing `ImageLogger._draw_annotated_image` infrastructure for drawing these regions. This will also add a purple rectangle showing the input `region`, and it uses CSS to draw the rectangles instead of creating another PNG.

Fixes #705.

Manual testing:

- [x] stbt.match with & without a region.
- [x] stbt.match_all with & without a region.