### PR TITLE
ocr_eq.replacements: Custom __setitem__

### DIFF
--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import collections
 import errno
 import glob
 import os
@@ -490,7 +491,26 @@ def ocr_eq(a: str, b: str) -> bool:
     return ocr_eq.normalize(a) == ocr_eq.normalize(b)
 
 
-ocr_eq.replacements = {
+def normalize(text):
+    return _normalize(text, ocr_eq.replacements)
+
+
+def _normalize(text, replacements):
+    for a, b in replacements.items():
+        text = text.replace(a, b)
+    return text
+
+
+class Replacements(collections.UserDict):
+    def __setitem__(self, key: str, value: str) -> None:
+        value = _normalize(value, self)
+        return super().__setitem__(key, value)
+
+    def __delitem__(self, key):
+        raise TypeError("Cannot remove items from ocr_eq.replacements")
+
+
+ocr_eq.replacements = Replacements({
     "''": '"',
     'm': 'rn',
     'i': 'l',
@@ -501,13 +521,7 @@ ocr_eq.replacements = {
     'o': 'O',
     '5': 'S',
     ' ': '',
-}
-
-
-def normalize(text):
-    for a, b in ocr_eq.replacements.items():
-        text = text.replace(a, b)
-    return text
+})
 
 
 ocr_eq.normalize = normalize

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -487,11 +487,18 @@ def test_ocr_eq_shouldnt_match(a, b):
 def test_ocr_eq_replacements():
     assert stbt.ocr_eq("hello", "hel 10")
     assert stbt.ocr_eq.normalize("hel 10") == "hellO"
-    orig = stbt.ocr_eq.replacements
+    orig = stbt.ocr_eq.replacements.copy()
     try:
         stbt.ocr_eq.replacements = {"1": "l"}
         assert stbt.ocr_eq("hello", "he11o")
         assert not stbt.ocr_eq("hello", "hel 10")
         assert stbt.ocr_eq.normalize("hel 10") == "hel l0"
     finally:
-        stbt.ocr_eq.replacements = orig
+        stbt.ocr_eq.replacements = orig.copy()
+
+    try:
+        # "I" is already normalized to "l"
+        stbt.ocr_eq.replacements["İ"] = "I"
+        assert stbt.ocr_eq("İ", "I")
+    finally:
+        stbt.ocr_eq.replacements = orig.copy()


### PR DESCRIPTION
There's a subtlety when adding your own replacements, if the replaced value is itself already a key in the replacements. Previously, you would have to do this:

    ocr_eq.replacements["İ"] = "I"                    # incorrect!
    ocr_eq.replacements["İ"] = ocr_eq.normalise("I")  # correct

Now, `ocr_eq.replacements["İ"] = "I"` is correct.

If a user replaces `ocr_eq.replacements` wholesale with a new dict, it'll lose this behaviour; but then that's their problem. Either replace it once with a single dict that you don't modify, or add to our one.

Note: I subclass [collections.UserDict] instead of subclassing `dict` directly, so that `copy()` preserves my subclass type (needed for my unit tests).

[collections.UserDict]: https://docs.python.org/3/library/collections.html#collections.UserDict