### PR TITLE
match, ocr: imgproc_cache cache-buster for v33

### DIFF
--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -479,7 +479,7 @@ class MatchTimeout(UITestFailure):
             self.expected, self.timeout_secs)
 
 
-@memoize_iterator({"version": "31"})
+@memoize_iterator({"version": "33"})
 def _find_matches(image, template, match_parameters, imglog):
     """Our image-matching algorithm.
 

--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -546,7 +546,7 @@ def bgr_diff(frame, color, threshold, imglog):
 ocr.text_color_differ = bgr_diff
 
 
-@imgproc_cache.memoize({"version": "32"})
+@imgproc_cache.memoize({"version": "33"})
 def _tesseract_subprocess(
         frame, mode, lang, _config, user_patterns, user_words, upsample,
         engine, char_whitelist, imglog, tesseract_version):


### PR DESCRIPTION
In case there are changes in behaviour due to new Tesseract / OpenCV versions.

Regarding stbt.match: In spite of the new `matchTemplate` implementation in OpenCV 4.4, we have extensive tests that check the match position, and none of those tests have required changes. Maybe the `first_pass_result` could vary very slightly, resulting in a change in behaviour when it was already very close to the threshold?