### PR TITLE
Make `find_file` a public API

### DIFF
--- a/_stbt/mask.py
+++ b/_stbt/mask.py
@@ -5,7 +5,7 @@ from typing import Union, Tuple
 import numpy
 
 from .imgutils import (
-    _convert_color, find_user_file, Image, load_image, _relative_filename)
+    _convert_color, find_file, Image, load_image, _relative_filename)
 from .types import Region
 
 try:
@@ -63,7 +63,7 @@ class Mask:
         self._binop = None
         self._region = None
         if isinstance(m, str):
-            absolute_filename = find_user_file(m)
+            absolute_filename = find_file(m)
             self._filename = absolute_filename
             self._invert = invert
         elif isinstance(m, numpy.ndarray):

--- a/stbt_core/__init__.py
+++ b/stbt_core/__init__.py
@@ -28,6 +28,7 @@ from _stbt.grid import (
 from _stbt.imgutils import (
     Color,
     crop,
+    find_file,
     Frame,
     Image,
     load_image,
@@ -90,6 +91,7 @@ __all__ = [
     "debug",
     "detect_motion",
     "draw_text",
+    "find_file",
     "for_object_repository",
     "Frame",
     "FrameDiffer",


### PR DESCRIPTION
Users often have trouble finding a file committed to git in the test-pack, such as a csv file with data needed by the test.