### PR TITLE
Make BGRDiff the default for press_and_wait / detect_motion / wait_for_motion

### DIFF
--- a/_stbt/motion.py
+++ b/_stbt/motion.py
@@ -5,7 +5,7 @@ from collections import deque
 from typing import Iterator, Optional
 
 from .config import ConfigurationError, get_config
-from .diff import FrameDiffer, GrayscaleDiff, MotionResult
+from .diff import BGRDiff, FrameDiffer, MotionResult
 from .imgutils import limit_time, FrameT
 from .logging import debug, draw_on
 from .mask import MaskTypes
@@ -99,7 +99,7 @@ def detect_motion(
         yield result
 
 
-detect_motion.differ : FrameDiffer = GrayscaleDiff
+detect_motion.differ : FrameDiffer = BGRDiff
 
 
 def wait_for_motion(

--- a/_stbt/stbt.conf
+++ b/_stbt/stbt.conf
@@ -36,7 +36,7 @@ interval_secs = 3
 max_presses = 10
 
 [motion]
-noise_threshold=0.84
+noise_threshold=25
 consecutive_frames=10/20
 
 [is_screen_black]

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -17,7 +17,7 @@ import enum
 import warnings
 from typing import Iterator, Optional
 
-from .diff import FrameDiffer, GrayscaleDiff
+from .diff import BGRDiff, FrameDiffer
 from .imgutils import FrameT
 from .logging import ddebug, debug, draw_on
 from .mask import MaskTypes
@@ -139,7 +139,7 @@ def press_and_wait(
     return result
 
 
-press_and_wait.differ: FrameDiffer = GrayscaleDiff
+press_and_wait.differ: FrameDiffer = BGRDiff
 
 
 def wait_for_transition_to_end(

--- a/tests/stbt.conf
+++ b/tests/stbt.conf
@@ -34,7 +34,7 @@ interval_secs = 3
 max_presses = 10
 
 [motion]
-noise_threshold=0.84
+noise_threshold=25
 consecutive_frames=10/20
 
 [is_screen_black]

--- a/tests/test-motion.sh
+++ b/tests/test-motion.sh
@@ -80,18 +80,18 @@ test_wait_for_motion_with_region_does_not_report_motion() {
     ! stbt run -v test.py
 }
 
-test_wait_for_motion_with_high_noisethreshold_reports_motion() {
+test_wait_for_motion_with_low_noisethreshold_reports_motion() {
     cat > test.py <<-EOF
 	from stbt_core import wait_for_motion
-	wait_for_motion(noise_threshold=1.0)
+	wait_for_motion(noise_threshold=0)
 	EOF
     stbt run -v test.py
 }
 
-test_wait_for_motion_with_low_noisethreshold_does_not_report_motion() {
+test_wait_for_motion_with_high_noisethreshold_does_not_report_motion() {
     cat > test.py <<-EOF
 	from stbt_core import wait_for_motion
-	wait_for_motion(noise_threshold=0.0, timeout_secs=1)
+	wait_for_motion(noise_threshold=255, timeout_secs=1)
 	EOF
     ! stbt run -v test.py
 }

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -111,7 +111,7 @@ def wipe():
     frame = numpy.zeros((720, 1280, 3), dtype=numpy.uint8)
     for x in range(0, 720, 2):
         frame[x:x + 2, :, :] = 255
-        yield stbt.Frame(frame, time=x / 30.)
+        yield stbt.Frame(frame.copy(), time=x / 30.)
 
 
 def clamp(x, bottom, top):
@@ -124,10 +124,10 @@ def gradient_wipe(min_=100, max_=200, swipe_height=40):
         (720 + swipe_height * 4, 1280, 3), dtype=numpy.uint8)
     diff = max_ - min_
 
-    # detect_motion ignores differences of under 40, so what's the fastest we
+    # detect_motion ignores differences of under 25, so what's the fastest we
     # can wipe while making sure the inter-frame differences are always under
-    # 40?:
-    speed = 40 * swipe_height / diff
+    # 25?:
+    speed = 24 * swipe_height / diff
 
     print("pixel difference: %f" % (diff / swipe_height))
     print("max_speed: %f" % speed)
@@ -139,7 +139,7 @@ def gradient_wipe(min_=100, max_=200, swipe_height=40):
 
     for x in range(0, frame.shape[0] - swipe_height * 3, int(speed)):
         frame[x:x + swipe_height * 3, :, :] = edge
-        yield stbt.Frame(frame[swipe_height * 2:swipe_height * 2 + 720],
+        yield stbt.Frame(frame[swipe_height * 2:swipe_height * 2 + 720].copy(),
                          time=x / 30.)
 
 

--- a/tests/test_stbt_debug.py
+++ b/tests/test_stbt_debug.py
@@ -343,57 +343,49 @@ def test_motion_debug():
         assert files == dedent("""\
             stbt-debug
             stbt-debug/00001
-            stbt-debug/00001/absdiff.png
-            stbt-debug/00001/absdiff_threshold_erode.png
-            stbt-debug/00001/absdiff_threshold.png
-            stbt-debug/00001/gray.png
+            stbt-debug/00001/eroded.png
             stbt-debug/00001/index.html
-            stbt-debug/00001/previous_frame_gray.png
+            stbt-debug/00001/previous_frame.png
             stbt-debug/00001/source.png
+            stbt-debug/00001/sqd.png
+            stbt-debug/00001/thresholded.png
             stbt-debug/00002
-            stbt-debug/00002/absdiff.png
-            stbt-debug/00002/absdiff_threshold_erode.png
-            stbt-debug/00002/absdiff_threshold.png
-            stbt-debug/00002/gray.png
+            stbt-debug/00002/eroded.png
             stbt-debug/00002/index.html
-            stbt-debug/00002/previous_frame_gray.png
+            stbt-debug/00002/previous_frame.png
             stbt-debug/00002/source.png
+            stbt-debug/00002/sqd.png
+            stbt-debug/00002/thresholded.png
             stbt-debug/00003
-            stbt-debug/00003/absdiff_masked.png
-            stbt-debug/00003/absdiff.png
-            stbt-debug/00003/absdiff_threshold_erode.png
-            stbt-debug/00003/absdiff_threshold.png
-            stbt-debug/00003/gray.png
+            stbt-debug/00003/eroded.png
             stbt-debug/00003/index.html
             stbt-debug/00003/mask.png
-            stbt-debug/00003/previous_frame_gray.png
+            stbt-debug/00003/previous_frame.png
             stbt-debug/00003/source.png
+            stbt-debug/00003/sqd.png
+            stbt-debug/00003/thresholded.png
             stbt-debug/00004
-            stbt-debug/00004/absdiff_masked.png
-            stbt-debug/00004/absdiff.png
-            stbt-debug/00004/absdiff_threshold_erode.png
-            stbt-debug/00004/absdiff_threshold.png
-            stbt-debug/00004/gray.png
+            stbt-debug/00004/eroded.png
             stbt-debug/00004/index.html
             stbt-debug/00004/mask.png
-            stbt-debug/00004/previous_frame_gray.png
+            stbt-debug/00004/previous_frame.png
             stbt-debug/00004/source.png
+            stbt-debug/00004/sqd.png
+            stbt-debug/00004/thresholded.png
             stbt-debug/00005
-            stbt-debug/00005/absdiff.png
-            stbt-debug/00005/absdiff_threshold_erode.png
-            stbt-debug/00005/absdiff_threshold.png
-            stbt-debug/00005/gray.png
+            stbt-debug/00005/eroded.png
             stbt-debug/00005/index.html
-            stbt-debug/00005/previous_frame_gray.png
+            stbt-debug/00005/previous_frame.png
             stbt-debug/00005/source.png
+            stbt-debug/00005/sqd.png
+            stbt-debug/00005/thresholded.png
             stbt-debug/00006
-            stbt-debug/00006/absdiff.png
-            stbt-debug/00006/absdiff_threshold_erode.png
-            stbt-debug/00006/absdiff_threshold.png
-            stbt-debug/00006/gray.png
+            stbt-debug/00006/eroded.png
             stbt-debug/00006/index.html
-            stbt-debug/00006/previous_frame_gray.png
+            stbt-debug/00006/previous_frame.png
             stbt-debug/00006/source.png
+            stbt-debug/00006/sqd.png
+            stbt-debug/00006/thresholded.png
         """)
 
         assert_expected("stbt-debug-expected-output/motion")


### PR DESCRIPTION
The previous default (GrayscaleDiff) doesn't detect changes that are different in colour but of a similar overall intensity, such as the XFinity keyboard shown in `tests/test_diff.py::test_bgrdiff`.
