### PR TITLE
Use Python's logging framework

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -49,6 +49,7 @@ disable=
   too-many-return-statements,
   too-many-statements,
   ungrouped-imports,
+  unnecessary-lambda-assignment,
   unnecessary-pass,
   use-implicit-booleaness-not-comparison,
   wrong-import-position,

--- a/_stbt/keyboard.py
+++ b/_stbt/keyboard.py
@@ -12,7 +12,7 @@ from _stbt.transition import TransitionStatus
 from _stbt.types import Region
 
 
-log = getLogger("stbt.keyboard")
+log = getLogger("stbt.Keyboard")
 
 
 class Keyboard():
@@ -610,6 +610,8 @@ class Keyboard():
         the :ref:`example above <keyboard-example>`.
         """
 
+        log.info("enter_text %r", text)
+
         for letter in text:
             # Sanity check so we don't fail halfway through typing.
             if not self._find_keys({"text": letter}):
@@ -620,9 +622,9 @@ class Keyboard():
                                     page, verify_every_keypress, retries)
             self.press_and_wait("KEY_OK", stable_secs=0.5, timeout_secs=1)  # pylint:disable=stbt-unused-return-value
             page = page.refresh()
-            log.debug("Keyboard: Entered %r; the selection is now on %r",
+            log.debug("Entered %r; the selection is now on %r",
                       letter, page.selection)
-        log.info("Keyboard: Entered %r", text)
+        log.info("Entered %r", text)
         return page
 
     def navigate_to(self, target, page, verify_every_keypress=False, retries=2):
@@ -648,6 +650,8 @@ class Keyboard():
 
         import stbt_core as stbt
 
+        log.info("navigate_to: %r", target)
+
         targets = self._find_keys(target)
         if not targets:
             raise ValueError("'%s' isn't in the keyboard" % (target,))
@@ -666,7 +670,7 @@ class Keyboard():
                 "Keyboard.navigate_to: Didn't reach %r after %s seconds"
                 % (target, self.navigate_timeout))
             keys = list(_keys_to_press(self.G_, current, targets))
-            log.debug("Keyboard: navigating from %r to %r by pressing %r",
+            log.debug("navigating from %r to %r by pressing %r",
                       current, target, [k for k, _ in keys])
             if not verify_every_keypress:
                 for k, _ in keys[:-1]:

--- a/_stbt/logging.py
+++ b/_stbt/logging.py
@@ -2,6 +2,7 @@
 
 import argparse
 import itertools
+import logging
 import os
 import sys
 from collections import namedtuple, OrderedDict
@@ -12,26 +13,40 @@ from .config import get_config
 from .types import Region
 from .utils import mkdir_p
 
+
 _debug_level = None
 
 # Running in a Jupyter Notebook:
 _jupyter_logging_enabled = "JPY_PARENT_PID" in os.environ
 
+logger = logging.getLogger("stbt")
+trace_logger = logging.getLogger("stbt.trace")
+
+
+def init_logger():
+    assert not logger.handlers, "stbt logger already initialised"
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(
+        logging.Formatter("%(name)s:%(levelname)s: %(message)s"))
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+
 
 def debug(msg):
     """Print the given string to stderr if stbt run `--verbose` was given."""
     if get_debug_level() > 0:
-        sys.stderr.write("%s\n" % (msg,))
+        logger.debug(msg)
 
 
 def ddebug(s):
     """Extra verbose debug for stbt developers, not end users"""
     if get_debug_level() > 1:
-        sys.stderr.write("%s\n" % (s,))
+        trace_logger.debug(s)
 
 
 def warn(s):
-    sys.stderr.write("warning: %s\n" % (s,))
+    logger.warning(s)
 
 
 def get_debug_level():

--- a/_stbt/logging.py
+++ b/_stbt/logging.py
@@ -65,7 +65,7 @@ def argparser_add_verbose_argument(argparser):
     argparser.add_argument(
         '-v', '--verbose', action=IncreaseDebugLevel, nargs=0,
         default=get_debug_level(),  # for stbt-run arguments dump
-        help='Enable debug output (specify twice to enable GStreamer element '
+        help='Enable debug output (specify twice to enable detailed '
              'dumps to ./stbt-debug directory)')
 
 

--- a/stbt_control.py
+++ b/stbt_control.py
@@ -17,6 +17,7 @@ from textwrap import dedent
 
 import _stbt.control
 from _stbt.config import ConfigurationError, get_config
+from _stbt.logging import init_logger
 
 SPECIAL_CHARS = {
     curses.ascii.SP: "Space",
@@ -39,6 +40,7 @@ SPECIAL_CHARS = {
 
 def main(argv):
     args = argparser().parse_args(argv[1:])
+    init_logger()
 
     if args.help_keymap:
         sys.exit(show_help_keymap())

--- a/stbt_match.py
+++ b/stbt_match.py
@@ -8,7 +8,6 @@ https://github.com/stb-tester/stb-tester/blob/master/LICENSE for details).
 
 import argparse
 import sys
-from contextlib import contextmanager
 
 import cv2
 
@@ -43,6 +42,7 @@ def main():
             'MatchParameters' in the stbt API documentation. For example:
             'confirm_threshold=0.70')""")
     args = parser.parse_args(sys.argv[1:])
+    _stbt.logging.init_logger()
 
     mp = {}
     try:
@@ -67,8 +67,7 @@ def main():
     if source_image is None:
         error("Invalid image '%s'" % args.source_file)
 
-    with (_stbt.logging.scoped_debug_level(2) if args.verbose
-          else noop_contextmanager()):
+    with _stbt.logging.scoped_debug_level(2 if args.verbose else 1):
         match_found = False
         for result in stbt.match_all(
                 args.reference_file, frame=source_image,
@@ -81,11 +80,6 @@ def main():
             if not args.all:
                 break
         sys.exit(0 if match_found else 1)
-
-
-@contextmanager
-def noop_contextmanager():
-    yield
 
 
 if __name__ == "__main__":

--- a/stbt_run.py
+++ b/stbt_run.py
@@ -12,7 +12,7 @@ import sys
 
 import _stbt.core
 from _stbt import imgproc_cache
-from _stbt.logging import debug
+from _stbt.logging import debug, init_logger
 from _stbt.stbt_run import (load_test_function,
                             sane_unicode_and_exception_handling, video)
 
@@ -42,6 +42,7 @@ def main(argv):
         help='Additional arguments passed on to the test script (in sys.argv)')
 
     args = parser.parse_args(argv[1:])
+    init_logger()
     debug("Arguments:\n" + "\n".join([
         "%s: %s" % (k, v) for k, v in args.__dict__.items()]))
 


### PR DESCRIPTION
This sidesteps some of the controversy / complexity of #611:

- Use Python's built-in logging instead of structlog.
- Don't configure the root logger, so that we don't change the behaviour of users' existing calls to `logging.basicConfig` (because
`basicConfig` is ignored if you call it more than once, or if you've already added handlers to the root logger some other way).
- Instead we create our own logger with `logging.getLogger("stbt")`, we configure it with a StreamHandler and a basic Formatter, and we set `propagate = False` so that our logger's messages don't get printed again by the root logger.

In this pull request we simply make `stbt.debug` use the logger. In future we might go through the code and use logging directly from all our code, perhaps with specific sub-loggers like "stbt.match".