### PR TITLE
FrameObject repr: Show self._frame

### DIFF
--- a/_stbt/frameobject.py
+++ b/_stbt/frameobject.py
@@ -214,7 +214,9 @@ class FrameObject(metaclass=_FrameObjectMeta):
                     args.append("%s=..." % (name,))
         else:
             args = ["is_visible=False"]
-        return "<%s(%s)>" % (self.__class__.__name__, ", ".join(args))
+        return "<%s(_frame=%r, %s)>" % (self.__class__.__name__,
+                                        self._frame,
+                                        ", ".join(args))
 
     def _iter_fields(self):
         if self:

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -46,17 +46,8 @@ class Frame(numpy.ndarray):
         self._draw_sink = getattr(obj, '_draw_sink', None)  # pylint: disable=attribute-defined-outside-init
 
     def __repr__(self):
-        if len(self.shape) == 3:
-            dimensions = "%dx%dx%d" % (
-                self.shape[1], self.shape[0], self.shape[2])  # pylint:disable=unsubscriptable-object
-
-        elif len(self.shape) == 2:
-            dimensions = "%dx%d" % (self.shape[1], self.shape[0])  # pylint:disable=unsubscriptable-object
-        else:
-            return super().__repr__()
-        return "<Frame(time=%s, dimensions=%s)>" % (
-            "None" if self.time is None else "%.3f" % self.time,
-            dimensions)
+        return "<Frame(time=%s)>" % (
+            "None" if self.time is None else "%.3f" % self.time,)
 
     def __str__(self):
         return repr(self)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -137,7 +137,7 @@ def test_that_image_and_frame_repr_can_print_numpy_scalar():
     # Operations like `numpy.max` propagate the type of the input, so its
     # output is still a `stbt.Image`.
     f = stbt.Frame(numpy.zeros((720, 1280, 3), dtype=numpy.uint8))
-    assert repr(numpy.max(f)) == "Frame(0, dtype=uint8)"
+    assert repr(numpy.max(f)) == "<Frame(time=None)>"
 
     img = stbt.load_image("action-panel.png")
     assert repr(numpy.max(img)) == "Image(255, dtype=uint8)"

--- a/tests/test_frameobject.py
+++ b/tests/test_frameobject.py
@@ -13,7 +13,7 @@ class TruthyFrameObject(stbt.FrameObject):
     >>> bool(TruthyFrameObject(frame))
     True
     >>> TruthyFrameObject(frame)
-    <TruthyFrameObject(is_visible=True)>
+    <TruthyFrameObject(_frame=<Frame(time=None)>, is_visible=True)>
     """
     @property
     def is_visible(self):
@@ -28,7 +28,7 @@ class FalseyFrameObject(stbt.FrameObject):
     >>> bool(fo)
     False
     >>> fo
-    <FalseyFrameObject(is_visible=False)>
+    <FalseyFrameObject(_frame=<Frame(time=None)>, is_visible=False)>
     >>> print(fo.public)
     None
     >>> fo._private
@@ -48,16 +48,17 @@ class FalseyFrameObject(stbt.FrameObject):
 
 
 class FrameObjectWithProperties(stbt.FrameObject):
+    # pylint:disable=line-too-long
     """Only public properties are listed in repr.
 
     >>> frame = _load_frame("with-dialog")
     >>> page = FrameObjectWithProperties(frame)
     >>> page
-    <FrameObjectWithProperties(is_visible=True, public=...)>
+    <FrameObjectWithProperties(_frame=<Frame(time=None)>, is_visible=True, public=...)>
     >>> page.public
     5
     >>> page
-    <FrameObjectWithProperties(is_visible=True, public=5)>
+    <FrameObjectWithProperties(_frame=<Frame(time=None)>, is_visible=True, public=5)>
     """
     @property
     def is_visible(self):
@@ -73,11 +74,12 @@ class FrameObjectWithProperties(stbt.FrameObject):
 
 
 class FrameObjectThatCallsItsOwnProperties(stbt.FrameObject):
+    # pylint:disable=line-too-long
     """Properties can be called from is_visible.
 
     >>> frame = _load_frame("with-dialog")
     >>> FrameObjectThatCallsItsOwnProperties(frame)
-    <FrameObjectThatCallsItsOwnProperties(is_visible=True, public=5)>
+    <FrameObjectThatCallsItsOwnProperties(_frame=<Frame(time=None)>, is_visible=True, public=5)>
     """
     @property
     def is_visible(self):
@@ -93,6 +95,7 @@ class FrameObjectThatCallsItsOwnProperties(stbt.FrameObject):
 
 
 class PrintingFrameObject(stbt.FrameObject):
+    # pylint:disable=line-too-long
     """
     This is a very naughty FrameObject.  It's properties cause side-effects so
     we can check that the caching is working:
@@ -111,7 +114,7 @@ class PrintingFrameObject(stbt.FrameObject):
     >>> m.another
     10
     >>> m
-    <PrintingFrameObject(is_visible=True, another=10)>
+    <PrintingFrameObject(_frame=<Frame(time=None)>, is_visible=True, another=10)>
     """
     @property
     def is_visible(self):
@@ -154,7 +157,7 @@ class FalseyPrintingFrameObject(stbt.FrameObject):
     >>> m._another
     11
     >>> m
-    <FalseyPrintingFrameObject(is_visible=False)>
+    <FalseyPrintingFrameObject(_frame=<Frame(time=None)>, is_visible=False)>
     """
     @property
     def is_visible(self):
@@ -205,7 +208,7 @@ def test_that_is_visible_and_properties_arent_racy():
 
 
 def _load_frame(name):
-    return stbt.load_image("images/frameobject/%s.png" % name)
+    return stbt.Frame(stbt.load_image("images/frameobject/%s.png" % name))
 
 
 class Dialog(stbt.FrameObject):
@@ -246,11 +249,11 @@ class Dialog(stbt.FrameObject):
     like this:
 
     >>> dialog
-    <Dialog(is_visible=True, message=u'This set-top box is great', title=...)>
+    <Dialog(_frame=<Frame(time=None)>, is_visible=True, message=u'This set-top box is great', title=...)>
     >>> dialog_fab
-    <Dialog(is_visible=True, message=u'This set-top box is fabulous', title=...)>
+    <Dialog(_frame=<Frame(time=None)>, is_visible=True, message=u'This set-top box is fabulous', title=...)>
     >>> no_dialog
-    <Dialog(is_visible=False)>
+    <Dialog(_frame=<Frame(time=None)>, is_visible=False)>
 
     This makes it convenient to use doctests for unit-testing your Frame
     Objects.
@@ -276,7 +279,7 @@ class Dialog(stbt.FrameObject):
     in a dict:
 
     >>> {dialog: 1}
-    {<Dialog(is_visible=True, message=u'This set-top box is great', title=u'Information')>: 1}
+    {<Dialog(_frame=<Frame(time=None)>, is_visible=True, message=u'This set-top box is great', title=u'Information')>: 1}
     >>> len({no_dialog, dialog, dialog, dialog_bunnies})
     2
 

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -16,7 +16,7 @@ def test_motionresult_repr():
         == ("MotionResult("
             "time=1466002032.336, motion=True, "
             "region=Region(x=321, y=32, right=334, bottom=42), "
-            "frame=<Frame(time=1466002032.336, dimensions=1280x720x3)>)")
+            "frame=<Frame(time=1466002032.336)>)")
 
 
 def test_wait_for_motion_half_motion_str_2of4():


### PR DESCRIPTION
So that you can see the frame timestamp associated with the FrameObject, click on it to see that frame in the video, etc.