### PR TITLE
BGRDiff: Implement inner loop in C

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,6 @@ exclude _stbt/gst_hacks.py
 exclude _stbt/gst_utils.py
 exclude _stbt/irnetbox.py
 exclude _stbt/power.py
-exclude _stbt/sqdiff.py
 exclude _stbt/stbt_run.py
 exclude _stbt/x11.py
 exclude _stbt/xxhash.py

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ INSTALL_PYLIB_FILES = \
     _stbt/imgutils.py \
     _stbt/irnetbox.py \
     _stbt/keyboard.py \
+    _stbt/libstbt.py \
     _stbt/libstbt.$(platform).so \
     _stbt/logging.py \
     _stbt/mask.py \

--- a/_stbt/diff.py
+++ b/_stbt/diff.py
@@ -229,7 +229,8 @@ def _threshold_diff_bgr(
         threshold: int) -> numpy.ndarray[numpy.uint8]:
     if a.shape[:2] != b.shape[:2]:
         raise ValueError("Images must be the same size")
-    if a.shape[2] != 3 or b.shape[2] != 3:
+    if (len(a.shape) < 3 or a.shape[2] != 3 or
+            len(b.shape) < 3 or b.shape[2] != 3):
         raise ValueError("Images must be 3-channel BGR images")
     try:
         from . import libstbt

--- a/_stbt/diff.py
+++ b/_stbt/diff.py
@@ -259,7 +259,7 @@ def _threshold_diff_bgr_numpy(
                            normalised.astype(numpy.uint8) &
                            mask_pixels[:, :, 0])
 
-    return (sqd > threshold).astype(numpy.uint8)
+    return (sqd >= threshold).astype(numpy.uint8)
 
 
 BGRDIFF_HTML = """\

--- a/_stbt/libstbt.py
+++ b/_stbt/libstbt.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import ctypes
+import os
+import platform
+
+import numpy
+
+
+def _find_file(path, root=os.path.dirname(os.path.abspath(__file__))):
+    return os.path.join(root, path)
+
+
+try:
+    _libstbt = ctypes.CDLL(_find_file(f"libstbt.{platform.machine()}.so"))
+except OSError:
+    raise ImportError("Failed to load libstbt.so")
+
+
+class _SqdiffResult(ctypes.Structure):
+    _fields_ = [("total", ctypes.c_uint64),
+                ("count", ctypes.c_uint32)]
+
+
+# SqdiffResult sqdiff(const uint8_t *t, uint16_t t_stride,
+#                     const uint8_t *f, uint16_t f_stride,
+#                     uint16_t width_px, uint16_t height_px,
+#                     int color_depth)
+
+_libstbt.sqdiff.restype = _SqdiffResult
+_libstbt.sqdiff.argtypes = [
+    ctypes.POINTER(ctypes.c_uint8), ctypes.c_uint16,
+    ctypes.POINTER(ctypes.c_uint8), ctypes.c_uint16,
+    ctypes.c_uint16, ctypes.c_uint16,
+    ctypes.c_int
+]
+
+PIXEL_DEPTH_BGR = 1
+PIXEL_DEPTH_BGRx = 2
+PIXEL_DEPTH_BGRA = 3
+
+COLOR_DEPTH_LOOKUP = {
+    (3, 3): PIXEL_DEPTH_BGR,
+    (4, 3): PIXEL_DEPTH_BGRx,
+    (4, 4): PIXEL_DEPTH_BGRA,
+}
+
+
+def sqdiff(template, frame):
+    if template.dtype != numpy.uint8 or frame.dtype != numpy.uint8:
+        raise NotImplementedError("dtype must be uint8")
+
+    if frame.strides[2] != 1 or template.strides[2] != 1 or \
+            frame.strides[1] != 3:
+        raise NotImplementedError("Pixel data must be contiguous")
+
+    color_depth = COLOR_DEPTH_LOOKUP[(template.strides[1], template.shape[2])]
+
+    t = template.ctypes.data_as(ctypes.POINTER(ctypes.c_uint8))
+    f = frame.ctypes.data_as(ctypes.POINTER(ctypes.c_uint8))
+
+    out = _libstbt.sqdiff(t, template.strides[0],
+                          f, frame.strides[0],
+                          template.shape[1], template.shape[0], color_depth)
+    return out.total, out.count

--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -24,13 +24,9 @@ from .imgutils import (
     load_image, _validate_region)
 from .logging import (_Annotation, ddebug, debug, draw_on, get_debug_level,
                       ImageLogger)
+from .sqdiff import sqdiff
 from .types import Position, Region, UITestFailure
 from .utils import to_unicode
-
-try:
-    from .sqdiff import sqdiff
-except ImportError:
-    sqdiff = None
 
 
 class MatchMethod(enum.Enum):
@@ -589,8 +585,7 @@ def _find_candidate_matches(image, template, match_parameters, imglog):
         raise ConfigurationError("'match.pyramid_levels' must be > 0")
 
     if (match_parameters.match_method == MatchMethod.SQDIFF and
-            template.shape[:2] == image.shape[:2] and
-            sqdiff is not None):
+            template.shape[:2] == image.shape[:2]):
         # Fast-path: image and template are the same size, skip pyramid, FFT,
         # etc.  This is particularly useful for full-image matching.
         ddebug("stbt-match: frame and template sizes match: Using fast-path")

--- a/_stbt/sqdiff.c
+++ b/_stbt/sqdiff.c
@@ -189,7 +189,7 @@ static void threshold_diff_BGR_line(
         int16_t diff_g = a[1] - b[1];
         int16_t diff_r = a[2] - b[2];
         uint32_t sqdiff = diff_b * diff_b + diff_g * diff_g + diff_r * diff_r;
-        uint8_t present = (sqdiff > threshold_sq) ? 1 : 0;
+        uint8_t present = (sqdiff >= threshold_sq) ? 1 : 0;
         out[0] = present;
         a += 3;
         b += 3;

--- a/_stbt/sqdiff.c
+++ b/_stbt/sqdiff.c
@@ -18,6 +18,10 @@ static uint32_t sqdiff_BGRA(
     uint32_t *count,
     const unsigned char* t, const unsigned char* f,
     uint16_t len_px);
+static void threshold_diff_BGR_line(
+    uint8_t *out, const uint8_t* a, uint8_t* b,
+    uint16_t len_px, uint32_t threshold_sq
+);
 
 typedef struct _SqdiffResult {
     uint64_t total;
@@ -136,4 +140,59 @@ static uint32_t sqdiff_BGRA(uint32_t *count,
     }
     *count += this_count;
     return this_total;
+}
+
+/**
+ * Calculate the square difference between two images, thresholded by a
+ * threshold_sq value.  Writes the result to out.
+ *
+ * a and b are pointers to the first pixel of the first line of the images.
+ * The images are assumed to be stored in packed BGR format.
+ *
+ * line_stride_a and line_stride_b are the number of bytes between the start
+ * of one line and the start of the next for a and b respectively.
+ *
+ * width_px and height_px are the width and height of the images in pixels.
+ *
+ * threshold_sq is the square of the threshold value.  If the square difference
+ * between two pixels is greater than this value, the output pixel will be 1,
+ * otherwise it will be 0.
+ *
+ * out is a pointer to the first pixel of the first line of the output image.
+ * The memory area for this image must be at least width_px * height_px bytes.
+ */
+void threshold_diff_bgr(
+    uint8_t *out,
+    const uint8_t* a, uint16_t line_stride_a,
+    uint8_t* b, uint16_t line_stride_b,
+    uint32_t threshold_sq,
+    uint16_t width_px, uint16_t height_px
+)
+{
+    for (uint16_t y = 0; y < height_px; y++) {
+        threshold_diff_BGR_line(out, a, b, width_px, threshold_sq);
+        a += line_stride_a;
+        b += line_stride_b;
+        out += width_px;
+    }
+}
+
+static void threshold_diff_BGR_line(
+    uint8_t *out,
+    const uint8_t* a, uint8_t* b,
+    uint16_t len_px,
+    uint32_t threshold_sq
+)
+{
+    for (uint16_t n = 0; n < len_px; n++) {
+        int16_t diff_b = a[0] - b[0];
+        int16_t diff_g = a[1] - b[1];
+        int16_t diff_r = a[2] - b[2];
+        uint32_t sqdiff = diff_b * diff_b + diff_g * diff_g + diff_r * diff_r;
+        uint8_t present = (sqdiff > threshold_sq) ? 1 : 0;
+        out[0] = present;
+        a += 3;
+        b += 3;
+        out += 1;
+    }
 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -75,6 +75,8 @@ UNRELEASED.
   implementations (subclasses) of this API, and their constructors *are* stable
   APIs. #799
 
+- Implement `BGRDiff` in C for performance improvement. #801
+
 #### v33
 
 13 July 2022.

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,4 +1,8 @@
+import numpy
+
 import stbt_core as stbt
+from _stbt import diff, libstbt
+from _stbt.imgutils import crop
 from _stbt.motion import DetectMotion
 
 # Note: BGRDiff is also tested by `test_press_and_wait*`.
@@ -15,3 +19,48 @@ def test_bgrdiff():
     result = DetectMotion(stbt.BGRDiff(), frame1).diff(frame2)
     assert result
     assert result.region == stbt.Region(x=87, y=145, right=129, bottom=161)
+
+
+def test_bgrdiff_c_equivalence():
+    f = numpy.random.random_integers(0, 255, (720, 1280, 3)).astype(numpy.uint8)
+
+    def bgrdiff(f1, f2, threshold):
+        n = diff._threshold_diff_bgr_numpy(f1, f2, threshold)
+        c = libstbt.threshold_diff_bgr(f1, f2, threshold)
+        assert numpy.all(n == c)
+        return c
+
+    assert_np_eq(bgrdiff(f, f, 0), numpy.zeros((720, 1280), dtype=numpy.uint8))
+
+    f1 = f.copy()
+    f1[30:40, 70:80, 0] = 35
+    f1[30:40, 70:80, 1] = 45
+    f1[30:40, 70:80, 2] = 55
+
+    f2 = f1.copy()
+    f2[30:40, 70:80, 0] = 32  # 3^2 ==  9
+    f2[30:40, 70:80, 1] = 50  # 5^2 == 25
+    f2[30:40, 70:80, 2] = 56  # 1^2 ==  1
+    #                    total diff == 35
+
+    expected = numpy.zeros((720, 1280), dtype=numpy.uint8)
+    expected[30:40, 70:80] = 1
+    assert_np_eq(bgrdiff(f1, f2, 34), expected)
+    assert_np_eq(bgrdiff(f, f, 35), numpy.zeros((720, 1280), dtype=numpy.uint8))
+
+    # And with cropping
+    r = stbt.Region(65, 25, 10, 10)
+
+    # Get the stride, etc. of f2 to be different to f1:
+    f2 = crop(f2, r.dilate(1)).copy()
+    f2 = f2[1:-1, 1:-1, :]
+
+    expected = numpy.zeros((10, 10), dtype=numpy.uint8)
+    expected[5:10, 5:10] = 1
+    assert_np_eq(bgrdiff(crop(f1, r), f2, 34), expected)
+
+
+def assert_np_eq(a, b):
+    assert a.dtype == b.dtype
+    assert a.shape == b.shape
+    assert numpy.all(a == b)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -30,7 +30,8 @@ def test_bgrdiff_c_equivalence():
         assert numpy.all(n == c)
         return c
 
-    assert_np_eq(bgrdiff(f, f, 0), numpy.zeros((720, 1280), dtype=numpy.uint8))
+    assert_np_eq(bgrdiff(f, f, 0), numpy.ones((720, 1280), dtype=numpy.uint8))
+    assert_np_eq(bgrdiff(f, f, 1), numpy.zeros((720, 1280), dtype=numpy.uint8))
 
     f1 = f.copy()
     f1[30:40, 70:80, 0] = 35
@@ -45,7 +46,7 @@ def test_bgrdiff_c_equivalence():
 
     expected = numpy.zeros((720, 1280), dtype=numpy.uint8)
     expected[30:40, 70:80] = 1
-    assert_np_eq(bgrdiff(f1, f2, 34), expected)
+    assert_np_eq(bgrdiff(f1, f2, 35), expected)
     assert_np_eq(bgrdiff(f, f, 35), numpy.zeros((720, 1280), dtype=numpy.uint8))
 
     # And with cropping
@@ -57,7 +58,7 @@ def test_bgrdiff_c_equivalence():
 
     expected = numpy.zeros((10, 10), dtype=numpy.uint8)
     expected[5:10, 5:10] = 1
-    assert_np_eq(bgrdiff(crop(f1, r), f2, 34), expected)
+    assert_np_eq(bgrdiff(crop(f1, r), f2, 35), expected)
 
 
 def assert_np_eq(a, b):


### PR DESCRIPTION
This removes a bunch of large temporary arrays from the BGRDiff hot path. From looking at godbolt it looks like it vectorises well too.

This code is basically untested.  More testing required.  Raising now for profiling.