### PR TITLE
FrameObject.refresh: Use self.__class__ instead of type(self)

### DIFF
--- a/_stbt/frameobject.py
+++ b/_stbt/frameobject.py
@@ -251,4 +251,4 @@ class FrameObject(metaclass=_FrameObjectMeta):
 
         Any additional keyword arguments are passed on to ``__init__``.
         """
-        return type(self)(frame=frame, **kwargs)
+        return self.__class__(frame=frame, **kwargs)


### PR DESCRIPTION
This helps pylint to infer the correct type.