### PR TITLE
Expose `Transition` (return type of `press_and_wait`) as public API

### DIFF
--- a/_stbt/keyboard.py
+++ b/_stbt/keyboard.py
@@ -14,7 +14,7 @@ from _stbt.frameobject import FrameObject
 from _stbt.grid import Grid
 from _stbt.imgutils import FrameT
 from _stbt.mask import MaskTypes, load_mask
-from _stbt.transition import _TransitionResult, TransitionStatus
+from _stbt.transition import Transition, TransitionStatus
 from _stbt.types import KeyT, Region
 
 
@@ -787,7 +787,7 @@ class Keyboard():
 
     def press_and_wait(
         self, key: KeyT, timeout_secs: float = 10, stable_secs: float = 1
-    ) -> _TransitionResult:
+    ) -> Transition:
         import stbt_core as stbt
         return stbt.press_and_wait(key, mask=self.mask,
                                    timeout_secs=timeout_secs,

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -35,7 +35,7 @@ def press_and_wait(
     retries: int = 0,
     frames: Optional[Iterator[FrameT]] = None,
     _dut=None,
-) -> _TransitionResult:
+) -> Transition:
 
     """Press a key, then wait for the screen to change, then wait for it to stop
     changing.
@@ -77,37 +77,8 @@ def press_and_wait(
         Defaults to ``stbt.frames()``.
 
     :returns:
-        An object that will evaluate to true if the transition completed, false
-        otherwise. It has the following attributes:
-
-        * **key** (*str*) – The name of the key that was pressed.
-        * **frame** (`stbt.Frame`) – If successful, the first video frame when
-          the transition completed; if timed out, the last frame seen.
-        * **status** (`stbt.TransitionStatus`) – Either ``START_TIMEOUT`` (the
-          transition didn't start – nothing moved), ``STABLE_TIMEOUT`` (the
-          transition didn't end – movement didn't stop), or ``COMPLETE`` (the
-          transition started and then stopped). If it's ``COMPLETE``, the whole
-          object will evaluate as true.
-        * **started** (*bool*) – The transition started (movement was seen
-          after the keypress). Implies that ``status`` is either ``COMPLETE``
-          or ``STABLE_TIMEOUT``.
-        * **complete** (*bool*) – The transition completed (movement started
-          and then stopped). Implies that ``status`` is ``COMPLETE``.
-        * **stable** (*bool*) – The screen is stable (no movement). Implies
-          ``complete or not started``.
-        * **press_time** (*float*) – When the key-press completed.
-        * **animation_start_time** (*float*) – When animation started after the
-          key-press (or ``None`` if timed out).
-        * **end_time** (*float*) – When animation completed (or ``None`` if
-          timed out).
-        * **duration** (*float*) – Time from ``press_time`` to ``end_time`` (or
-          ``None`` if timed out).
-        * **animation_duration** (*float*) – Time from ``animation_start_time``
-          to ``end_time`` (or ``None`` if timed out).
-
-        All times are measured in seconds since 1970-01-01T00:00Z; the
-        timestamps can be compared with system time (the output of
-        ``time.time()``).
+        A `Transition` object that will evaluate to true if the transition
+        completed, false otherwise.
 
     Changed in v32: Use the same difference-detection algorithm as
     `wait_for_motion`.
@@ -152,7 +123,7 @@ def press_and_wait(
 
 
 def _press_and_wait(key, mask, timeout_secs, stable_secs, min_size,
-                    frames, _dut) -> _TransitionResult:
+                    frames, _dut) -> Transition:
 
     t = _Transition(mask, timeout_secs, stable_secs, min_size, frames)
     press_result = _dut.press(key)
@@ -173,7 +144,7 @@ def wait_for_transition_to_end(
     stable_secs: float = 1,
     min_size: Optional[SizeT] = None,
     frames: Optional[Iterator[FrameT]] = None,
-) -> _TransitionResult:
+) -> Transition:
 
     """Wait for the screen to stop changing.
 
@@ -252,12 +223,12 @@ class _Transition():
                 _debug(
                     "Transition didn't start within %s seconds of pressing %s",
                     f, self.timeout_secs, press_result.key)
-                return _TransitionResult(
+                return Transition(
                     press_result.key, f, TransitionStatus.START_TIMEOUT,
                     press_result.end_time, None, None)
 
         end_result = self.wait_for_transition_to_end(f)  # pylint:disable=undefined-loop-variable
-        return _TransitionResult(
+        return Transition(
             press_result.key, end_result.frame, end_result.status,
             press_result.end_time, animation_start_time, end_result.end_time)
 
@@ -283,13 +254,13 @@ class _Transition():
                 _debug("Transition complete (stable for %ss since %.3f).",
                        first_stable_frame, self.stable_secs,
                        first_stable_frame.time)
-                return _TransitionResult(
+                return Transition(
                     None, first_stable_frame, TransitionStatus.COMPLETE,
                     None, initial_frame.time, first_stable_frame.time)
             if f.time >= self.expiry_time:
                 _debug("Transition didn't end within %s seconds",
                        f, self.timeout_secs)
-                return _TransitionResult(
+                return Transition(
                     None, f, TransitionStatus.STABLE_TIMEOUT,
                     None, initial_frame.time, None)
 
@@ -302,7 +273,41 @@ def _ddebug(s, f, *args):
     ddebug(("transition: %.3f: " + s) % ((getattr(f, "time", 0),) + args))
 
 
-class _TransitionResult():
+class Transition():
+    """The return value from `press_and_wait` and `wait_for_transition_to_end`.
+
+    This object will evaluate to true if the transition completed, false
+    otherwise. It has the following attributes:
+
+    * **key** (*str*) – The name of the key that was pressed.
+    * **frame** (`stbt.Frame`) – If successful, the first video frame when
+      the transition completed; if timed out, the last frame seen.
+    * **status** (`stbt.TransitionStatus`) – Either ``START_TIMEOUT`` (the
+      transition didn't start – nothing moved), ``STABLE_TIMEOUT`` (the
+      transition didn't end – movement didn't stop), or ``COMPLETE`` (the
+      transition started and then stopped). If it's ``COMPLETE``, the whole
+      object will evaluate as true.
+    * **started** (*bool*) – The transition started (movement was seen
+      after the keypress). Implies that ``status`` is either ``COMPLETE``
+      or ``STABLE_TIMEOUT``.
+    * **complete** (*bool*) – The transition completed (movement started
+      and then stopped). Implies that ``status`` is ``COMPLETE``.
+    * **stable** (*bool*) – The screen is stable (no movement). Implies
+      ``complete or not started``.
+    * **press_time** (*float*) – When the key-press completed.
+    * **animation_start_time** (*float*) – When animation started after the
+      key-press (or ``None`` if timed out).
+    * **end_time** (*float*) – When animation completed (or ``None`` if
+      timed out).
+    * **duration** (*float*) – Time from ``press_time`` to ``end_time`` (or
+      ``None`` if timed out).
+    * **animation_duration** (*float*) – Time from ``animation_start_time``
+      to ``end_time`` (or ``None`` if timed out).
+
+    All times are measured in seconds since 1970-01-01T00:00Z; the
+    timestamps can be compared with system time (the output of
+    ``time.time()``).
+    """
     def __init__(self, key, frame, status, press_time, animation_start_time,
                  end_time):
         self.key: KeyT = key
@@ -314,7 +319,7 @@ class _TransitionResult():
 
     def __repr__(self):
         return (
-            "_TransitionResult(key=%r, frame=<Frame>, status=%s, "
+            "Transition(key=%r, frame=<Frame>, status=%s, "
             "press_time=%s, animation_start_time=%s, end_time=%s)" % (
                 self.key,
                 self.status,
@@ -325,7 +330,7 @@ class _TransitionResult():
     def __str__(self):
         # Also lists the properties -- it's useful to see them in the logs.
         return (
-            "_TransitionResult(key=%r, frame=<Frame>, status=%s, "
+            "Transition(key=%r, frame=<Frame>, status=%s, "
             "press_time=%s, animation_start_time=%s, end_time=%s, duration=%s, "
             "animation_duration=%s)" % (
                 self.key,

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -319,7 +319,7 @@ class Transition():
 
     def __repr__(self):
         return (
-            "Transition(key=%r, frame=<Frame>, status=%s, "
+            "_TransitionResult(key=%r, frame=<Frame>, status=%s, "
             "press_time=%s, animation_start_time=%s, end_time=%s)" % (
                 self.key,
                 self.status,
@@ -330,7 +330,7 @@ class Transition():
     def __str__(self):
         # Also lists the properties -- it's useful to see them in the logs.
         return (
-            "Transition(key=%r, frame=<Frame>, status=%s, "
+            "_TransitionResult(key=%r, frame=<Frame>, status=%s, "
             "press_time=%s, animation_start_time=%s, end_time=%s, duration=%s, "
             "animation_duration=%s)" % (
                 self.key,
@@ -368,6 +368,11 @@ class Transition():
     def stable(self) -> bool:
         return self.status in (TransitionStatus.START_TIMEOUT,
                                TransitionStatus.COMPLETE)
+
+
+# For backwards compatibility with users who may have done
+# `from _stbt.transition import TransitionResult`; remove in v35.
+_TransitionResult = Transition
 
 
 class TransitionStatus(enum.Enum):

--- a/stbt_core/__init__.py
+++ b/stbt_core/__init__.py
@@ -74,6 +74,7 @@ from _stbt.precondition import (
     PreconditionError)
 from _stbt.transition import (
     press_and_wait,
+    Transition,
     TransitionStatus,
     wait_for_transition_to_end)
 from _stbt.types import (
@@ -147,6 +148,7 @@ __all__ = [
     "set_global_ocr_corrections",
     "Size",
     "TextMatchResult",
+    "Transition",
     "TransitionStatus",
     "UITestError",
     "UITestFailure",

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -7,7 +7,7 @@ import pytest
 
 import stbt_core as stbt
 from _stbt.keyboard import _keys_to_press, _strip_shift_transitions
-from _stbt.transition import _TransitionResult, TransitionStatus
+from _stbt.transition import Transition, TransitionStatus
 
 # pylint:disable=redefined-outer-name
 
@@ -126,10 +126,10 @@ class DUT():
 
     def handle_press_and_wait(self, key, **_kwargs):
         self.handle_press(key)
-        return _TransitionResult(key, None, TransitionStatus.COMPLETE, 0, 0, 0)
+        return Transition(key, None, TransitionStatus.COMPLETE, 0, 0, 0)
 
     def handle_wait_for_transition_to_end(self, *_args, **_kwargs):
-        return _TransitionResult(None, None, TransitionStatus.COMPLETE, 0, 0, 0)
+        return Transition(None, None, TransitionStatus.COMPLETE, 0, 0, 0)
 
 
 class DoubleKeypressDUT(DUT):
@@ -166,7 +166,7 @@ class MissedKeypressDUT(DUT):
             status = TransitionStatus.START_TIMEOUT
         else:
             status = TransitionStatus.COMPLETE
-        return _TransitionResult(key, None, status, 0, 0, 0)
+        return Transition(key, None, status, 0, 0, 0)
 
 
 class SlowDUT(DUT):
@@ -177,14 +177,14 @@ class SlowDUT(DUT):
     def handle_press_and_wait(self, key, **_kwargs):
         logging.debug("SlowDUT.handle_press: delaying %s", key)
         self._delayed_keypress = key
-        return _TransitionResult(key, None, TransitionStatus.COMPLETE, 0, 0, 0)
+        return Transition(key, None, TransitionStatus.COMPLETE, 0, 0, 0)
 
     def handle_wait_for_transition_to_end(self, *_args, **_kwargs):
         key = self._delayed_keypress
         self._delayed_keypress = None
         assert key is not None
         super().handle_press(key)
-        return _TransitionResult(key, None, TransitionStatus.COMPLETE, 0, 0, 0)
+        return Transition(key, None, TransitionStatus.COMPLETE, 0, 0, 0)
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_transition.py
+++ b/tests/test_transition.py
@@ -5,7 +5,7 @@ from numpy import isclose
 
 import stbt_core as stbt
 from _stbt.logging import scoped_debug_level
-from _stbt.transition import _TransitionResult
+from _stbt.transition import Transition
 from _stbt.types import Keypress
 
 
@@ -218,8 +218,8 @@ def test_press_and_wait_timestamps(diff_algorithm):
     (stbt.TransitionStatus.COMPLETE,       True,   True,    True),
 ])
 def test_transitionresult_properties(status, started, complete, stable):
-    t = _TransitionResult(key="KEY_OK", frame=None, status=status,
-                          press_time=0, animation_start_time=0, end_time=0)
+    t = Transition(key="KEY_OK", frame=None, status=status,
+                   press_time=0, animation_start_time=0, end_time=0)
     assert t.started == started
     assert t.complete == complete
     assert t.stable == stable


### PR DESCRIPTION
Needed for type annotations on navigation functions etc.

I have called it "Transition" instead of "TransitionResult" because having "TransitionResult" and "TransitionStatus" (the enum) is too confusing. Now there's confusion between "Transition" vs. "_Transition" (the latter is a private helper class) but at least the confusion is limited to the internal implementation details in `transition.py`.