### PR TITLE
stbt lint: stbt-missing-image: Fix false positive for f-strings

### DIFF
--- a/_stbt/pylint_plugin.py
+++ b/_stbt/pylint_plugin.py
@@ -16,7 +16,7 @@ import subprocess
 
 from astroid import (
     Assert, Attribute, BinOp, Call, ClassDef, Const, Expr, FunctionDef,
-    Keyword, MANAGER, Name, Raise, Uninferable)
+    JoinedStr, Keyword, MANAGER, Name, Raise, Uninferable)
 from astroid.context import InferenceContext
 from pylint.checkers import BaseChecker
 from pylint.interfaces import IAstroidChecker
@@ -218,7 +218,7 @@ def _is_uri(filename):
 
 def _is_calculated_value(node):
     return (
-        isinstance(node.parent, BinOp) or
+        isinstance(node.parent, (BinOp, JoinedStr)) or
         (isinstance(node.parent, Call) and
          node.parent.func.as_string().split(".")[-1] in ("join", "replace")))
 

--- a/tests/test-stbt-lint.sh
+++ b/tests/test-stbt-lint.sh
@@ -37,6 +37,7 @@ test_that_stbt_lint_ignores_generated_image_names() {
 	var = 'idontexist'
 	stbt.wait_for_match(var + '.png')
 	stbt.wait_for_match('%s.png' % var)
+	stbt.wait_for_match(f"{var} - selected.png")
 	stbt.wait_for_match(os.path.join('directory', 'idontexist.png'))
 	stbt.wait_for_match(join('directory', 'idontexist.png'))
 	var.replace('idontexist', 'idontexist.png')


### PR DESCRIPTION
Astroid represents `f"{var} - selected.png"` like this:

    JoinedStr(values=[
        FormattedValue(value=<Name.var>),
        Const.str(value=" - selected.png")
    ])

Without this commit, we'd report a false positive:

> E:  6,20: Image " - selected.png" not found on disk (stbt-missing-image)