### PR TITLE
Keyboard.add_grid: Merge identical adjacent keys

### DIFF
--- a/_stbt/grid.py
+++ b/_stbt/grid.py
@@ -168,7 +168,8 @@ class Grid():
             region,
             self.data and self.data[position[1]][position[0]])
 
-    def __getitem__(self, key: Union[int, Region, Position]) -> Cell:
+    def __getitem__(
+            self, key: Union[int, Region, Position, tuple[int, int]]) -> Cell:
         if isinstance(key, int):
             return self.get(index=key)
         elif isinstance(key, Region):

--- a/_stbt/keyboard.py
+++ b/_stbt/keyboard.py
@@ -318,7 +318,7 @@ class Keyboard():
                 _join_with_commas([str(x) for x in sorted(keys)],
                                   last_one=" or ")))
 
-    def _find_keys(self, query, mode=None):
+    def _find_keys(self, query, mode=None) -> "list[Key]":
         """Like the public `find_keys`, but takes a "query" (see _find_key)."""
         if isinstance(query, Keyboard.Key):
             if mode is not None and query.mode != mode:
@@ -368,7 +368,7 @@ class Keyboard():
                 _join_with_commas([str(x) for x in sorted(keys)],
                                   last_one=" or ")))
 
-    def _add_key(self, spec):
+    def _add_key(self, spec) -> "Key":
         """Add a node to the graph. Raises if the node already exists."""
         nodes = self._find_keys(spec)
         if len(nodes) > 0:
@@ -515,7 +515,7 @@ class Keyboard():
                     "(must contain 3 fields): %r"
                     % (i, line.strip()))
 
-    def add_grid(self, grid: Grid, mode: Optional[str] = None) -> None:
+    def add_grid(self, grid: Grid, mode: Optional[str] = None) -> Grid:
         """Add keys, and transitions between them, to the model of the keyboard.
 
         If the keyboard (or part of the keyboard) is arranged in a regular
@@ -751,7 +751,7 @@ class Keyboard():
         return page
 
     def press_and_wait(
-        self, key: KeyT, timeout_secs: int = 10, stable_secs: int = 1
+        self, key: KeyT, timeout_secs: float = 10, stable_secs: float = 1
     ) -> _TransitionResult:
         import stbt_core as stbt
         return stbt.press_and_wait(key, mask=self.mask,

--- a/_stbt/keyboard.py
+++ b/_stbt/keyboard.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import dataclasses
 import re
 import time
+import typing
 from logging import getLogger
 from typing import Dict, List, Optional, Union, TypeAlias, TypeVar
 
@@ -515,7 +517,8 @@ class Keyboard():
                     "(must contain 3 fields): %r"
                     % (i, line.strip()))
 
-    def add_grid(self, grid: Grid, mode: Optional[str] = None) -> Grid:
+    def add_grid(self, grid: Grid, mode: Optional[str] = None,
+                 merge: bool = False) -> Grid:
         """Add keys, and transitions between them, to the model of the keyboard.
 
         If the keyboard (or part of the keyboard) is arranged in a regular
@@ -534,19 +537,25 @@ class Keyboard():
         :param str mode: Optional mode that applies to all the keys specified
             in ``grid``. See `add_key` for more details about modes.
 
+        :param bool merge: If True, adjacent keys with the same name and mode
+            will be merged, and a single larger key will be added in its place.
+
         :returns: A new `stbt.Grid` where each cell's data is a key object
             that can be used with `add_transition` (for example to define
             additional transitions from the edges of this grid onto other
             keys).
         """
 
+        # For merging keys allow looking them up by value:
+        specs: dict[tuple[tuple[str, typing.Any], ...], list[_MutRegion]] = {}
+
         # First add the keys. It's an exception if any of them already exist.
         # The data is a string or a dict; we don't support previously-created
         # Key instances because what should we do with the existing Key's
         # `region`?
-        keys = []
         for cell in grid:
             x, y = cell.position
+            spec: "dict[str, typing.Any]"
             if cell.data is None:
                 raise ValueError("Grid cell [%i,%i] doesn't have any data"
                                  % (x, y))
@@ -565,29 +574,55 @@ class Keyboard():
                                  % (type(cell.data), x, y))
 
             spec["mode"] = mode
-            spec["region"] = cell.region
-            keys.append(self._add_key(spec))
+            if "region" in spec:
+                del spec["region"]
+
+            # Can't use a dict as a key in another dict, so convert to a tuple
+            # like ((key, value), ...)
+            spec_key = tuple(sorted(spec.items()))
+            specs.setdefault(spec_key, []).append(
+                _MutRegion(cell.position.x, cell.position.y,
+                           cell.position.x + 1, cell.position.y + 1))
+
+        keys: "list[Keyboard.Key | None]" = [None] * (grid.cols * grid.rows)
+        for tspec, regions in specs.items():
+            if merge:
+                regions = _merge_regions(regions)
+            for region in regions:
+                spec = dict(tspec)
+                spec["region"] = Region.bounding_box(
+                    grid[region.x, region.y].region,
+                    grid[region.right - 1, region.bottom - 1].region)
+                key = self._add_key(spec)
+                for x in range(region.x, region.right):
+                    for y in range(region.y, region.bottom):
+                        keys[y * grid.cols + x] = key
 
         # Now add the transitions.
         for cell in grid:
             x, y = cell.position
             source = keys[grid[x, y].index]
+            assert isinstance(source, Keyboard.Key)
             if x > 0:
                 target = keys[grid[x - 1, y].index]
-                self.add_transition(source, target, "KEY_LEFT",
-                                    symmetrical=False)
+                if source is not target:
+                    self.add_transition(source, target, "KEY_LEFT",
+                                        symmetrical=False)
             if x < grid.cols - 1:
                 target = keys[grid[x + 1, y].index]
-                self.add_transition(source, target, "KEY_RIGHT",
-                                    symmetrical=False)
+                if source is not target:
+                    self.add_transition(source, target, "KEY_RIGHT",
+                                        symmetrical=False)
             if y > 0:
                 target = keys[grid[x, y - 1].index]
-                self.add_transition(source, target, "KEY_UP",
-                                    symmetrical=False)
+                if source is not target:
+                    self.add_transition(source, target, "KEY_UP",
+                                        symmetrical=False)
             if y < grid.rows - 1:
                 target = keys[grid[x, y + 1].index]
-                self.add_transition(source, target, "KEY_DOWN",
-                                    symmetrical=False)
+                if source is not target:
+                    self.add_transition(source, target, "KEY_DOWN",
+                                        symmetrical=False)
 
         return Grid(
             region=grid.region,
@@ -768,6 +803,86 @@ class Keyboard():
         return stbt.wait_for_transition_to_end(initial_frame, mask=self.mask,
                                                timeout_secs=timeout_secs,
                                                stable_secs=stable_secs)
+
+
+@dataclasses.dataclass
+class _MutRegion:
+    x: int
+    y: int
+    right: int
+    bottom: int
+
+
+def _merge_regions(posns: list[_MutRegion]):
+    """Given a list of regions, merge any that are touching into larger regions.
+
+    This can currently only cope with rectangular regions.
+    """
+    if len(posns) <= 1:
+        # Common case
+        return posns
+    # First do horizontal merge:
+    out: list[_MutRegion] = []
+    last = None
+    for posn in posns:
+        if last and posn.x == last.right and posn.y == last.y:
+            last.right += 1
+        else:
+            last = posn
+            out.append(last)
+
+    # Now do vertical merge in >x^2 time because I'm lazy:
+    modified = True
+    while modified:
+        modified = False
+        for n, a in enumerate(out):
+            for m, b in enumerate(out[n + 1:], n + 1):
+                if a.bottom != b.y:
+                    continue
+                if a.x == b.x and a.right == b.right:
+                    a.bottom = b.bottom
+                    del out[m]
+                    modified = True
+                    break
+                # Only support rectangles for now:
+                if b.x < a.right and a.x < b.right:
+                    # Overlapping, but not equal
+                    raise NotImplementedError(
+                        "Keyboard.add_grid doesn't currently support "
+                        "merging non-rectangular regions"
+                    )
+            if modified:
+                break
+    return out
+
+
+def test_merge_regions():
+    import textwrap
+    import pytest
+
+    def r(s):
+        out = []
+        s = textwrap.dedent(s)
+        for y, line in enumerate(s.split("\n")):
+            for x, c in enumerate(line):
+                if c == "#":
+                    out.append(_MutRegion(x, y, x + 1, y + 1))
+        return out
+
+    assert _merge_regions([]) == []
+    assert _merge_regions(r("#")) == [_MutRegion(0, 0, 1, 1)]
+    assert _merge_regions(r("##")) == [_MutRegion(0, 0, 2, 1)]
+    assert _merge_regions(r("#\n#")) == [_MutRegion(0, 0, 1, 2)]
+    assert _merge_regions(r(".##\n.##")) == [_MutRegion(1, 0, 3, 2)]
+    with pytest.raises(NotImplementedError):
+        _merge_regions(r("##\n#."))
+    assert _merge_regions(r("""\
+        ......##.
+        ..##..##.
+        ..##....#
+        """)) == [_MutRegion(6, 0, 8, 2),
+                  _MutRegion(2, 1, 4, 3),
+                  _MutRegion(8, 2, 9, 3)]
 
 
 def _minimal_query(query):

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -476,8 +476,56 @@ for k in "abcdefghijklmnopqrstuvwxzy1234567890":
                        {"mode": "lowercase", "name": k},
                        "KEY_OK")
 
+# Same as kb1, but defined in a more succinct way using merge=True
+kb5 = stbt.Keyboard()
+kb5.add_grid(stbt.Grid(
+    region=stbt.Region(x=125, y=95, right=430, bottom=500),
+    data=[
+        ["lowercase"] * 2 + ["uppercase"] * 2 + ["symbols"] * 2,
+        "abcdef",
+        "ghijkl",
+        "mnopqr",
+        "stuvwx",
+        "yz1234",
+        "567890",
+        [" "] * 2 + ["BACKSPACE"] * 2 + ["CLEAR"] * 2
+    ]), mode="lowercase", merge=True)
+kb5.add_grid(stbt.Grid(
+    region=stbt.Region(x=125, y=95, right=430, bottom=500),
+    data=[
+        ["lowercase"] * 2 + ["uppercase"] * 2 + ["symbols"] * 2,
+        "ABCDEF",
+        "GHIJKL",
+        "MNOPQR",
+        "STUVWX",
+        "YZ1234",
+        "567890",
+        [" "] * 2 + ["BACKSPACE"] * 2 + ["CLEAR"] * 2
+    ]), mode="uppercase", merge=True)
+kb5.add_grid(stbt.Grid(
+    region=stbt.Region(x=125, y=95, right=430, bottom=500),
+    data=[
+        ["lowercase"] * 2 + ["uppercase"] * 2 + ["symbols"] * 2,
+        "!@#$%&",
+        "~*\\/?^",
+        "_`;:|=",
+        "éñ[]{}",
+        "çü.,+-",
+        "<>()'\"",
+        [" "] * 2 + ["BACKSPACE"] * 2 + ["CLEAR"] * 2
+    ]), mode="symbols", merge=True)
 
-@pytest.mark.parametrize("kb", [kb1, kb2], ids=["kb1", "kb2"])
+# Mode changes: For example when "ABC" is selected and we are in
+# lowercase mode, pressing OK takes us to "ABC" still selected
+# but the keyboard is now in uppercase mode.
+for source_mode in ["lowercase", "uppercase", "symbols"]:
+    for target_mode in ["lowercase", "uppercase", "symbols"]:
+        kb5.add_transition({"name": target_mode, "mode": source_mode},
+                           {"name": target_mode, "mode": target_mode},
+                           "KEY_OK")
+
+
+@pytest.mark.parametrize("kb", [kb1, kb2, kb5], ids=["kb1", "kb2", "kb5"])
 def test_enter_text_mixed_case(dut, kb):
     logging.debug("Keys: %r", kb.G.nodes())
     page = SearchPage(dut, kb)
@@ -490,8 +538,8 @@ def test_enter_text_mixed_case(dut, kb):
 
 
 @pytest.mark.parametrize("kb",
-                         [kb1, kb2, kb3],
-                         ids=["kb1", "kb2", "kb3"])
+                         [kb1, kb2, kb3, kb5],
+                         ids=["kb1", "kb2", "kb3", "kb5"])
 def test_enter_text_single_case(dut, kb):
     page = SearchPage(dut, kb)
     assert page.selection.name == "a"
@@ -500,7 +548,8 @@ def test_enter_text_single_case(dut, kb):
     assert dut.entered == "hi there"
 
 
-@pytest.mark.parametrize("kb", [kb1, kb2, kb3], ids=["kb1", "kb2", "kb3"])
+@pytest.mark.parametrize("kb", [kb1, kb2, kb3, kb5],
+                         ids=["kb1", "kb2", "kb3", "kb5"])
 def test_that_enter_text_uses_minimal_keypresses(dut, kb):
     page = SearchPage(dut, kb)
     assert page.selection.name == "a"
@@ -509,7 +558,8 @@ def test_that_enter_text_uses_minimal_keypresses(dut, kb):
                            "KEY_RIGHT", "KEY_OK"]
 
 
-@pytest.mark.parametrize("kb", [kb1, kb2, kb3], ids=["kb1", "kb2", "kb3"])
+@pytest.mark.parametrize("kb", [kb1, kb2, kb3, kb5],
+                         ids=["kb1", "kb2", "kb3", "kb5"])
 def test_enter_text_twice(dut, kb):
     """This is really a test of your Page Object's implementation of enter_text.
 
@@ -536,7 +586,8 @@ def test_that_enter_text_finds_keys_by_text(dut):
     assert dut.entered == " "
 
 
-@pytest.mark.parametrize("kb", [kb1, kb2, kb3], ids=["kb1", "kb2", "kb3"])
+@pytest.mark.parametrize("kb", [kb1, kb2, kb3, kb5],
+                         ids=["kb1", "kb2", "kb3", "kb5"])
 def test_navigate_to(dut, kb):
     page = SearchPage(dut, kb)
     assert page.selection.name == "a"
@@ -545,7 +596,7 @@ def test_navigate_to(dut, kb):
     assert dut.pressed == ["KEY_DOWN"] * 6 + ["KEY_RIGHT"] * 2
 
 
-@pytest.mark.parametrize("kb", [kb1, kb2], ids=["kb1", "kb2"])
+@pytest.mark.parametrize("kb", [kb1, kb2, kb5], ids=["kb1", "kb2", "kb5"])
 def test_navigate_to_other_mode(dut, kb):
     page = SearchPage(dut, kb)
     assert page.selection.name == "a"
@@ -563,7 +614,8 @@ def test_navigate_to_other_mode(dut, kb):
     ("c", False, 2),
     ("c", True, 1),
 ])
-@pytest.mark.parametrize("kb", [kb1, kb2, kb3], ids=["kb1", "kb2", "kb3"])
+@pytest.mark.parametrize("kb", [kb1, kb2, kb3, kb5],
+                         ids=["kb1", "kb2", "kb3", "kb5"])
 def test_that_navigate_to_checks_target(double_keypress_dut, kb, target,
                                         verify_every_keypress, num_presses):
     """DUT skips the B when pressing right from A (and lands on C)."""
@@ -599,7 +651,8 @@ def test_that_navigate_to_waits_for_dut_to_catch_up(slow_dut):
     assert slow_dut.pressed == ["KEY_RIGHT"] * 5
 
 
-@pytest.mark.parametrize("kb", [kb1, kb2, kb3], ids=["kb1", "kb2", "kb3"])
+@pytest.mark.parametrize("kb", [kb1, kb2, kb3, kb5],
+                         ids=["kb1", "kb2", "kb3", "kb5"])
 def test_that_keyboard_validates_the_targets_before_navigating(dut, kb):
     page = SearchPage(dut, kb)
     with pytest.raises(ValueError):
@@ -610,7 +663,8 @@ def test_that_keyboard_validates_the_targets_before_navigating(dut, kb):
     assert dut.pressed == []
 
 
-@pytest.mark.parametrize("kb", [kb1, kb2, kb3], ids=["kb1", "kb2", "kb3"])
+@pytest.mark.parametrize("kb", [kb1, kb2, kb3, kb5],
+                         ids=["kb1", "kb2", "kb3", "kb5"])
 def test_that_keyboard_validates_the_page_object_selection(dut, kb):
     page = SearchPage(dut, kb, is_visible=False)
     with pytest.raises(AssertionError) as excinfo:
@@ -818,7 +872,8 @@ def assert_repr_equal(a, b):
     assert re.match("^" + a + "$", b)
 
 
-@pytest.mark.parametrize("kb", [kb1, kb2, kb3], ids=["kb1", "kb2", "kb3"])
+@pytest.mark.parametrize("kb", [kb1, kb2, kb3, kb5],
+                         ids=["kb1", "kb2", "kb3", "kb5"])
 def test_keys_to_press(kb):
     a = kb.find_key("a")
     b = kb.find_key("b")
@@ -874,7 +929,8 @@ def test_keys_to_press(kb):
             ("KEY_DOWN", {space})]
 
 
-@pytest.mark.parametrize("kb", [kb1, kb2, kb3], ids=["kb1", "kb2", "kb3"])
+@pytest.mark.parametrize("kb", [kb1, kb2, kb3, kb5],
+                         ids=["kb1", "kb2", "kb3", "kb5"])
 def test_keyboard_weights(kb):
     five = kb.find_key("5", mode="lowercase" if kb.modes else None)
     six = kb.find_key("6", mode="lowercase" if kb.modes else None)


### PR DESCRIPTION
For example: this keyboard has a 3 square wide space bar and a two square wide OK button on the bottom row:

    KEYBOARD = stbt.Keyboard()
    KEYBOARD.add_grid(
        stbt.Grid(
            stbt.Region(377, 476, 527, 228),
            data=[
                "qwertyuiop",
                "asdfghjkl,",
                ["CAPS"] + list("zxcvbnm.") + ["BACKSPACE"],
                ["?123"] + list("◀▶   -_") + ["OK"] * 2,
            ]
        ),
        mode="lower", merge=True
    )

Without this change you'd have to separately add space and ok as separate keys and explicitly list the transitions up, left and right.  This is much less verbose and more readable.  See the changes to the tests to see.