### PR TITLE
get_config: Improve error message when type conversion fails

### DIFF
--- a/_stbt/config.py
+++ b/_stbt/config.py
@@ -101,9 +101,9 @@ def get_config(
             raise ConfigurationError(e.message)
         else:
             return default
-    except ValueError:
-        raise ConfigurationError("'%s.%s' invalid type (must be %s)" % (
-            section, key, type_.__name__))
+    except ValueError as e:
+        raise ConfigurationError("'%s.%s' invalid type (must be %s): %s" % (
+            section, key, type_.__name__, e))
 
 
 def set_config(section, option, value):


### PR DESCRIPTION
This helped me to debug why configparser's `getboolean` was failing. The error message now looks like this:

> 'global.should_also_be_true' invalid type (must be bool): Not a boolean: yes  # with a comment

"Not a boolean: yes  # with a comment" is from the ValueError. As an aside, it made me realise that Python 3's configparser disables inline comments by default.