### PR TITLE
ocr_eq: Produce a better error message if given non-string

### DIFF
--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -509,7 +509,10 @@ def ocr_eq(a: str, b: str) -> bool:
     return ocr_eq.normalize(a) == ocr_eq.normalize(b)
 
 
-def normalize(text):
+def normalize(text: str):
+    if not isinstance(text, str):
+        raise TypeError(
+            f"stbt.ocr_eq.normalize: Expected a str, got {text!r}")
     return _normalize(text, ocr_eq.replacements)
 
 


### PR DESCRIPTION
If you pass a `Region` to `ocr_eq.normalize` it used to raise a confusing error:

    >>> ocr_eq.normalize(stbt.Region(0, 0, 1, 1))
    TypeError: '<=' not supported between instances of 'int' and 'str'

Now it says:

    TypeError: stbt.ocr_eq.normalize: Expected a str, got Region(x=0, y=0, right=1, bottom=1)