### PR TITLE
HdmiCecControl: Add "KEY_GUIDE" alias for "KEY_EPG"

### DIFF
--- a/_stbt/control_gpl.py
+++ b/_stbt/control_gpl.py
@@ -89,6 +89,7 @@ class HdmiCecControl():
         "KEY_SUB_PICTURE": 81,  # <- not in input-event-codes.h
         "KEY_VOD": 82,
         "KEY_EPG": 83,
+        "KEY_GUIDE": 83,  # alias
         "KEY_TIMER_PROGRAMMING": 84,  # <- not in input-event-codes.h
         "KEY_CONFIG": 85,  # Initial Configuration
         # 0x56 - 0x5F Reserved

--- a/stbt_core/__init__.py
+++ b/stbt_core/__init__.py
@@ -189,9 +189,8 @@ def press(
         lircd.conf configuration file.
 
         If you are using HDMI CEC control, see the available key names
-        `here <https://github.com/stb-tester/stb-tester/blob/v28/_stbt/control_gpl.py#L18-L117>`__.
-        Note that some devices might not understand all of the CEC commands in
-        that list.
+        `here <https://stb-tester.com/kb/cec-names>`__. Note that some devices
+        might not understand every CEC command in that list.
 
     :type interpress_delay_secs: int or float
     :param interpress_delay_secs:


### PR DESCRIPTION
We tend to use "KEY_GUIDE" as it's clearer than a cryptic acronym.