### PR TITLE
Refactor: Replace subclassing FrameDiffer with subclassing Differ

### DIFF
--- a/_stbt/diff.py
+++ b/_stbt/diff.py
@@ -5,8 +5,7 @@ import typing
 import cv2
 import numpy
 
-from .imgutils import (
-    Frame, FrameT, crop, _frame_repr, _image_region, pixel_bounding_box)
+from .imgutils import Frame, FrameT, crop, _frame_repr, pixel_bounding_box
 from .logging import ddebug, ImageLogger
 from .mask import load_mask, MaskTypes
 from .types import Region, SizeT
@@ -211,36 +210,6 @@ class BGRDiff(Differ):
         ddebug(str(result))
         imglog.html(BGRDIFF_HTML, result=result)
         return result
-
-
-class FrameDiffer():
-    """Interface for different algorithms for diffing frames in a sequence.
-
-    Say you have a sequence of frames A, B, C. Typically you will compare frame
-    A against B, and then frame B against C. This is a class (not a function)
-    so that you can remember work you've done on frame B, so that you don't
-    repeat that work when you need to compare against frame C.
-    """
-    def __init__(self, differ: Differ, initial_frame: FrameT,
-                 mask: MaskTypes = Region.ALL):
-        self.differ: Differ = differ
-        self.mask_tuple = differ.preprocess_mask(
-            mask, _image_region(initial_frame))
-        self.prev_frame = differ.preprocess(initial_frame, self.mask_tuple)
-
-    def diff(self, frame: FrameT) -> MotionResult:
-        new_frame = self.differ.preprocess(frame, self.mask_tuple)
-        motion = self.differ.diff(self.prev_frame, new_frame, self.mask_tuple)
-
-        if motion:
-            # Only update the comparison frame if it's different to the previous
-            # one.  This makes `detect_motion` more sensitive to slow motion
-            # because the differences between frames 1 and 2 might be small and
-            # the differences between frames 2 and 3 might be small but we'd see
-            # the difference by looking between 1 and 3.
-            self.prev_frame = new_frame
-
-        return motion
 
 
 BGRDIFF_HTML = """\

--- a/_stbt/diff.py
+++ b/_stbt/diff.py
@@ -93,14 +93,16 @@ class Differ:
             "%s.replace is not implemented" % self.__class__.__name__)
 
     def preprocess_mask(
-            self, mask: MaskTypes, frame_region: Region) -> "_PreProcessedMask":
+            self, mask: MaskTypes,
+            frame_region: Region  # pylint:disable=unused-argument
+    ) -> "_PreProcessedMask":
         """
         Pre-process a mask.  The returned value from this will be passed to
         `preprocess` and `diff`.
 
         :meta private:
         """
-        return load_mask(mask).to_array(frame_region)
+        return mask
 
     def preprocess(
             self, frame: FrameT,
@@ -166,6 +168,10 @@ class BGRDiff(Differ):
         if erode is UNSET:
             erode = self.kernel
         return self.__class__(min_size, threshold, erode)
+
+    def preprocess_mask(
+            self, mask: MaskTypes, frame_region: Region):
+        return load_mask(mask).to_array(frame_region)
 
     def diff(self, a, b, mask):
         mask_pixels, region = mask
@@ -294,6 +300,10 @@ class GrayscaleDiff(Differ):
         if erode is UNSET:
             erode = self.kernel
         return self.__class__(min_size, threshold, erode)
+
+    def preprocess_mask(
+            self, mask: MaskTypes, frame_region: Region):
+        return load_mask(mask).to_array(frame_region)
 
     def preprocess(self, frame, mask):
         _, region = mask

--- a/_stbt/diff.py
+++ b/_stbt/diff.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional
+import typing
 
 import cv2
 import numpy
@@ -49,20 +49,77 @@ class MotionResult():
                 self.motion, self.region, _frame_repr(self.frame)))
 
 
-class FrameDiffer():
-    """Interface for different algorithms for diffing frames in a sequence.
+class UNSET:
+    """Sentinel"""
 
-    Say you have a sequence of frames A, B, C. Typically you will compare frame
-    A against B, and then frame B against C. This is a class (not a function)
-    so that you can remember work you've done on frame B, so that you don't
-    repeat that work when you need to compare against frame C.
+
+class Differ:
     """
-    def diff(self, frame: FrameT):
+    This is a low level interface enabling customising how two images are
+    compared.  It's used by `wait_for_motion` and `press_and_wait`.
+
+    `Differ` is designed so we can efficiently implement `GrayscaleDiff`
+    without doing the colour -> grayscale conversion on the same image twice -
+    just as we could before.  To avoid internal state the interface makes
+    preprocessing explicit.  This makes the classes hard to use, but that's ok -
+    it's a low-level interface intended mostly for internal use.
+
+    The only public interface is the subclass constructors.  The methods are not
+    intended for use by external code.
+    """
+    PreProcessedFrame: typing.TypeAlias = FrameT
+    PreProcessedMask: typing.TypeAlias = tuple[numpy.ndarray | None, Region]
+
+    def replace(self, min_size=UNSET, threshold=UNSET, erode=UNSET):
+        """
+        Return a new Differ with the specified parameters replaced.
+
+        Differs are immutable, much like namedtuples.  This method allows
+        creating a new differ, overriding some of the parameters.
+
+        This is needed to allow passing parameters like `min_size` directly to
+        e.g. `press_and_wait` rather than at `Differ` construction time.
+
+        :meta private:
+        """
+        raise NotImplementedError(
+            "%s.replace is not implemented" % self.__class__.__name__)
+
+    def preprocess_mask(
+            self, mask: MaskTypes, frame_region: Region) -> "PreProcessedMask":
+        """
+        Pre-process a mask.  The returned value from this will be passed to
+        `preprocess` and `diff`.
+
+        :meta private:
+        """
+        return load_mask(mask).to_array(frame_region)
+
+    def preprocess(
+            self, frame: FrameT,
+            mask_tuple: "PreProcessedMask"  # pylint:disable=unused-argument
+    ) -> "PreProcessedFrame":
+        """
+        Pre-process a frame.  The returned value from this will be passed to
+        `diff`.  `mask_tuple` is the return value from `preprocess_mask`.
+
+        :meta private:
+        """
+        return frame
+
+    def diff(self, a: "PreProcessedFrame", b: "PreProcessedFrame",
+             mask_tuple: "PreProcessedMask") -> MotionResult:
+        """
+        Compare two frames.  `a` and `b` are the return values from
+        `preprocess`.  `mask_tuple` is the return value from `preprocess_mask`.
+
+        :meta private:
+        """
         raise NotImplementedError(
             "%s.diff is not implemented" % self.__class__.__name__)
 
 
-class BGRDiff(FrameDiffer):
+class BGRDiff(Differ):
     """Compares 2 frames by calculating the color distance between them.
 
     The algorithm is a simple euclidean distance between each pair of
@@ -78,18 +135,12 @@ class BGRDiff(FrameDiffer):
 
     def __init__(
         self,
-        initial_frame: FrameT,
-        mask: MaskTypes = Region.ALL,
-        min_size: Optional[SizeT] = None,
+        min_size: SizeT | None = None,
         threshold: float = 25,
         erode: bool = True,
     ):
-        self.prev_frame = initial_frame
         self.min_size = min_size
         self.threshold = threshold
-
-        self.mask_, self.region = load_mask(mask).to_array(
-            _image_region(initial_frame))
 
         if isinstance(erode, numpy.ndarray):  # For power users
             kernel = erode
@@ -99,15 +150,25 @@ class BGRDiff(FrameDiffer):
             kernel = None
         self.kernel = kernel
 
-    def diff(self, frame: FrameT) -> MotionResult:
-        imglog = ImageLogger("BGRDiff", region=self.region,
+    def replace(self, min_size=UNSET, threshold=UNSET, erode=UNSET):
+        if min_size is UNSET:
+            min_size = self.min_size
+        if threshold is UNSET:
+            threshold = self.threshold
+        if erode is UNSET:
+            erode = self.kernel
+        return self.__class__(min_size, threshold, erode)
+
+    def diff(self, prev_frame, frame, mask):  # pylint:disable=too-many-locals,arguments-renamed
+        mask_pixels, region = mask
+
+        imglog = ImageLogger("BGRDiff", region=region,
                              min_size=self.min_size, threshold=self.threshold)
         imglog.imwrite("source", frame)
-        imglog.imwrite("previous_frame", self.prev_frame)
+        imglog.imwrite("previous_frame", prev_frame)
 
-        mask_pixels = self.mask_
-        cframe = crop(frame, self.region)
-        cprev = crop(self.prev_frame, self.region)
+        cframe = crop(frame, region)
+        cprev = crop(prev_frame, region)
 
         sqd = numpy.subtract(cframe, cprev, dtype=numpy.int32)
         sqd = (sqd[:, :, 0] ** 2 +
@@ -139,12 +200,37 @@ class BGRDiff(FrameDiffer):
         out_region = pixel_bounding_box(d)
         if out_region:
             # Undo crop:
-            out_region = out_region.translate(self.region)
+            out_region = out_region.translate(region)
 
         motion = bool(out_region and (
             self.min_size is None or
             (out_region.width >= self.min_size[0] and
              out_region.height >= self.min_size[1])))
+        result = MotionResult(getattr(frame, "time", None), motion,
+                              out_region, frame)
+        ddebug(str(result))
+        imglog.html(BGRDIFF_HTML, result=result)
+        return result
+
+
+class FrameDiffer():
+    """Interface for different algorithms for diffing frames in a sequence.
+
+    Say you have a sequence of frames A, B, C. Typically you will compare frame
+    A against B, and then frame B against C. This is a class (not a function)
+    so that you can remember work you've done on frame B, so that you don't
+    repeat that work when you need to compare against frame C.
+    """
+    def __init__(self, differ: Differ, initial_frame: FrameT,
+                 mask: MaskTypes = Region.ALL):
+        self.differ: Differ = differ
+        self.mask_tuple = differ.preprocess_mask(
+            mask, _image_region(initial_frame))
+        self.prev_frame = differ.preprocess(initial_frame, self.mask_tuple)
+
+    def diff(self, frame: FrameT) -> MotionResult:
+        new_frame = self.differ.preprocess(frame, self.mask_tuple)
+        motion = self.differ.diff(self.prev_frame, new_frame, self.mask_tuple)
 
         if motion:
             # Only update the comparison frame if it's different to the previous
@@ -152,13 +238,9 @@ class BGRDiff(FrameDiffer):
             # because the differences between frames 1 and 2 might be small and
             # the differences between frames 2 and 3 might be small but we'd see
             # the difference by looking between 1 and 3.
-            self.prev_frame = frame
+            self.prev_frame = new_frame
 
-        result = MotionResult(getattr(frame, "time", None), motion,
-                              out_region, frame)
-        ddebug(str(result))
-        imglog.html(BGRDIFF_HTML, result=result)
-        return result
+        return motion
 
 
 BGRDIFF_HTML = """\
@@ -198,7 +280,7 @@ BGRDIFF_HTML = """\
 """
 
 
-class GrayscaleDiff(FrameDiffer):
+class GrayscaleDiff(Differ):
     """Compares 2 frames by converting them to grayscale, calculating
     pixel-wise absolute differences, and ignoring differences below a
     threshold.
@@ -209,18 +291,12 @@ class GrayscaleDiff(FrameDiffer):
 
     def __init__(
         self,
-        initial_frame: FrameT,
-        mask: MaskTypes = Region.ALL,
-        min_size: Optional[SizeT] = None,
+        min_size: SizeT | None = None,
         threshold: float = 0.84,
         erode: bool = True,
     ):
-        self.prev_frame = initial_frame
         self.min_size = min_size
         self.threshold = threshold
-
-        self.mask_, self.region = load_mask(mask).to_array(
-            _image_region(initial_frame))
 
         if isinstance(erode, numpy.ndarray):  # For power users
             kernel = erode
@@ -230,27 +306,37 @@ class GrayscaleDiff(FrameDiffer):
             kernel = None
         self.kernel = kernel
 
-        self.prev_frame_gray = self.gray(initial_frame)
+    def replace(self, min_size=UNSET, threshold=UNSET, erode=UNSET):
+        if min_size is UNSET:
+            min_size = self.min_size
+        if threshold is UNSET:
+            threshold = self.threshold
+        if erode is UNSET:
+            erode = self.kernel
+        return self.__class__(min_size, threshold, erode)
 
-    def gray(self, frame: FrameT):
-        return cv2.cvtColor(crop(frame, self.region), cv2.COLOR_BGR2GRAY)
+    def preprocess(self, frame, mask_tuple):
+        _, region = mask_tuple
+        return frame, cv2.cvtColor(crop(frame, region), cv2.COLOR_BGR2GRAY)
 
-    def diff(self, frame: FrameT) -> MotionResult:
-        frame_gray = self.gray(frame)
+    def diff(self, a, b, mask_tuple) -> MotionResult:
+        _, prev_frame_gray = a
+        frame, frame_gray = b
+        mask, region = mask_tuple
 
-        imglog = ImageLogger("GrayscaleDiff", region=self.region,
+        imglog = ImageLogger("GrayscaleDiff", region=region,
                              min_size=self.min_size,
                              threshold=self.threshold)
         imglog.imwrite("source", frame)
         imglog.imwrite("gray", frame_gray)
-        imglog.imwrite("previous_frame_gray", self.prev_frame_gray)
+        imglog.imwrite("previous_frame_gray", prev_frame_gray)
 
-        absdiff = cv2.absdiff(self.prev_frame_gray, frame_gray)
+        absdiff = cv2.absdiff(prev_frame_gray, frame_gray)
         imglog.imwrite("absdiff", absdiff)
 
-        if self.mask_ is not None:
-            absdiff = cv2.bitwise_and(absdiff, self.mask_)
-            imglog.imwrite("mask", self.mask_)
+        if mask is not None:
+            absdiff = cv2.bitwise_and(absdiff, mask)
+            imglog.imwrite("mask", mask)
             imglog.imwrite("absdiff_masked", absdiff)
 
         _, thresholded = cv2.threshold(
@@ -265,21 +351,12 @@ class GrayscaleDiff(FrameDiffer):
         out_region = pixel_bounding_box(thresholded)
         if out_region:
             # Undo crop:
-            out_region = out_region.translate(self.region)
+            out_region = out_region.translate(region)
 
         motion = bool(out_region and (
             self.min_size is None or
             (out_region.width >= self.min_size[0] and
              out_region.height >= self.min_size[1])))
-
-        if motion:
-            # Only update the comparison frame if it's different to the previous
-            # one.  This makes `detect_motion` more sensitive to slow motion
-            # because the differences between frames 1 and 2 might be small and
-            # the differences between frames 2 and 3 might be small but we'd see
-            # the difference by looking between 1 and 3.
-            self.prev_frame = frame
-            self.prev_frame_gray = frame_gray
 
         result = MotionResult(getattr(frame, "time", None), motion,
                               out_region, frame)

--- a/_stbt/diff.py
+++ b/_stbt/diff.py
@@ -74,8 +74,8 @@ class Differ:
     # The only public interface is the subclass constructors. The methods are
     # not intended for use by external code.
 
-    PreProcessedFrame: typing.TypeAlias = FrameT
-    PreProcessedMask: typing.TypeAlias = tuple[numpy.ndarray | None, Region]
+    _PreProcessedFrame: typing.TypeAlias
+    _PreProcessedMask: typing.TypeAlias
 
     def replace(self, min_size=UNSET, threshold=UNSET, erode=UNSET):
         """
@@ -93,7 +93,7 @@ class Differ:
             "%s.replace is not implemented" % self.__class__.__name__)
 
     def preprocess_mask(
-            self, mask: MaskTypes, frame_region: Region) -> "PreProcessedMask":
+            self, mask: MaskTypes, frame_region: Region) -> "_PreProcessedMask":
         """
         Pre-process a mask.  The returned value from this will be passed to
         `preprocess` and `diff`.
@@ -104,8 +104,8 @@ class Differ:
 
     def preprocess(
             self, frame: FrameT,
-            mask: "PreProcessedMask"  # pylint:disable=unused-argument
-    ) -> "PreProcessedFrame":
+            mask: "_PreProcessedMask"  # pylint:disable=unused-argument
+    ) -> "_PreProcessedFrame":
         """
         Pre-process a frame.  The returned value from this will be passed to
         `diff`.  `mask_tuple` is the return value from `preprocess_mask`.
@@ -114,8 +114,8 @@ class Differ:
         """
         return frame
 
-    def diff(self, a: "PreProcessedFrame", b: "PreProcessedFrame",
-             mask: "PreProcessedMask") -> MotionResult:
+    def diff(self, a: "_PreProcessedFrame", b: "_PreProcessedFrame",
+             mask: "_PreProcessedMask") -> MotionResult:
         """
         Compare two frames.  `a` and `b` are the return values from
         `preprocess`.  `mask_tuple` is the return value from `preprocess_mask`.

--- a/_stbt/diff.py
+++ b/_stbt/diff.py
@@ -104,7 +104,7 @@ class Differ:
 
     def preprocess(
             self, frame: FrameT,
-            mask_tuple: "PreProcessedMask"  # pylint:disable=unused-argument
+            mask: "PreProcessedMask"  # pylint:disable=unused-argument
     ) -> "PreProcessedFrame":
         """
         Pre-process a frame.  The returned value from this will be passed to
@@ -115,7 +115,7 @@ class Differ:
         return frame
 
     def diff(self, a: "PreProcessedFrame", b: "PreProcessedFrame",
-             mask_tuple: "PreProcessedMask") -> MotionResult:
+             mask: "PreProcessedMask") -> MotionResult:
         """
         Compare two frames.  `a` and `b` are the return values from
         `preprocess`.  `mask_tuple` is the return value from `preprocess_mask`.
@@ -167,8 +167,10 @@ class BGRDiff(Differ):
             erode = self.kernel
         return self.__class__(min_size, threshold, erode)
 
-    def diff(self, prev_frame, frame, mask):  # pylint:disable=too-many-locals,arguments-renamed
+    def diff(self, a, b, mask):
         mask_pixels, region = mask
+        prev_frame = a
+        frame = b
 
         imglog = ImageLogger("BGRDiff", region=region,
                              min_size=self.min_size, threshold=self.threshold)
@@ -293,14 +295,14 @@ class GrayscaleDiff(Differ):
             erode = self.kernel
         return self.__class__(min_size, threshold, erode)
 
-    def preprocess(self, frame, mask_tuple):
-        _, region = mask_tuple
+    def preprocess(self, frame, mask):
+        _, region = mask
         return frame, cv2.cvtColor(crop(frame, region), cv2.COLOR_BGR2GRAY)
 
-    def diff(self, a, b, mask_tuple) -> MotionResult:
+    def diff(self, a, b, mask) -> MotionResult:
         _, prev_frame_gray = a
         frame, frame_gray = b
-        mask, region = mask_tuple
+        mask, region = mask
 
         imglog = ImageLogger("GrayscaleDiff", region=region,
                              min_size=self.min_size,

--- a/_stbt/mask.py
+++ b/_stbt/mask.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple, TypeAlias, Union
 
 import cv2
 import numpy
@@ -19,7 +19,7 @@ except ImportError:
     Xxhash64 = None
 
 
-MaskTypes = Union[str, numpy.ndarray, "Mask", Region, None]
+MaskTypes: TypeAlias = Union[str, numpy.ndarray, "Mask", Region, None]
 
 
 def load_mask(mask: MaskTypes) -> Mask:

--- a/_stbt/motion.py
+++ b/_stbt/motion.py
@@ -90,7 +90,8 @@ def detect_motion(
     except StopIteration:
         return
 
-    differ = detect_motion.differ(frame, mask, threshold=noise_threshold)
+    differ_ = detect_motion.differ.replace(threshold=noise_threshold)
+    differ = FrameDiffer(differ_, frame, mask)
     for frame in frames:
         result = differ.diff(frame)
         draw_on(frame, result, label="detect_motion()")
@@ -99,7 +100,7 @@ def detect_motion(
         yield result
 
 
-detect_motion.differ : FrameDiffer = BGRDiff
+detect_motion.differ : FrameDiffer = BGRDiff()
 
 
 def wait_for_motion(

--- a/_stbt/motion.py
+++ b/_stbt/motion.py
@@ -5,7 +5,7 @@ from collections import deque
 from typing import Iterator, Optional
 
 from .config import ConfigurationError, get_config
-from .diff import BGRDiff, FrameDiffer, MotionResult
+from .diff import BGRDiff, Differ, FrameDiffer, MotionResult
 from .imgutils import limit_time, FrameT
 from .logging import debug, draw_on
 from .mask import MaskTypes
@@ -100,7 +100,7 @@ def detect_motion(
         yield result
 
 
-detect_motion.differ : FrameDiffer = BGRDiff()
+detect_motion.differ : Differ = BGRDiff()
 
 
 def wait_for_motion(

--- a/_stbt/motion.py
+++ b/_stbt/motion.py
@@ -5,8 +5,8 @@ from collections import deque
 from typing import Iterator, Optional
 
 from .config import ConfigurationError, get_config
-from .diff import BGRDiff, Differ, FrameDiffer, MotionResult
-from .imgutils import limit_time, FrameT
+from .diff import BGRDiff, Differ, MotionResult
+from .imgutils import _image_region, limit_time, FrameT
 from .logging import debug, draw_on
 from .mask import MaskTypes
 from .types import Region, UITestFailure
@@ -90,10 +90,10 @@ def detect_motion(
     except StopIteration:
         return
 
-    differ_ = detect_motion.differ.replace(threshold=noise_threshold)
-    differ = FrameDiffer(differ_, frame, mask)
+    differ = detect_motion.differ.replace(threshold=noise_threshold)
+    dm = DetectMotion(differ, frame, mask)
     for frame in frames:
-        result = differ.diff(frame)
+        result = dm.diff(frame)
         draw_on(frame, result, label="detect_motion()")
         debug("%s found: %s" % (
             "Motion" if result.motion else "No motion", str(result)))
@@ -101,6 +101,41 @@ def detect_motion(
 
 
 detect_motion.differ : Differ = BGRDiff()
+
+
+class DetectMotion():
+    """Concrete implementation of the `detect_motion` algorithm.
+
+    This class is an internal implementation detail, not part of the public
+    API. It isn't part of `detect_motion` because it offers a more convenient
+    API for `press_and_wait` to use.
+
+    Responsibilities of this class:
+
+    - Remember the work done on already-seen frames (e.g. GrayscaleDiff's
+      colorspace conversion).
+    - The logic for when we update the "reference" frame.
+    """
+    def __init__(self, differ: Differ, initial_frame: FrameT,
+                 mask: MaskTypes = Region.ALL):
+        self.differ: Differ = differ
+        self.mask_tuple = differ.preprocess_mask(
+            mask, _image_region(initial_frame))
+        self.prev_frame = differ.preprocess(initial_frame, self.mask_tuple)
+
+    def diff(self, frame: FrameT) -> MotionResult:
+        new_frame = self.differ.preprocess(frame, self.mask_tuple)
+        motion = self.differ.diff(self.prev_frame, new_frame, self.mask_tuple)
+
+        if motion:
+            # Only update the comparison frame if it's different to the previous
+            # one.  This makes `detect_motion` more sensitive to slow motion
+            # because the differences between frames 1 and 2 might be small and
+            # the differences between frames 2 and 3 might be small but we'd see
+            # the difference by looking between 1 and 3.
+            self.prev_frame = new_frame
+
+        return motion
 
 
 def wait_for_motion(

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -139,7 +139,7 @@ def press_and_wait(
     return result
 
 
-press_and_wait.differ: FrameDiffer = BGRDiff
+press_and_wait.differ: FrameDiffer = BGRDiff()
 
 
 def wait_for_transition_to_end(
@@ -210,8 +210,9 @@ class _Transition():
     def wait(self, press_result):
         self.expiry_time = press_result.end_time + self.timeout_secs
 
-        differ = press_and_wait.differ(initial_frame=press_result.frame_before,
-                                       mask=self.mask, min_size=self.min_size)
+        differ_ = press_and_wait.differ.replace(min_size=self.min_size)
+        differ = FrameDiffer(differ_, press_result.frame_before, self.mask)
+
         # Wait for animation to start
         for f in self.frames:
             if f.time < press_result.end_time:
@@ -244,8 +245,8 @@ class _Transition():
             self.expiry_time = initial_frame.time + self.timeout_secs
 
         first_stable_frame = initial_frame
-        differ = press_and_wait.differ(initial_frame=initial_frame,
-                                       mask=self.mask, min_size=self.min_size)
+        differ_ = press_and_wait.differ.replace(min_size=self.min_size)
+        differ = FrameDiffer(differ_, initial_frame, self.mask)
         while True:
             f = next(self.frames)
             motion_result = differ.diff(f)

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -17,7 +17,7 @@ import enum
 import warnings
 from typing import Iterator, Optional
 
-from .diff import BGRDiff, FrameDiffer
+from .diff import BGRDiff, Differ, FrameDiffer
 from .imgutils import FrameT
 from .logging import ddebug, debug, draw_on
 from .mask import MaskTypes
@@ -139,7 +139,7 @@ def press_and_wait(
     return result
 
 
-press_and_wait.differ: FrameDiffer = BGRDiff()
+press_and_wait.differ: Differ = BGRDiff()
 
 
 def wait_for_transition_to_end(

--- a/_stbt/types.py
+++ b/_stbt/types.py
@@ -352,9 +352,19 @@ class Region(namedtuple('Region', 'x y right bottom'),
             raise TypeError("Region.contains expects a Region, Position, or "
                             "None. Got %r" % (other,))
 
-    def translate(
-        self, x: Optional[float] = None, y: Optional[float] = None
-    ) -> Region:
+    @typing.overload
+    def translate(self, x: Region) -> Region:
+        ...
+
+    @typing.overload
+    def translate(self, x: float | None, y: float | None) -> Region:
+        ...
+
+    @typing.overload
+    def translate(self, x: tuple[int, int]) -> Region:
+        ...
+
+    def translate(self, x=None, y=None):
         """
         :returns: A new region with the position of the region adjusted by the
             given amounts.  The width and height are unaffected.

--- a/stbt_core/__init__.py
+++ b/stbt_core/__init__.py
@@ -21,7 +21,7 @@ from _stbt.config import (
     get_config)
 from _stbt.diff import (
     BGRDiff,
-    FrameDiffer,
+    Differ,
     GrayscaleDiff,
     MotionResult)
 from _stbt.frameobject import (
@@ -98,12 +98,12 @@ __all__ = [
     "crop",
     "debug",
     "detect_motion",
+    "Differ",
     "Direction",
     "draw_text",
     "find_file",
     "for_object_repository",
     "Frame",
-    "FrameDiffer",
     "FrameObject",
     "frames",
     "get_config",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ import os
 
 import pytest
 
-import stbt_core
 import _stbt.logging
 
 
@@ -13,6 +12,7 @@ _stbt.logging._debug_level = 1
 
 @pytest.fixture(scope="function")
 def test_pack_root():
+    import stbt_core
     stbt_core.TEST_PACK_ROOT = os.path.abspath(os.path.dirname(__file__))
     try:
         yield

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -8,9 +8,9 @@ def test_bgrdiff():
     frame2 = stbt.load_image("images/diff/xfinity-search-keyboard-2.png")
 
     # GrayscaleDiff doesn't see the difference in the "?123"
-    assert not stbt.GrayscaleDiff(frame1).diff(frame2)
+    assert not stbt.FrameDiffer(stbt.GrayscaleDiff(), frame1).diff(frame2)
 
     # BGRDiff does see it:
-    result = stbt.BGRDiff(frame1).diff(frame2)
+    result = stbt.FrameDiffer(stbt.BGRDiff(), frame1).diff(frame2)
     assert result
     assert result.region == stbt.Region(x=87, y=145, right=129, bottom=161)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,4 +1,5 @@
 import stbt_core as stbt
+from _stbt.motion import DetectMotion
 
 # Note: BGRDiff is also tested by `test_press_and_wait*`.
 
@@ -8,9 +9,9 @@ def test_bgrdiff():
     frame2 = stbt.load_image("images/diff/xfinity-search-keyboard-2.png")
 
     # GrayscaleDiff doesn't see the difference in the "?123"
-    assert not stbt.FrameDiffer(stbt.GrayscaleDiff(), frame1).diff(frame2)
+    assert not DetectMotion(stbt.GrayscaleDiff(), frame1).diff(frame2)
 
     # BGRDiff does see it:
-    result = stbt.FrameDiffer(stbt.BGRDiff(), frame1).diff(frame2)
+    result = DetectMotion(stbt.BGRDiff(), frame1).diff(frame2)
     assert result
     assert result.region == stbt.Region(x=87, y=145, right=129, bottom=161)

--- a/tests/test_transition.py
+++ b/tests/test_transition.py
@@ -53,7 +53,7 @@ def F(state, t):
     return array
 
 
-@pytest.fixture(scope="function", params=[stbt.BGRDiff, stbt.GrayscaleDiff])
+@pytest.fixture(scope="function", params=[stbt.BGRDiff(), stbt.GrayscaleDiff()])
 def diff_algorithm(request):
     previous = stbt.press_and_wait.differ
     try:


### PR DESCRIPTION
Instead of subclassing `FrameDiffer` we now subclass `Differ` and pass an
instance of that subclass to `FrameDiffer`.  So before you'd write:

    press_and_wait.differ = BGRDiff

and now it's

    press_and_wait.differ = BGRDiff()

This means that we can customise differ parameters by passing arguments to
the constructor like:

    press_and_wait.differ = BGRDiff(threshold=60)

To support this differs are now immutable.  The `previous_frame` state that
used to live in `BGRDiff` and `GreyscaleDiff` is now implemented in
`FrameDiffer` which is now a concrete class.

We still need to support passing differ parameters directly to
`press_and_wait`, etc. like `press_and_wait(min_size=...)`, so there's a
`.replace` argument which returns a new differ, but with those parameters
set.

`Differ` is designed so we can efficiently implement `GrayscaleDiff`
without doing the colour -> grayscale conversion on the same image twice -
just as we could before.  To avoid internal state the interface makes
preprocessing explicit.  This makes the classes harder to use directly, but
that's ok because users won't be using them directly.

Currently we don't override `preprocess_mask` anywhere, but it seems to
fall out naturally from the design.

**TODO**

* [x] Rebase now that #785 is merged
* [x] Make tests pass
* ~~Pass ImageLogger into methods?~~

**Future work**

* Allow passing a `Differ` as `second_pass_method` to match.
* Global stbt.default_differ?
* Pass `differ` argument into `press_and_wait`, etc.