### PR TITLE
Rename libstbt.so => libstbt.x86_64.so

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 .stbt-prefix
 .venv
 __pycache__
-_stbt/libstbt.so
+_stbt/libstbt.x86_64.so
 debian-packages
 docs/stbt.1
 dist/

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ INSTALL_PYLIB_FILES = \
     _stbt/imgutils.py \
     _stbt/irnetbox.py \
     _stbt/keyboard.py \
-    _stbt/libstbt.so \
+    _stbt/libstbt.x86_64.so \
     _stbt/logging.py \
     _stbt/mask.py \
     _stbt/match.py \
@@ -297,7 +297,7 @@ sq = $(subst ','\'',$(1)) # function to escape single quotes (')
 TAGS:
 	etags stbt_core/**.py _stbt/**.py
 
-_stbt/libstbt.so : _stbt/sqdiff.c
+_stbt/libstbt.x86_64.so : _stbt/sqdiff.c
 	$(CC) -shared -fPIC -O3 -o $@ _stbt/sqdiff.c $(CFLAGS)
 
 ### Documentation ############################################################

--- a/_stbt/sqdiff.py
+++ b/_stbt/sqdiff.py
@@ -1,5 +1,6 @@
 import ctypes
 import os
+import platform
 
 import numpy
 
@@ -10,7 +11,7 @@ def _find_file(path, root=os.path.dirname(os.path.abspath(__file__))):
     return os.path.join(root, path)
 
 
-_libstbt = ctypes.CDLL(_find_file("libstbt.so"))
+_libstbt = ctypes.CDLL(_find_file(f"libstbt.{platform.machine()}.so"))
 
 
 class _SqdiffResult(ctypes.Structure):


### PR DESCRIPTION
To make it easier to build a single package that supports multiple architectures.