### PR TITLE
Better typing

### DIFF
--- a/_stbt/black.py
+++ b/_stbt/black.py
@@ -23,7 +23,7 @@ from .types import Region
 
 def is_screen_black(frame: Optional[Frame] = None,
                     mask: MaskTypes = Region.ALL,
-                    threshold: int = None,
+                    threshold: "Optional[int]" = None,
                     region: Region = Region.ALL) -> "_IsScreenBlackResult":
     """Check for the presence of a black screen in a video frame.
 
@@ -112,9 +112,9 @@ def is_screen_black(frame: Optional[Frame] = None,
 
 
 class _IsScreenBlackResult():
-    def __init__(self, black, frame):
-        self.black = black
-        self.frame = frame
+    def __init__(self, black: bool, frame: Frame):
+        self.black: bool = black
+        self.frame: Frame = frame
 
     def __bool__(self):
         return self.black

--- a/_stbt/black.py
+++ b/_stbt/black.py
@@ -23,8 +23,8 @@ from .types import Region
 
 def is_screen_black(frame: Optional[Frame] = None,
                     mask: MaskTypes = Region.ALL,
-                    threshold: "Optional[int]" = None,
-                    region: Region = Region.ALL) -> "_IsScreenBlackResult":
+                    threshold: Optional[int] = None,
+                    region: Region = Region.ALL) -> _IsScreenBlackResult:
     """Check for the presence of a black screen in a video frame.
 
     :param Frame frame:

--- a/_stbt/config.py
+++ b/_stbt/config.py
@@ -4,7 +4,7 @@ import configparser
 import enum
 import os
 from contextlib import contextmanager
-from typing import Callable, Union, Type, TypeVar
+from typing import Callable, Type, TypeVar
 
 
 DefaultT = TypeVar('DefaultT')
@@ -25,9 +25,9 @@ class NoDefault():
 def get_config(
     section: str,
     key: str,
-    default: Union[Type[NoDefault], DefaultT] = NoDefault,
+    default: DefaultT | Type[NoDefault] = NoDefault,
     type_: Callable[[str], T] = str,
-) -> Union[T, DefaultT]:
+) -> "T | DefaultT":
     """Read the value of ``key`` from ``section`` of the test-pack
     configuration file.
 

--- a/_stbt/grid.py
+++ b/_stbt/grid.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import namedtuple
-from typing import Any, Iterator, List, Optional, Sequence, TypeVar, Union
+from typing import Any, Iterator, Optional, Sequence, TypeVar
 
 from .types import Position, PositionT, Region
 
@@ -95,7 +95,7 @@ class Grid():
         return self.cols * self.rows
 
     @property
-    def cells(self) -> List[Cell]:
+    def cells(self) -> list[Cell]:
         return [self.get(index=i)
                 for i in range(self.cols * self.rows)]
 
@@ -161,6 +161,8 @@ class Grid():
                     break
             else:
                 raise IndexError("data %r not found" % (data,))
+        else:
+            assert False, "Unreachable"
 
         return Grid.Cell(
             index,
@@ -169,7 +171,7 @@ class Grid():
             self.data and self.data[position[1]][position[0]])
 
     def __getitem__(
-            self, key: Union[int, Region, Position, tuple[int, int]]) -> Cell:
+            self, key: "int | Region | Position | tuple[int, int]") -> Cell:
         if isinstance(key, int):
             return self.get(index=key)
         elif isinstance(key, Region):
@@ -190,7 +192,7 @@ class Grid():
     def __len__(self) -> int:
         return self.cols * self.rows
 
-    def _index_to_position(self, index):
+    def _index_to_position(self, index: int) -> Position:
         area = self.cols * self.rows
         if index < -area:
             raise IndexError("Index out of range: index %r in %r" %
@@ -203,10 +205,10 @@ class Grid():
             raise IndexError("Index out of range: index %r in %r" %
                              (index, self))
 
-    def _position_to_index(self, position):
+    def _position_to_index(self, position: Position) -> int:
         return position[0] + position[1] * self.cols
 
-    def _region_to_position(self, region):
+    def _region_to_position(self, region) -> Position:
         rel = region.translate(x=-self.region.x, y=-self.region.y)
         centre = (float(rel.x + rel.right) / 2,
                   float(rel.y + rel.bottom) / 2)

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -4,9 +4,10 @@ import errno
 import inspect
 import os
 import re
+import typing
 import warnings
 from functools import lru_cache
-from typing import Optional, overload, Sequence, Tuple, TypeAlias, Union
+from typing import Optional, overload, Sequence, TypeAlias
 
 import cv2
 import numpy
@@ -19,7 +20,7 @@ from .types import Region
 FrameT : TypeAlias = numpy.typing.NDArray[numpy.uint8]
 
 # Anything that load_image can take:
-ImageT : TypeAlias = Union[numpy.typing.NDArray[numpy.uint8], str]
+ImageT : TypeAlias = numpy.typing.NDArray[numpy.uint8] | str
 
 
 class Frame(numpy.ndarray):
@@ -201,17 +202,17 @@ class Color:
                  alpha: "Optional[int]" = None) -> None:
         ...
     @overload
-    def __init__(self, bgr: "Tuple[int, int, int]") -> None:
+    def __init__(self, bgr: "tuple[int, int, int]") -> None:
         ...
     @overload
-    def __init__(self, bgra: "Tuple[int, int, int, int]") -> None:
+    def __init__(self, bgra: "tuple[int, int, int, int]") -> None:
         ...
     def __init__(self, *args,
                  hexstring: str = None,
                  blue: int = None, green: int = None, red: int = None,
                  alpha: int = None,
-                 bgr: "Tuple[int, int, int]" = None,
-                 bgra: "Tuple[int, int, int, int]" = None) -> None:
+                 bgr: "tuple[int, int, int]" = None,
+                 bgra: "tuple[int, int, int, int]" = None) -> None:
 
         self.array: numpy.ndarray  # BGR with shape (1, 1, 3) or BGRA (1, 1, 4)
 
@@ -304,7 +305,7 @@ class Color:
         return hash(self.hexstring)
 
 
-ColorT : TypeAlias = Union[Color, str, Tuple[int, int, int]]
+ColorT : TypeAlias = Color | str | tuple[int, int, int]
 
 
 def crop(frame: FrameT, region: Region) -> FrameT:
@@ -367,7 +368,7 @@ def load_image(
     :param flags: Flags to pass to :ocv:pyfunc:`cv2.imread`. Deprecated; use
       ``color_channels`` instead.
 
-    :param Tuple[int] color_channels: Tuple of acceptable numbers of color
+    :param tuple[int] color_channels: tuple of acceptable numbers of color
       channels for the output image: 1 for grayscale, 3 for color, and 4 for
       color with an alpha (transparency) channel. For example,
       ``color_channels=(3, 4)`` will accept color images with or without an

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -380,7 +380,7 @@ def load_image(filename, flags=None, color_channels=None) -> Image:
     :param flags: Flags to pass to :ocv:pyfunc:`cv2.imread`. Deprecated; use
       ``color_channels`` instead.
 
-    :param tuple[int] color_channels: tuple of acceptable numbers of color
+    :param tuple[int] color_channels: Tuple of acceptable numbers of color
       channels for the output image: 1 for grayscale, 3 for color, and 4 for
       color with an alpha (transparency) channel. For example,
       ``color_channels=(3, 4)`` will accept color images with or without an

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -7,7 +7,7 @@ import re
 import typing
 import warnings
 from functools import lru_cache
-from typing import Optional, overload, Sequence, TypeAlias
+from typing import overload, TypeAlias
 
 import cv2
 import numpy
@@ -344,11 +344,23 @@ def _image_region(image):
     return Region(0, 0, s[1], s[0])
 
 
+@typing.overload
+def load_image(filename: ImageT) -> Image:
+    ...
+
+
+@typing.overload
+def load_image(filename: ImageT, flags: int) -> Image:
+    ...
+
+
+@typing.overload
 def load_image(
-    filename: ImageT,
-    flags: Optional[Tuple[int]] = None,
-    color_channels: Optional[Sequence[int]] = None,
-) -> Image:
+        filename: ImageT, /, color_channels: int | tuple[int, ...]) -> Image:
+    ...
+
+
+def load_image(filename, flags=None, color_channels=None) -> Image:
     """Find & read an image from disk.
 
     If given a relative filename, this will search in the directory of the

--- a/_stbt/keyboard.py
+++ b/_stbt/keyboard.py
@@ -7,7 +7,7 @@ import re
 import time
 import typing
 from logging import getLogger
-from typing import Dict, List, Optional, Union, TypeAlias, TypeVar
+from typing import Optional, TypeAlias, TypeVar
 
 from attr import attrs, attrib
 from _stbt.frameobject import FrameObject
@@ -19,7 +19,7 @@ from _stbt.types import KeyT, Region
 
 
 FrameObjectT = TypeVar("FrameObjectT", bound=FrameObject)
-QueryT: TypeAlias = Union["Keyboard.Key", Dict[str, str], str]
+QueryT: TypeAlias = "Keyboard.Key | dict[str, str] | str"
 
 log = getLogger("stbt.Keyboard")
 
@@ -287,7 +287,7 @@ class Keyboard():
         text: Optional[str] = None,
         region: Optional[Region] = None,
         mode: Optional[str] = None,
-    ) -> List[Key]:
+    ) -> list[Key]:
         """Find matching keys in the model of the keyboard.
 
         This is like `find_key`, but it returns a list containing any

--- a/_stbt/mask.py
+++ b/_stbt/mask.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Optional, Tuple, TypeAlias, Union
+from typing import TypeAlias
 
 import cv2
 import numpy
@@ -19,7 +19,7 @@ except ImportError:
     Xxhash64 = None
 
 
-MaskTypes: TypeAlias = Union[str, numpy.ndarray, "Mask", Region, None]
+MaskTypes: TypeAlias = "str | numpy.ndarray | Mask | Region | None"
 
 
 def load_mask(mask: MaskTypes) -> Mask:
@@ -149,7 +149,7 @@ class Mask:
                          self._invert))
 
     def to_array(self, region: Region, color_channels: int = 1) \
-            -> Tuple[Optional[numpy.ndarray], Region]:
+            -> tuple[numpy.ndarray | None, Region]:
         """Materialize the mask to a numpy array of the specified size.
 
         Most users will never need to call this method; it's for people who
@@ -163,7 +163,7 @@ class Mask:
           will be identical — for example with 3 channels, pixels will be
           either [0, 0, 0] or [255, 255, 255].
 
-        :rtype: Tuple[Optional[numpy.ndarray], Region]
+        :rtype: tuple[numpy.ndarray | None, Region]
         :returns:
           A tuple of:
 
@@ -249,7 +249,7 @@ class BinOp:
 def _to_array_and_bounding_box_cached(
         mask: Mask,
         region: Region,
-        color_channels: int) -> Tuple[Optional[numpy.ndarray], Region]:
+        color_channels: int) -> tuple[numpy.ndarray | None, Region]:
 
     if mask._region is not None and not mask._invert:
         array = None

--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -289,8 +289,8 @@ def match(
 
 def match_all(
     image: ImageT,
-    frame: FrameT = None,
-    match_parameters: MatchParameters = None,
+    frame: Optional[FrameT] = None,
+    match_parameters: Optional[MatchParameters] = None,
     region: Region = Region.ALL,
 ) -> Iterator[MatchResult]:
     """
@@ -450,7 +450,7 @@ def wait_for_match(
     consecutive_matches: int = 1,
     match_parameters: Optional[MatchParameters] = None,
     region: Region = Region.ALL,
-    frames: Iterator[FrameT] = None,
+    frames: Optional[Iterator[FrameT]] = None,
 ) -> MatchResult:
     """Search for an image in the device-under-test's video stream.
 

--- a/_stbt/motion.py
+++ b/_stbt/motion.py
@@ -17,7 +17,7 @@ def detect_motion(
     noise_threshold: Optional[int] = None,
     mask: MaskTypes = Region.ALL,
     region: Region = Region.ALL,
-    frames: Iterator[FrameT] = None,
+    frames: Optional[Iterator[FrameT]] = None,
 ) -> Iterator[MotionResult]:
     """Generator that yields a sequence of one `MotionResult` for each frame
     processed from the device-under-test's video stream.
@@ -144,11 +144,11 @@ class DetectMotion():
 
 def wait_for_motion(
     timeout_secs: float = 10,
-    consecutive_frames: int = None,
+    consecutive_frames: "Optional[int | str]" = None,
     noise_threshold: Optional[int] = None,
     mask: MaskTypes = Region.ALL,
     region: Region = Region.ALL,
-    frames: Iterator[FrameT] = None,
+    frames: "Optional[Iterator[FrameT]]" = None,
 ) -> MotionResult:
     """Search for motion in the device-under-test's video stream.
 

--- a/_stbt/multipress.py
+++ b/_stbt/multipress.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 import time
+from typing import Optional
 
 from .types import KeyT
 
@@ -70,8 +71,8 @@ class MultiPress():
 
     def __init__(
         self,
-        key_mapping: dict[KeyT, str] = None,
-        interpress_delay_secs: float = None,
+        key_mapping: Optional[dict[KeyT, str]] = None,
+        interpress_delay_secs: Optional[float] = None,
         interletter_delay_secs: float = 1,
     ):
 

--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -7,7 +7,7 @@ import re
 import shutil
 import subprocess
 from enum import IntEnum
-from typing import Dict, List, Optional, Union
+from typing import Optional
 
 import cv2
 import numpy
@@ -19,7 +19,7 @@ from .logging import debug, ImageLogger, warn
 from .types import Region
 from .utils import LooseVersion, named_temporary_directory, to_unicode
 
-CorrectionsT = Dict[Union[re.Pattern, str], str]
+CorrectionsT = dict[re.Pattern | str, str]
 
 
 # Tesseract sometimes has a hard job distinguishing certain glyphs such as
@@ -122,7 +122,7 @@ class TextMatchResult():
     _fields = ("time", "match", "region", "frame", "text")
 
     def __init__(self, time, match, region, frame, text):
-        self.time: Optional[float] = time
+        self.time: float | None = time
         self.match: bool = match
         self.region: Region = region
         self.frame: FrameT = frame
@@ -143,18 +143,18 @@ class TextMatchResult():
 
 
 def ocr(
-    frame: FrameT = None,
+    frame: Optional[FrameT] = None,
     region: Region = Region.ALL,
     mode: OcrMode = OcrMode.PAGE_SEGMENTATION_WITHOUT_OSD,
-    lang: str = None,
-    tesseract_config: Optional[Dict[str, Union[bool, str, int]]] = None,
-    tesseract_user_words: Union[List[str], str] = None,
-    tesseract_user_patterns: Union[List[str], str] = None,
+    lang: Optional[str] = None,
+    tesseract_config: Optional[dict[str, bool | str | int]] = None,
+    tesseract_user_words: Optional[list[str] | str] = None,
+    tesseract_user_patterns: Optional[list[str] | str] = None,
     upsample: bool = True,
-    text_color: ColorT = None,
-    text_color_threshold: float = None,
+    text_color: Optional[ColorT] = None,
+    text_color_threshold: Optional[float] = None,
     engine: Optional[OcrEngine] = None,
-    char_whitelist: str = None,
+    char_whitelist: Optional[str] = None,
     corrections: Optional[CorrectionsT] = None,
 ):
     r"""Return the text present in the video frame as a Unicode string.
@@ -295,17 +295,17 @@ def ocr(
 
 def match_text(
     text: str,
-    frame: FrameT = None,
+    frame: Optional[FrameT] = None,
     region: Region = Region.ALL,
     mode: OcrMode = OcrMode.PAGE_SEGMENTATION_WITHOUT_OSD,
-    lang: str = None,
-    tesseract_config: Optional[Dict[str, Union[bool, str, int]]] = None,
+    lang: Optional[str] = None,
+    tesseract_config: Optional[dict[str, bool | str | int]] = None,
     case_sensitive: bool = False,
     upsample: bool = True,
-    text_color: ColorT = None,
-    text_color_threshold: float = None,
+    text_color: Optional[ColorT] = None,
+    text_color_threshold: Optional[float] = None,
     engine: Optional[OcrEngine] = None,
-    char_whitelist: str = None,
+    char_whitelist: Optional[str] = None,
 ) -> TextMatchResult:
     """Search for the specified text in a single video frame.
 

--- a/_stbt/precondition.py
+++ b/_stbt/precondition.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import traceback
 from contextlib import contextmanager
-from typing import ContextManager, Optional
+from typing import Iterator
 
 from .imgutils import FrameT
 from .logging import debug
@@ -21,7 +21,7 @@ class PreconditionError(UITestError):
         super().__init__()
         self.message: str = message
         self.original_exception: Exception = original_exception
-        self.screenshot: Optional[FrameT] = None
+        self.screenshot: FrameT | None = None
 
     def __str__(self):
         return (
@@ -30,7 +30,7 @@ class PreconditionError(UITestError):
 
 
 @contextmanager
-def as_precondition(message: str) -> ContextManager[None]:
+def as_precondition(message: str) -> Iterator[None]:
     """Context manager that replaces test failures with test errors.
 
     Stb-tester's reports show test failures (that is, `UITestFailure` or

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -31,9 +31,9 @@ def press_and_wait(
     region: Region = Region.ALL,
     timeout_secs: float = 10,
     stable_secs: float = 1,
-    min_size: SizeT | None = None,
+    min_size: Optional[SizeT] = None,
     retries: int = 0,
-    frames: Iterator[FrameT] | None = None,
+    frames: Optional[Iterator[FrameT]] = None,
     _dut=None,
 ) -> _TransitionResult:
 
@@ -67,7 +67,7 @@ def press_and_wait(
     :param min_size: A tuple of ``(width, height)``, in pixels, for differences
         to be considered as "motion". Use this to ignore small differences,
         such as the blinking text cursor in a search box.
-    :type min_size: Tuple[int, int]
+    :type min_size: tuple[int, int]
 
     :param int retries: Press the key again (up to this number of times) if
         the first press didn't have any effect (that is, if the press failed
@@ -166,13 +166,13 @@ press_and_wait.differ: Differ = BGRDiff()
 
 
 def wait_for_transition_to_end(
-    initial_frame: FrameT | None = None,
+    initial_frame: Optional[FrameT] = None,
     mask: MaskTypes = Region.ALL,
     region: Region = Region.ALL,
     timeout_secs: float = 10,
     stable_secs: float = 1,
-    min_size: SizeT | None = None,
-    frames: Iterator[FrameT] | None = None,
+    min_size: Optional[SizeT] = None,
+    frames: Optional[Iterator[FrameT]] = None,
 ) -> _TransitionResult:
 
     """Wait for the screen to stop changing.
@@ -310,7 +310,7 @@ class _TransitionResult():
         self.status: TransitionStatus = status
         self.press_time: float = press_time
         self.animation_start_time: float = animation_start_time
-        self.end_time: Optional[float] = end_time
+        self.end_time: float | None = end_time
 
     def __repr__(self):
         return (

--- a/_stbt/types.py
+++ b/_stbt/types.py
@@ -5,23 +5,26 @@ from __future__ import annotations
 import typing
 from collections import namedtuple
 from enum import Enum
-from typing import Optional, Tuple, TypeAlias
+from typing import Optional, TypeAlias
 
 if typing.TYPE_CHECKING:
     from .mask import Mask
 
 
-PositionT : TypeAlias = Tuple[int, int]
-SizeT : TypeAlias = Tuple[int, int]
+PositionT : TypeAlias = tuple[int, int]
+SizeT : TypeAlias = tuple[int, int]
 
 
-class Position(namedtuple('Position', 'x y')):
+class Position(typing.NamedTuple):
     """A point with ``x`` and ``y`` coordinates."""
-    pass
+    x: int
+    y: int
 
 
-class Size(namedtuple('Size', 'width height')):
+class Size(typing.NamedTuple):
     """Size of a rectangle with ``width`` and ``height``."""
+    width: int
+    height: int
 
 
 class Direction(Enum):
@@ -38,7 +41,7 @@ class Direction(Enum):
 
 
 # None means no region
-RegionT : TypeAlias = Optional["Region"]
+RegionT : TypeAlias = "Region | None"
 
 
 class _RegionClsMethods(type):
@@ -327,7 +330,7 @@ class Region(namedtuple('Region', 'x y right bottom'),
     def from_extents(x, y, right, bottom) -> Region:
         return Region(x, y, right=right, bottom=bottom)
 
-    def to_slice(self) -> Tuple[slice, slice]:
+    def to_slice(self) -> tuple[slice, slice]:
         """A 2-dimensional slice suitable for indexing a `stbt.Frame`."""
         return (slice(max(0, self.y),
                       max(0, self.bottom)),
@@ -513,8 +516,8 @@ class Region(namedtuple('Region', 'x y right bottom'),
         return self.replace(x=self.x - width, right=self.x)
 
 
-Region.ALL: Region = Region(x=-float('inf'), y=-float('inf'),
-                            right=float('inf'), bottom=float('inf'))
+Region.ALL = Region(x=-float('inf'), y=-float('inf'),
+                    right=float('inf'), bottom=float('inf'))
 
 
 KeyT : TypeAlias = str

--- a/_stbt/wait.py
+++ b/_stbt/wait.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import Callable, TypeVar
+from typing import Callable, Optional, TypeVar
 
 from .logging import debug
 
@@ -14,7 +14,7 @@ T = TypeVar("T")
 def wait_until(callable_: Callable[[], T],
                timeout_secs: float = 10,
                interval_secs: float = 0,
-               predicate: Callable[[T], bool] = None,
+               predicate: Optional[Callable[[T], bool]] = None,
                stable_secs: float = 0) -> T | None:
     """Wait until a condition becomes true, or until a timeout.
 

--- a/stbt_core/__init__.py
+++ b/stbt_core/__init__.py
@@ -10,6 +10,7 @@ https://github.com/stb-tester/stb-tester/blob/master/LICENSE for details).
 
 from __future__ import annotations
 
+import typing
 from contextlib import contextmanager
 from typing import ContextManager, Iterator, Optional
 
@@ -158,6 +159,9 @@ __all__ = [
 
 from _stbt.imgutils import ImageT
 from _stbt.types import KeyT, RegionT
+if typing.TYPE_CHECKING:
+    import _stbt.core
+
 
 TEST_PACK_ROOT: "str|None" = None
 
@@ -178,7 +182,8 @@ def last_keypress() -> "Keypress|None":
 
 
 def press(
-    key: KeyT, interpress_delay_secs: float = None, hold_secs: float = None
+    key: KeyT, interpress_delay_secs: Optional[float] = None,
+    hold_secs: Optional[float] = None
 ) -> Keypress:
     """Send the specified key-press to the device under test.
 
@@ -218,7 +223,7 @@ def press(
 
 
 def pressing(
-    key: KeyT, interpress_delay_secs: float = None
+    key: KeyT, interpress_delay_secs: Optional[float] = None
 ) -> ContextManager[Keypress]:
     """Context manager that will press and hold the specified key for the
     duration of the ``with`` code block.
@@ -285,7 +290,7 @@ def press_until_match(
         key, image, interval_secs, max_presses, match_parameters, region)
 
 
-def frames(timeout_secs: float = None) -> Iterator[Frame]:
+def frames(timeout_secs: Optional[float] = None) -> Iterator[Frame]:
     """Generator that yields video frames captured from the device-under-test.
 
     For example::
@@ -368,7 +373,8 @@ class UnconfiguredDeviceUnderTest():
             "stbt.get_frame isn't configured to run on your hardware")
 
 
-_dut = UnconfiguredDeviceUnderTest()
+_dut: "_stbt.core.DeviceUnderTest | UnconfiguredDeviceUnderTest" = (
+    UnconfiguredDeviceUnderTest())
 
 
 @contextmanager


### PR DESCRIPTION
* Don't use `Tuple/List/Dict`, use `tuple/list/dict` instead
* Don't use `Union`, use `|` instead
* Use `Optional[T]` only in parameters where `None` means "use the default
  value", rather than when `None` is a meaningful value by itself.  For
  instance: `region=None` means select nothing - as `None` is a valid
  region, while `frame=None` means grab a frame from live.  None is just
  a placeholder.  This means that we never use `Optional` in a return value
  position.
* Fix missing use of `Optional` in a few places
* Add a few more type annotations