### PR TITLE
Mask: Add `from_alpha_channel` constructor

### DIFF
--- a/_stbt/mask.py
+++ b/_stbt/mask.py
@@ -8,7 +8,7 @@ import cv2
 import numpy
 
 from .imgutils import (
-    _convert_color, crop, find_file, Image, ImageT, load_image,
+    _convert_color, crop, find_file, Image, ImageT, _image_region, load_image,
     pixel_bounding_box, _relative_filename)
 from .logging import logger
 from .types import Region
@@ -117,9 +117,10 @@ class Mask:
           path lookup algorithm.
         """
         image = load_image(image)
-        if image.shape[2] != 4:
-            raise ValueError(f"{image} doesn't have an alpha channel")
-        return Mask(image[:, :, 3])
+        if image.shape[2] == 4:
+            return Mask(image[:, :, 3])
+        else:
+            return Mask(_image_region(image))
 
     def __eq__(self, o):
         if isinstance(o, Region):

--- a/_stbt/mask.py
+++ b/_stbt/mask.py
@@ -8,8 +8,8 @@ import cv2
 import numpy
 
 from .imgutils import (
-    _convert_color, crop, find_file, Image, load_image, pixel_bounding_box,
-    _relative_filename)
+    _convert_color, crop, find_file, Image, ImageT, load_image,
+    pixel_bounding_box, _relative_filename)
 from .logging import logger
 from .types import Region
 
@@ -102,6 +102,24 @@ class Mask:
         else:
             raise TypeError("Expected filename, Image, Mask, or Region. "
                             f"Got {m!r}")
+
+    @staticmethod
+    def from_alpha_channel(image: ImageT) -> Mask:
+        """Create a mask from the alpha channel of an image.
+
+        :type image: string or `numpy.ndarray`
+        :param image:
+          An image with an alpha (transparency) channel. This can be the
+          filename of a png file on disk, or an image previously loaded with
+          `stbt.load_image`.
+
+          Filenames should be relative paths. See `stbt.load_image` for the
+          path lookup algorithm.
+        """
+        image = load_image(image)
+        if image.shape[2] != 4:
+            raise ValueError(f"{image} doesn't have an alpha channel")
+        return Mask(image[:, :, 3])
 
     def __eq__(self, o):
         if isinstance(o, Region):

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -354,3 +354,16 @@ def test_1080p_mask():
     mask_pixels, mask_region = mask.to_array(_image_region(frame))
     assert mask_region == Region(x=49, y=750, right=1866, bottom=1011)
     assert mask_pixels.shape == (261, 1817, 1)
+
+
+def test_mask_from_alpha_channel():
+    with pytest.raises(ValueError, match=(
+            r"<Image\(filename='.*', dimensions=.*x.*x3\)> "
+            r"doesn't have an alpha channel")):
+        Mask.from_alpha_channel("videotestsrc-full-frame.png")
+
+    alpha = Mask.from_alpha_channel("videotestsrc-blacktransparent-blue.png")
+    _, mask_region = alpha.to_array(Region(0, 0, 138, 160))
+    assert mask_region == Region(0, 0, 138, 160)
+    _, mask_region = (~alpha).to_array(Region(0, 0, 138, 160))
+    assert mask_region == Region(46, 0, right=92, bottom=160)

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -357,11 +357,11 @@ def test_1080p_mask():
 
 
 def test_mask_from_alpha_channel():
-    with pytest.raises(ValueError, match=(
-            r"<Image\(filename='.*', dimensions=.*x.*x3\)> "
-            r"doesn't have an alpha channel")):
-        Mask.from_alpha_channel("videotestsrc-full-frame.png")
+    # Image without alpha channel
+    assert Mask.from_alpha_channel("videotestsrc-full-frame.png") == \
+        Region(0, 0, 320, 240)
 
+    # Image with alpha channel
     alpha = Mask.from_alpha_channel("videotestsrc-blacktransparent-blue.png")
     _, mask_region = alpha.to_array(Region(0, 0, 138, 160))
     assert mask_region == Region(0, 0, 138, 160)


### PR DESCRIPTION
Useful when you have a reference image with some transparent parts, but you want to use that same mask for an operation other than `match`.