### PR TITLE
load_image: Remove memoization; Mask.to_array: Make the array read-only

### DIFF
--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -5,7 +5,6 @@ import inspect
 import os
 import re
 import warnings
-from functools import lru_cache
 from typing import overload, Tuple
 
 import cv2
@@ -412,7 +411,6 @@ def load_image(filename, flags=None, color_channels=None) -> Image:
     return img
 
 
-@lru_cache(maxsize=5)
 def _imread(absolute_filename, color_channels):
     if color_channels == (3,):
         flags = cv2.IMREAD_COLOR

--- a/_stbt/mask.py
+++ b/_stbt/mask.py
@@ -122,6 +122,8 @@ class Mask:
     @lru_cache(maxsize=5)
     def _to_array(mask: "Mask", shape: Tuple[int, int, int]) -> numpy.ndarray:
         array: numpy.ndarray
+        if len(shape) == 2:
+            shape = shape + (1,)
         if mask._filename is not None:
             array = load_image(mask._filename, color_channels=(shape[2],))
             if array.shape != shape:

--- a/_stbt/mask.py
+++ b/_stbt/mask.py
@@ -151,6 +151,7 @@ class Mask:
         if mask._invert:
             array = ~array  # pylint:disable=invalid-unary-operand-type
 
+        array.flags.writeable = False
         return array
 
     def __repr__(self):

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -176,6 +176,11 @@ def test_mask_memoization():
     a6 = Mask("mask-out-left-half-720p.png").to_array((720, 1280, 1))
     assert a5 is a6
 
+    # the mask is read-only
+    with pytest.raises(ValueError):
+        a1[2, 2] = 22
+    assert a1[2, 2, 0] == 0
+
 
 def test_mask_with_3_channels():
     m = Mask(Region(x=0, y=0, right=2, bottom=2))

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -190,6 +190,14 @@ def test_mask_with_3_channels():
         assert numpy.array_equal(a1[:, :, 0], a3[:, :, c])
 
 
+def test_mask_to_array_with_2ary_shape():
+    m1 = Mask(Region(x=0, y=0, right=2, bottom=2))
+    assert m1.to_array(shape=(4, 6)).shape == (4, 6, 1)
+
+    m2 = Mask("mask-out-left-half-720p.png")
+    assert m2.to_array(shape=(720, 1280)).shape == (720, 1280, 1)
+
+
 def test_mask_shape_mismatch():
     with pytest.raises(ValueError,
                        match=(r"Mask shape \(720, 1280, 1\) and required shape "


### PR DESCRIPTION
`Mask.to_array` is memoized so if the user modifies the array in-place it would affect the array we return from future calls to `to_array`.

The `load_image` change was made late in the v33 release and I'm nervous it hasn't been tested enough. We can revisit for v34.  `wait_for_motion(mask="a filename.png")` will still memoize the mask (because `Mask.to_array` has its own memoization) but `wait_for_match("a filename.png")` won't.