### PR TITLE
API: press_and_wait/wait_for_transition_to_end: Add public frames parameter

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -10,6 +10,7 @@ https://github.com/stb-tester/stb-tester/blob/master/LICENSE for details).
 import argparse
 import datetime
 import sys
+import typing
 import threading
 import warnings
 import weakref
@@ -33,6 +34,11 @@ gi.require_version("Gst", "1.0")
 from gi.repository import GLib, Gst  # pylint:disable=wrong-import-order
 
 Gst.init(None)
+
+if typing.TYPE_CHECKING:
+    # pylint:disable=unused-import
+    from _stbt.control import RemoteControl
+    # pylint:enable=unused-import
 
 warnings.filterwarnings(
     action="default", category=DeprecationWarning, module=r"_stbt")
@@ -84,13 +90,13 @@ class DeviceUnderTest():
                  mainloop=None, _time=None):
         if _time is None:
             import time as _time
-        self._time_of_last_press = 0
-        self._display = display
-        self._control = control
-        self._sink_pipeline = sink_pipeline
-        self._mainloop = mainloop
+        self._time_of_last_press: float = 0
+        self._display: "Display" = display
+        self._control: "RemoteControl" = control
+        self._sink_pipeline: "SinkPipeline" = sink_pipeline
+        self._mainloop: "typing.ContextManager[None]" = mainloop
         self._time = _time
-        self._last_keypress = None
+        self._last_keypress: "Keypress|None" = None
 
     def __enter__(self):
         if self._display:

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -7,6 +7,8 @@ License: LGPL v2.1 or (at your option) any later version (see
 https://github.com/stb-tester/stb-tester/blob/master/LICENSE for details).
 """
 
+from __future__ import annotations
+
 import argparse
 import datetime
 import sys
@@ -91,12 +93,12 @@ class DeviceUnderTest():
         if _time is None:
             import time as _time
         self._time_of_last_press: float = 0
-        self._display: "Display" = display
-        self._control: "RemoteControl" = control
-        self._sink_pipeline: "SinkPipeline" = sink_pipeline
-        self._mainloop: "typing.ContextManager[None]" = mainloop
+        self._display: Display = display
+        self._control: RemoteControl = control
+        self._sink_pipeline: SinkPipeline = sink_pipeline
+        self._mainloop: typing.ContextManager[None] = mainloop
         self._time = _time
-        self._last_keypress: "Keypress|None" = None
+        self._last_keypress: Keypress | None = None
 
     def __enter__(self):
         if self._display:

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -130,7 +130,7 @@ def press_and_wait(
             DeprecationWarning, stacklevel=2)
         mask = region
 
-    t = _Transition(mask, timeout_secs, stable_secs, min_size, _dut)
+    t = _Transition(mask, timeout_secs, stable_secs, min_size, _dut.frames())
     press_result = _dut.press(key)
     debug("transition: %.3f: Pressed %s" % (press_result.end_time, key))
     result = t.wait(press_result)
@@ -148,7 +148,7 @@ def wait_for_transition_to_end(
     timeout_secs: float = 10,
     stable_secs: float = 1,
     min_size: "SizeT|None" = None,
-    _dut=None,
+    _frames: "typing.Iterator[core.Frame]|None" = None,
 ) -> _TransitionResult:
 
     """Wait for the screen to stop changing.
@@ -174,9 +174,9 @@ def wait_for_transition_to_end(
 
     :returns: See `press_and_wait`.
     """
-    if _dut is None:
+    if _frames is None:
         import stbt_core
-        _dut = stbt_core
+        _frames = stbt_core.frames()
 
     if region is not Region.ALL:
         if mask is not Region.ALL:
@@ -187,7 +187,7 @@ def wait_for_transition_to_end(
             DeprecationWarning, stacklevel=2)
         mask = region
 
-    t = _Transition(mask, timeout_secs, stable_secs, min_size, _dut)
+    t = _Transition(mask, timeout_secs, stable_secs, min_size, _frames)
     result = t.wait_for_transition_to_end(initial_frame)
     debug("wait_for_transition_to_end() -> %s" % (result,))
     return result
@@ -196,14 +196,13 @@ def wait_for_transition_to_end(
 class _Transition():
     def __init__(self, mask: "MaskTypes", timeout_secs: float,
                  stable_secs: float, min_size: "SizeT|None",
-                 dut: "core.DeviceUnderTest"):
+                 frames: "typing.Iterator[core.Frame]"):
         self.mask = mask
         self.timeout_secs = timeout_secs
         self.stable_secs = stable_secs
         self.min_size = min_size
-        self.dut = dut
+        self.frames = frames
 
-        self.frames = self.dut.frames()
         self.expiry_time = None
 
     def wait(self, press_result):

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -38,6 +38,7 @@ def press_and_wait(
     timeout_secs: float = 10,
     stable_secs: float = 1,
     min_size: "SizeT|None" = None,
+    frames: "typing.Iterator[core.Frame]|None" = None,
     _dut=None,
 ) -> _TransitionResult:
 
@@ -72,6 +73,9 @@ def press_and_wait(
         to be considered as "motion". Use this to ignore small differences,
         such as the blinking text cursor in a search box.
     :type min_size: Tuple[int, int]
+
+    :param frames: An iterable of video-frames to analyse. Defaults to
+        `stbt.frames()`.
 
     :returns:
         An object that will evaluate to true if the transition completed, false
@@ -120,6 +124,8 @@ def press_and_wait(
     if _dut is None:
         import stbt_core
         _dut = stbt_core
+    if frames is None:
+        frames = _dut.frames()
 
     if region is not Region.ALL:
         if mask is not Region.ALL:
@@ -130,7 +136,7 @@ def press_and_wait(
             DeprecationWarning, stacklevel=2)
         mask = region
 
-    t = _Transition(mask, timeout_secs, stable_secs, min_size, _dut.frames())
+    t = _Transition(mask, timeout_secs, stable_secs, min_size, frames)
     press_result = _dut.press(key)
     debug("transition: %.3f: Pressed %s" % (press_result.end_time, key))
     result = t.wait(press_result)
@@ -148,7 +154,7 @@ def wait_for_transition_to_end(
     timeout_secs: float = 10,
     stable_secs: float = 1,
     min_size: "SizeT|None" = None,
-    _frames: "typing.Iterator[core.Frame]|None" = None,
+    frames: "typing.Iterator[core.Frame]|None" = None,
 ) -> _TransitionResult:
 
     """Wait for the screen to stop changing.
@@ -171,12 +177,14 @@ def wait_for_transition_to_end(
     :param Region region: See `press_and_wait`.
     :param int|float timeout_secs: See `press_and_wait`.
     :param int|float stable_secs: See `press_and_wait`.
+    :param frames: An iterable of video-frames to analyse. Defaults to
+        `stbt.frames()`.
 
     :returns: See `press_and_wait`.
     """
-    if _frames is None:
+    if frames is None:
         import stbt_core
-        _frames = stbt_core.frames()
+        frames = stbt_core.frames()
 
     if region is not Region.ALL:
         if mask is not Region.ALL:
@@ -187,7 +195,7 @@ def wait_for_transition_to_end(
             DeprecationWarning, stacklevel=2)
         mask = region
 
-    t = _Transition(mask, timeout_secs, stable_secs, min_size, _frames)
+    t = _Transition(mask, timeout_secs, stable_secs, min_size, frames)
     result = t.wait_for_transition_to_end(initial_frame)
     debug("wait_for_transition_to_end() -> %s" % (result,))
     return result

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -14,21 +14,14 @@ https://github.com/stb-tester/stb-tester/blob/master/LICENSE for details).
 from __future__ import annotations
 
 import enum
-import typing
 import warnings
-from typing import Optional
+from typing import Iterator, Optional
 
 from .diff import FrameDiffer, GrayscaleDiff
 from .imgutils import FrameT
 from .logging import ddebug, debug, draw_on
 from .mask import MaskTypes
-from .types import KeyT, Region
-
-if typing.TYPE_CHECKING:
-    # pylint:disable=unused-import
-    from . import core
-    from .types import SizeT
-    # pylint:enable=unused-import
+from .types import KeyT, Region, SizeT
 
 
 def press_and_wait(
@@ -37,8 +30,8 @@ def press_and_wait(
     region: Region = Region.ALL,
     timeout_secs: float = 10,
     stable_secs: float = 1,
-    min_size: "SizeT|None" = None,
-    frames: "typing.Iterator[core.Frame]|None" = None,
+    min_size: SizeT | None = None,
+    frames: Iterator[FrameT] | None = None,
     _dut=None,
 ) -> _TransitionResult:
 
@@ -74,8 +67,8 @@ def press_and_wait(
         such as the blinking text cursor in a search box.
     :type min_size: Tuple[int, int]
 
-    :param frames: An iterable of video-frames to analyse. Defaults to
-        `stbt.frames()`.
+    :param Iterator[stbt.Frame] frames: An iterable of video-frames to analyse.
+        Defaults to ``stbt.frames()``.
 
     :returns:
         An object that will evaluate to true if the transition completed, false
@@ -148,13 +141,13 @@ press_and_wait.differ: FrameDiffer = GrayscaleDiff
 
 
 def wait_for_transition_to_end(
-    initial_frame: "FrameT|None" = None,
+    initial_frame: FrameT | None = None,
     mask: MaskTypes = Region.ALL,
     region: Region = Region.ALL,
     timeout_secs: float = 10,
     stable_secs: float = 1,
-    min_size: "SizeT|None" = None,
-    frames: "typing.Iterator[core.Frame]|None" = None,
+    min_size: SizeT | None = None,
+    frames: Iterator[FrameT] | None = None,
 ) -> _TransitionResult:
 
     """Wait for the screen to stop changing.
@@ -177,8 +170,8 @@ def wait_for_transition_to_end(
     :param Region region: See `press_and_wait`.
     :param int|float timeout_secs: See `press_and_wait`.
     :param int|float stable_secs: See `press_and_wait`.
-    :param frames: An iterable of video-frames to analyse. Defaults to
-        `stbt.frames()`.
+    :param Iterator[stbt.Frame] frames: An iterable of video-frames to analyse.
+        Defaults to ``stbt.frames()``.
 
     :returns: See `press_and_wait`.
     """
@@ -202,9 +195,9 @@ def wait_for_transition_to_end(
 
 
 class _Transition():
-    def __init__(self, mask: "MaskTypes", timeout_secs: float,
-                 stable_secs: float, min_size: "SizeT|None",
-                 frames: "typing.Iterator[core.Frame]"):
+    def __init__(self, mask: MaskTypes, timeout_secs: float,
+                 stable_secs: float, min_size: SizeT | None,
+                 frames: Iterator[FrameT]):
         self.mask = mask
         self.timeout_secs = timeout_secs
         self.stable_secs = stable_secs

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -113,6 +113,8 @@ def press_and_wait(
     using `load_mask`. The ``region`` parameter is deprecated; pass your
     `Region` to ``mask`` instead. You can't specify ``mask`` and ``region``
     at the same time.
+
+    Added in v34: The ``frames`` parameter.
     """
     if _dut is None:
         import stbt_core
@@ -170,8 +172,7 @@ def wait_for_transition_to_end(
     :param Region region: See `press_and_wait`.
     :param int|float timeout_secs: See `press_and_wait`.
     :param int|float stable_secs: See `press_and_wait`.
-    :param Iterator[stbt.Frame] frames: An iterable of video-frames to analyse.
-        Defaults to ``stbt.frames()``.
+    :param Iterator[stbt.Frame] frames: See `press_and_wait`.
 
     :returns: See `press_and_wait`.
     """

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -22,11 +22,12 @@ from .diff import FrameDiffer, GrayscaleDiff
 from .imgutils import FrameT
 from .logging import ddebug, debug, draw_on
 from .mask import MaskTypes
-from .types import KeyT, Region, SizeT
+from .types import KeyT, Region
 
 if typing.TYPE_CHECKING:
     # pylint:disable=unused-import
     from . import core
+    from .types import SizeT
     # pylint:enable=unused-import
 
 
@@ -36,7 +37,7 @@ def press_and_wait(
     region: Region = Region.ALL,
     timeout_secs: float = 10,
     stable_secs: float = 1,
-    min_size: SizeT = None,
+    min_size: "SizeT|None" = None,
     _dut=None,
 ) -> _TransitionResult:
 
@@ -141,12 +142,12 @@ press_and_wait.differ: FrameDiffer = GrayscaleDiff
 
 
 def wait_for_transition_to_end(
-    initial_frame: FrameT = None,
+    initial_frame: "FrameT|None" = None,
     mask: MaskTypes = Region.ALL,
     region: Region = Region.ALL,
     timeout_secs: float = 10,
     stable_secs: float = 1,
-    min_size: SizeT = None,
+    min_size: "SizeT|None" = None,
     _dut=None,
 ) -> _TransitionResult:
 

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -14,6 +14,7 @@ https://github.com/stb-tester/stb-tester/blob/master/LICENSE for details).
 from __future__ import annotations
 
 import enum
+import typing
 import warnings
 from typing import Optional
 
@@ -22,6 +23,11 @@ from .imgutils import FrameT
 from .logging import ddebug, debug, draw_on
 from .mask import MaskTypes
 from .types import KeyT, Region, SizeT
+
+if typing.TYPE_CHECKING:
+    # pylint:disable=unused-import
+    from . import core
+    # pylint:enable=unused-import
 
 
 def press_and_wait(
@@ -187,7 +193,9 @@ def wait_for_transition_to_end(
 
 
 class _Transition():
-    def __init__(self, mask, timeout_secs, stable_secs, min_size, dut):
+    def __init__(self, mask: "MaskTypes", timeout_secs: float,
+                 stable_secs: float, min_size: "SizeT|None",
+                 dut: "core.DeviceUnderTest"):
         self.mask = mask
         self.timeout_secs = timeout_secs
         self.stable_secs = stable_secs

--- a/_stbt/types.py
+++ b/_stbt/types.py
@@ -246,6 +246,8 @@ class Region(namedtuple('Region', 'x y right bottom'),
         commutative and associative.
     """
 
+    ALL: "Region"
+
     def __new__(
         cls,
         x: float,

--- a/tests/test_transition.py
+++ b/tests/test_transition.py
@@ -158,11 +158,11 @@ def test_wait_for_transition_to_end(diff_algorithm):
     _stbt = FakeDeviceUnderTest()
 
     transition = stbt.wait_for_transition_to_end(
-        timeout_secs=0.2, stable_secs=0.1, _frames=_stbt.frames())
+        timeout_secs=0.2, stable_secs=0.1, frames=_stbt.frames())
 
     _stbt.press("ball")
     transition = stbt.wait_for_transition_to_end(
-        timeout_secs=0.2, stable_secs=0.1, _frames=_stbt.frames())
+        timeout_secs=0.2, stable_secs=0.1, frames=_stbt.frames())
     print(transition)
     assert not transition
     assert transition.status == stbt.TransitionStatus.STABLE_TIMEOUT

--- a/tests/test_transition.py
+++ b/tests/test_transition.py
@@ -158,11 +158,11 @@ def test_wait_for_transition_to_end(diff_algorithm):
     _stbt = FakeDeviceUnderTest()
 
     transition = stbt.wait_for_transition_to_end(
-        timeout_secs=0.2, stable_secs=0.1, _dut=_stbt)
+        timeout_secs=0.2, stable_secs=0.1, _frames=_stbt.frames())
 
     _stbt.press("ball")
     transition = stbt.wait_for_transition_to_end(
-        timeout_secs=0.2, stable_secs=0.1, _dut=_stbt)
+        timeout_secs=0.2, stable_secs=0.1, _frames=_stbt.frames())
     print(transition)
     assert not transition
     assert transition.status == stbt.TransitionStatus.STABLE_TIMEOUT


### PR DESCRIPTION
Consistent with `wait_for_motion`.  This will allow performing some transformation on the video before it's processed by `wait_for_motion`.