### PR TITLE
BGRDiff: Fix mask number of channels

### DIFF
--- a/_stbt/diff.py
+++ b/_stbt/diff.py
@@ -3,7 +3,6 @@
 import cv2
 import numpy
 
-from .config import get_config
 from .imgutils import crop, _frame_repr, _image_region, pixel_bounding_box
 from .logging import ddebug, ImageLogger
 from .mask import load_mask
@@ -200,16 +199,13 @@ class GrayscaleDiff(FrameDiffer):
     """
 
     def __init__(self, initial_frame, mask=Region.ALL, min_size=None,
-                 threshold=None, erode=True):
+                 threshold=0.84, erode=True):
         self.prev_frame = initial_frame
         self.min_size = min_size
+        self.threshold = threshold
 
         self.mask_, self.region = load_mask(mask).to_array(
             _image_region(initial_frame))
-
-        if threshold is None:
-            threshold = get_config('motion', 'noise_threshold', type_=float)
-        self.threshold = threshold
 
         if isinstance(erode, numpy.ndarray):  # For power users
             kernel = erode

--- a/_stbt/diff.py
+++ b/_stbt/diff.py
@@ -81,7 +81,7 @@ class BGRDiff(FrameDiffer):
         self.threshold = threshold
 
         self.mask_, self.region = load_mask(mask).to_array(
-            _image_region(initial_frame), color_channels=3)
+            _image_region(initial_frame))
 
         if isinstance(erode, numpy.ndarray):  # For power users
             kernel = erode
@@ -105,6 +105,7 @@ class BGRDiff(FrameDiffer):
         sqd = (sqd[:, :, 0] ** 2 +
                sqd[:, :, 1] ** 2 +
                sqd[:, :, 2] ** 2)
+        sqd = sqd.reshape(sqd.shape + (1,))
 
         if imglog.enabled:
             normalised = numpy.sqrt(sqd / 3)

--- a/_stbt/motion.py
+++ b/_stbt/motion.py
@@ -73,6 +73,9 @@ def detect_motion(timeout_secs=10, noise_threshold=None, mask=Region.ALL,
             DeprecationWarning, stacklevel=2)
         mask = region
 
+    if noise_threshold is None:
+        noise_threshold = get_config('motion', 'noise_threshold', type_=float)
+
     debug(f"Searching for motion, using mask={mask}")
 
     try:

--- a/tests/masks.ipynb
+++ b/tests/masks.ipynb
@@ -41,9 +41,22 @@
     "def frames():\n",
     "    yield f1\n",
     "    yield f2\n",
+    "stbt.detect_motion.differ = stbt.GrayscaleDiff\n",
     "next(stbt.detect_motion(frames=frames()))\n",
     "next(stbt.detect_motion(mask=stbt.Region(x=10, y=60, right=85, bottom=85), frames=frames()))\n",
     "next(stbt.detect_motion(mask=stbt.Region(10, 10, right=80, bottom=150) - stbt.Region(x=10, y=60, right=85, bottom=85), frames=frames()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stbt.detect_motion.differ = stbt.BGRDiff\n",
+    "next(stbt.detect_motion(frames=frames(), noise_threshold=40))\n",
+    "next(stbt.detect_motion(mask=stbt.Region(x=10, y=60, right=85, bottom=85), frames=frames(), noise_threshold=40))\n",
+    "next(stbt.detect_motion(mask=stbt.Region(10, 10, right=80, bottom=150) - stbt.Region(x=10, y=60, right=85, bottom=85), frames=frames(), noise_threshold=40))"
    ]
   }
  ],

--- a/tests/test_transition.py
+++ b/tests/test_transition.py
@@ -129,6 +129,8 @@ def test_press_and_wait_stable_timeout(diff_algorithm, min_size):
      stbt.TransitionStatus.STABLE_TIMEOUT),
     (stbt.Region.ALL, (0, 32), stbt.TransitionStatus.START_TIMEOUT),
     (stbt.Region.ALL, (0, 10), stbt.TransitionStatus.STABLE_TIMEOUT),
+    (~stbt.Region(x=10, y=340, right=640, bottom=380), None,
+     stbt.TransitionStatus.STABLE_TIMEOUT),
 ])
 def test_press_and_wait_with_mask_or_region(mask, min_size, expected,
                                             diff_algorithm):


### PR DESCRIPTION
> d = numpy.logical_and(d, mask_pixels)
> ValueError: operands could not be broadcast together with shapes (720,1280) (720,1280,3)

None of the regions in our unit test actually resulted in a pixel mask -- they were all "simple" masks that could be expressed as a region.