### PR TITLE
FrameObject repr: Only print values of properties already calculated

### DIFF
--- a/_stbt/frameobject.py
+++ b/_stbt/frameobject.py
@@ -55,6 +55,13 @@ def _memoize_property_fn(fn):
     return inner
 
 
+def _convert_is_visible_to_bool(fn):
+    @functools.wraps(fn)
+    def inner(self):
+        return bool(fn(self))
+    return inner
+
+
 def _mark_in_is_visible(fn):
     @functools.wraps(fn)
     def inner(self):
@@ -63,7 +70,7 @@ def _mark_in_is_visible(fn):
         except AttributeError:
             self._FrameObject__local.in_is_visible = 1
         try:
-            return bool(fn(self))
+            return fn(self)
         finally:
             self._FrameObject__local.in_is_visible -= 1
     return inner
@@ -90,6 +97,8 @@ class _FrameObjectMeta(type):
                         "FrameObjects must be immutable but this property has "
                         "a setter")
                 f = v.fget
+                if k == 'is_visible':
+                    f = _convert_is_visible_to_bool(f)
                 # The value of any property is cached after the first use
                 f = _memoize_property_fn(f)
                 # Public properties return `None` if the FrameObject isn't

--- a/_stbt/frameobject.py
+++ b/_stbt/frameobject.py
@@ -193,7 +193,7 @@ class FrameObject(metaclass=_FrameObjectMeta):
         The object's string representation includes all its public properties.
         """
         args = ", ".join(("%s=%r" % x) for x in self._iter_fields())
-        return "%s(%s)" % (self.__class__.__name__, args)
+        return "<%s(%s)>" % (self.__class__.__name__, args)
 
     def _iter_fields(self):
         if self:

--- a/tests/test_frameobject.py
+++ b/tests/test_frameobject.py
@@ -13,7 +13,7 @@ class TruthyFrameObject(stbt.FrameObject):
     >>> bool(TruthyFrameObject(frame))
     True
     >>> TruthyFrameObject(frame)
-    TruthyFrameObject(is_visible=True)
+    <TruthyFrameObject(is_visible=True)>
     """
     @property
     def is_visible(self):
@@ -28,7 +28,7 @@ class FalseyFrameObject(stbt.FrameObject):
     >>> bool(fo)
     False
     >>> fo
-    FalseyFrameObject(is_visible=False)
+    <FalseyFrameObject(is_visible=False)>
     >>> print(fo.public)
     None
     >>> fo._private
@@ -52,7 +52,7 @@ class FrameObjectWithProperties(stbt.FrameObject):
 
     >>> frame = _load_frame("with-dialog")
     >>> FrameObjectWithProperties(frame)
-    FrameObjectWithProperties(is_visible=True, public=5)
+    <FrameObjectWithProperties(is_visible=True, public=5)>
     """
     @property
     def is_visible(self):
@@ -72,7 +72,7 @@ class FrameObjectThatCallsItsOwnProperties(stbt.FrameObject):
 
     >>> frame = _load_frame("with-dialog")
     >>> FrameObjectThatCallsItsOwnProperties(frame)
-    FrameObjectThatCallsItsOwnProperties(is_visible=True, public=5)
+    <FrameObjectThatCallsItsOwnProperties(is_visible=True, public=5)>
     """
     @property
     def is_visible(self):
@@ -106,7 +106,7 @@ class PrintingFrameObject(stbt.FrameObject):
     >>> m.another
     10
     >>> m
-    PrintingFrameObject(is_visible=True, another=10)
+    <PrintingFrameObject(is_visible=True, another=10)>
     """
     @property
     def is_visible(self):
@@ -149,7 +149,7 @@ class FalseyPrintingFrameObject(stbt.FrameObject):
     >>> m._another
     11
     >>> m
-    FalseyPrintingFrameObject(is_visible=False)
+    <FalseyPrintingFrameObject(is_visible=False)>
     """
     @property
     def is_visible(self):
@@ -241,11 +241,11 @@ class Dialog(stbt.FrameObject):
     like this:
 
     >>> dialog
-    Dialog(is_visible=True, message=u'This set-top box is great', title=u'Information')
+    <Dialog(is_visible=True, message=u'This set-top box is great', title=u'Information')>
     >>> dialog_fab
-    Dialog(is_visible=True, message=u'This set-top box is fabulous', title=u'Information')
+    <Dialog(is_visible=True, message=u'This set-top box is fabulous', title=u'Information')>
     >>> no_dialog
-    Dialog(is_visible=False)
+    <Dialog(is_visible=False)>
 
     This makes it convenient to use doctests for unit-testing your Frame
     Objects.
@@ -271,7 +271,7 @@ class Dialog(stbt.FrameObject):
     in a dict:
 
     >>> {dialog: 1}
-    {Dialog(is_visible=True, message=u'This set-top box is great', title=u'Information'): 1}
+    {<Dialog(is_visible=True, message=u'This set-top box is great', title=u'Information')>: 1}
     >>> len({no_dialog, dialog, dialog, dialog_bunnies})
     2
 

--- a/tests/test_frameobject.py
+++ b/tests/test_frameobject.py
@@ -51,7 +51,12 @@ class FrameObjectWithProperties(stbt.FrameObject):
     """Only public properties are listed in repr.
 
     >>> frame = _load_frame("with-dialog")
-    >>> FrameObjectWithProperties(frame)
+    >>> page = FrameObjectWithProperties(frame)
+    >>> page
+    <FrameObjectWithProperties(is_visible=True, public=...)>
+    >>> page.public
+    5
+    >>> page
     <FrameObjectWithProperties(is_visible=True, public=5)>
     """
     @property
@@ -241,9 +246,9 @@ class Dialog(stbt.FrameObject):
     like this:
 
     >>> dialog
-    <Dialog(is_visible=True, message=u'This set-top box is great', title=u'Information')>
+    <Dialog(is_visible=True, message=u'This set-top box is great', title=...)>
     >>> dialog_fab
-    <Dialog(is_visible=True, message=u'This set-top box is fabulous', title=u'Information')>
+    <Dialog(is_visible=True, message=u'This set-top box is fabulous', title=...)>
     >>> no_dialog
     <Dialog(is_visible=False)>
 


### PR DESCRIPTION
To avoid triggering expensive calculations.
