### PR TITLE
Print deprecation warning for deprecated "region" parameter

### DIFF
--- a/_stbt/black.py
+++ b/_stbt/black.py
@@ -8,6 +8,7 @@ License: LGPL v2.1 or (at your option) any later version (see
 https://github.com/stb-tester/stb-tester/blob/master/LICENSE for details).
 """
 
+import warnings
 from typing import Optional
 
 import cv2
@@ -68,6 +69,10 @@ def is_screen_black(frame: Optional[Frame] = None,
     if region is not Region.ALL:
         if mask is not Region.ALL:
             raise ValueError("Cannot specify mask and region at the same time")
+        warnings.warn(
+            "stbt.is_screen_black: The 'region' parameter is deprecated; "
+            "pass your Region to 'mask' instead",
+            DeprecationWarning, stacklevel=2)
         mask = region
 
     mask_, region = load_mask(mask).to_array(frame.region)

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -36,8 +36,7 @@ from gi.repository import GLib, Gst  # pylint:disable=wrong-import-order
 Gst.init(None)
 
 warnings.filterwarnings(
-    action="always", category=DeprecationWarning, message='.*stb-tester')
-
+    action="default", category=DeprecationWarning, module=r"_stbt")
 
 # Functions available to stbt scripts
 # ===========================================================================

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -384,7 +384,7 @@ def load_image(filename, flags=None, color_channels=None) -> Image:
         warnings.warn(
             "load_image: flags=%s argument is deprecated. Use "
             "color_channels=%r instead" % (flags, color_channels),
-            DeprecationWarning)
+            DeprecationWarning, stacklevel=2)
 
     if color_channels is None:
         color_channels = (3, 4)

--- a/_stbt/motion.py
+++ b/_stbt/motion.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 
+import warnings
 from collections import deque
 
 from .config import ConfigurationError, get_config
@@ -66,6 +67,10 @@ def detect_motion(timeout_secs=10, noise_threshold=None, mask=Region.ALL,
     if region is not Region.ALL:
         if mask is not Region.ALL:
             raise ValueError("Cannot specify mask and region at the same time")
+        warnings.warn(
+            "stbt.detect_motion: The 'region' parameter is deprecated; "
+            "pass your Region to 'mask' instead",
+            DeprecationWarning, stacklevel=2)
         mask = region
 
     debug(f"Searching for motion, using mask={mask}")
@@ -147,6 +152,15 @@ def wait_for_motion(
         raise ConfigurationError(
             "`motion_frames` exceeds `considered_frames`")
 
+    if region is not Region.ALL:
+        if mask is not Region.ALL:
+            raise ValueError("Cannot specify mask and region at the same time")
+        warnings.warn(
+            "stbt.wait_for_motion: The 'region' parameter is deprecated; "
+            "pass your Region to 'mask' instead",
+            DeprecationWarning, stacklevel=2)
+        mask = region
+
     debug("Waiting for %d out of %d frames with motion, using mask=%r" % (
         motion_frames, considered_frames, mask))
 
@@ -154,7 +168,7 @@ def wait_for_motion(
     motion_count = 0
     last_frame = None
     for res in detect_motion(
-            timeout_secs, noise_threshold, mask, region, frames):
+            timeout_secs, noise_threshold, mask, frames=frames):
         motion_count += bool(res)
         if len(matches) == matches.maxlen:
             motion_count -= bool(matches.popleft())

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -14,6 +14,7 @@ https://github.com/stb-tester/stb-tester/blob/master/LICENSE for details).
 """
 
 import enum
+import warnings
 
 from .diff import MotionDiff
 from .logging import ddebug, debug, draw_on
@@ -107,6 +108,10 @@ def press_and_wait(
     if region is not Region.ALL:
         if mask is not Region.ALL:
             raise ValueError("Cannot specify mask and region at the same time")
+        warnings.warn(
+            "stbt.press_and_wait: The 'region' parameter is deprecated; "
+            "pass your Region to 'mask' instead",
+            DeprecationWarning, stacklevel=2)
         mask = region
 
     t = _Transition(mask, timeout_secs, stable_secs, min_size, _dut)
@@ -154,6 +159,10 @@ def wait_for_transition_to_end(
     if region is not Region.ALL:
         if mask is not Region.ALL:
             raise ValueError("Cannot specify mask and region at the same time")
+        warnings.warn(
+            "stbt.wait_for_transition_to_end: The 'region' parameter is "
+            "deprecated; pass your Region to 'mask' instead",
+            DeprecationWarning, stacklevel=2)
         mask = region
 
     t = _Transition(mask, timeout_secs, stable_secs, min_size, _dut)


### PR DESCRIPTION
Note: stacklevel=2 shows the line of code that called is_screen_black (etc) instead of the line of code in is_screen_black itself that is calling `warnings.warn`.

stacklevel=1:

    _stbt/black.py:72: DeprecationWarning: stbt.is_screen_black: The 'region' parameter is deprecated; pass your Region to 'mask' instead
      warnings.warn(

stacklevel=2:

    test.py:4: DeprecationWarning: stbt.is_screen_black: The 'region' parameter is deprecated; pass your Region to 'mask' instead
      print(stbt.is_screen_black(region=stbt.Region(0,0,100,100)))

I also changed the warnings filter so that these messages actually get shown. The "default" action prints the warning once per (file, line number) — i.e. once per call-site.