### PR TITLE
is_screen_black, MotionDiff: Use _image_region instead of frame.region

### DIFF
--- a/_stbt/black.py
+++ b/_stbt/black.py
@@ -14,7 +14,8 @@ from typing import Optional
 import cv2
 
 from .config import get_config
-from .imgutils import crop, Frame, _frame_repr, pixel_bounding_box
+from .imgutils import (
+    crop, Frame, _frame_repr, _image_region, pixel_bounding_box)
 from .logging import debug, ImageLogger
 from .mask import load_mask, MaskTypes
 from .types import Region
@@ -75,7 +76,7 @@ def is_screen_black(frame: Optional[Frame] = None,
             DeprecationWarning, stacklevel=2)
         mask = region
 
-    mask_, region = load_mask(mask).to_array(frame.region)
+    mask_, region = load_mask(mask).to_array(_image_region(frame))
 
     imglog = ImageLogger("is_screen_black", region=region, threshold=threshold)
     imglog.imwrite("source", frame)

--- a/_stbt/diff.py
+++ b/_stbt/diff.py
@@ -4,7 +4,7 @@ import cv2
 import numpy
 
 from .config import get_config
-from .imgutils import crop, _frame_repr, pixel_bounding_box
+from .imgutils import crop, _frame_repr, _image_region, pixel_bounding_box
 from .logging import ddebug, ImageLogger
 from .mask import load_mask
 from .types import Region
@@ -36,7 +36,8 @@ class MotionDiff(FrameDiffer):
         self.prev_frame = initial_frame
         self.min_size = min_size
 
-        self.mask_, self.region = load_mask(mask).to_array(initial_frame.region)
+        self.mask_, self.region = load_mask(mask).to_array(
+            _image_region(initial_frame))
 
         if threshold is None:
             threshold = get_config('motion', 'noise_threshold', type_=float)


### PR DESCRIPTION
To support numpy arrays that aren't a `stbt.Frame`. We'd probably never hit this outside our own selftests but no need to introduced a breaking change if we don't need to.