### PR TITLE
load_image: Fix typing overload: color_channels is keyword-only

### DIFF
--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -356,7 +356,7 @@ def load_image(filename: ImageT, flags: int) -> Image:
 
 @typing.overload
 def load_image(
-        filename: ImageT, /, color_channels: int | tuple[int, ...]) -> Image:
+        filename: ImageT, *, color_channels: int | tuple[int, ...]) -> Image:
     ...
 
 


### PR DESCRIPTION
The "/" was added in commit 9e73a7850 (load_image typing: Ensure that color_channels is passed by name). The commit message suggests that the intention is for color_channels to be a keyword-only argument. But "/" means positional-only: https://peps.python.org/pep-0570/