### PR TITLE
ocr_eq: Ignore punctuation

### DIFF
--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -621,7 +621,7 @@ def test_ocr_eq_replacements():
         stbt.ocr_eq.replacements = {"1": "l"}
         assert stbt.ocr_eq("hello", "he11o")
         assert not stbt.ocr_eq("hello", "hel 10")
-        assert stbt.ocr_eq.normalize("hel 10") == "hel l0"
+        assert stbt.ocr_eq.normalize("hel 10") == "hell0"
 
     with temporary_ocr_eq_replacements():
         # "I" is already normalized to "l"
@@ -644,8 +644,8 @@ def test_ocr_eq_replacements():
         assert stbt.ocr_eq("he11o", "he**o")
 
     assert stbt.ocr_eq("Movies & TV", "Movies 8. TV")  # YouTube menu
-    assert stbt.ocr_eq("8 .", "&")  # Hypothetical (not yet seen in real life)
     assert stbt.ocr_eq("BT Sport", "8T Sport")  # Apple TV
+    assert stbt.ocr_eq("Music", "Music:")  # Apple TV
     assert stbt.ocr_eq("App version", "App vefslon")  # YouTube settings menu
     assert stbt.ocr_eq("YuppTV - Live, CatchUp, Movies",
                        "YuppTV - Live, CatchUp. Movies")  # Roku


### PR DESCRIPTION
I have seen Tesseract return "Music:" (with a trailing colon) instead of "Music" — admittedly I was doing my own binarisation, but the binarised image looked 100% correct.