### PR TITLE
LIRC control: Increase socket timeout

### DIFF
--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -304,7 +304,7 @@ def new_local_lirc_control(lircd_socket, control_name):
     def _connect():
         try:
             s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            s.settimeout(3)
+            s.settimeout(10)
             s.connect(lircd_socket)
             return s
         except socket.error as e:


### PR DESCRIPTION
The first keypress can take a while if the lircd (or stbt-control-relay) process is socket-activated and hasn't started yet.