### PR TITLE
Keyboard: Suport Page Object with `focus` property instead of `selection`

### DIFF
--- a/_stbt/keyboard.py
+++ b/_stbt/keyboard.py
@@ -167,6 +167,11 @@ class Keyboard():
       `navigate_to`.
     * Increased default ``navigate_timeout`` from 20 to 60 seconds.
 
+    Changed in v34:
+
+    * The property of the ``page`` object should be called ``focus``, not
+      ``selection`` (for backward compatibility we still support ``selection``).
+
     .. _Page Object: https://stb-tester.com/manual/object-repository#what-is-a-page-object
     .. _Directed Graph: https://en.wikipedia.org/wiki/Directed_graph
     '''


### PR DESCRIPTION
"focus" is going to be our official name going forward; "selection" is ambiguous because you can have "selected" something and then move the "focus" somewhere else without changing the active "selection".

I'm adding this to Keyboard for consistency with [navigate_1d].

For backwards compatibility we use the `selection` property, if it exists (even if `focus` also exists, to avoid changing behaviour for existing users, in case they have both a `focus` and a `selection`, even though it seems unlikely... but doing it this way means we can release this in a v34 minor release).

[navigate_1d]: https://stb-tester.com/manual/python-api#stbt.navigate_1d
