### PR TITLE
press_and_wait: Add retries parameter

### DIFF
--- a/_stbt/logging.py
+++ b/_stbt/logging.py
@@ -33,10 +33,10 @@ def init_logger():
     logger.propagate = False
 
 
-def debug(msg: str):
+def debug(msg: str, *args, **kwargs):
     """Print the given string to stderr if stbt run `--verbose` was given."""
     if get_debug_level() > 0:
-        logger.debug(msg)
+        logger.debug(msg, *args, **kwargs)
 
 
 def ddebug(s):
@@ -45,8 +45,8 @@ def ddebug(s):
         trace_logger.debug(s)
 
 
-def warn(s):
-    logger.warning(s)
+def warn(msg: str, *args, **kwargs):
+    logger.warning(msg, *args, **kwargs)
 
 
 def get_debug_level():


### PR DESCRIPTION
If the keypress had no effect at all, retry this number of times. Defaults to 0, so you have to opt-in to this behaviour by specifying, say, `retries=1` or `retries=2`.

Useful for devices with a tendency to miss keypresses.

TODO:

- ~stbt.Keyboard.navigate_to passes its own `retries` into `press_and_wait`.~ Doesn't make sense because `navigate_to` uses `press`, not `press_and_wait`.
- [x] Tests.