### PR TITLE
Internal: Add `logging.draw_source_region`

### DIFF
--- a/_stbt/black.py
+++ b/_stbt/black.py
@@ -16,7 +16,7 @@ import cv2
 from .config import get_config
 from .imgutils import (
     crop, Frame, _frame_repr, _image_region, pixel_bounding_box)
-from .logging import debug, ImageLogger
+from .logging import debug, draw_source_region, ImageLogger
 from .mask import load_mask, MaskTypes
 from .types import Region
 
@@ -78,6 +78,7 @@ def is_screen_black(frame: Optional[Frame] = None,
 
     mask_, region = load_mask(mask).to_array(_image_region(frame))
 
+    draw_source_region(frame, region)
     imglog = ImageLogger("is_screen_black", region=region, threshold=threshold)
     imglog.imwrite("source", frame)
 

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -518,6 +518,10 @@ class SinkPipeline():
                     to_unicode(obj))
                 self.text_annotations.append(
                     _TextAnnotation(start_time, text, duration_secs))
+            elif isinstance(obj, logging.SourceRegion):
+                # Backwards compatibility.  Consider changing this in the
+                # future.
+                pass
             elif hasattr(obj, "region") and hasattr(obj, "time"):
                 annotation = _Annotation.from_result(obj, label=label)
                 if annotation.time:

--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -22,8 +22,8 @@ from .imgproc_cache import memoize_iterator
 from .imgutils import (
     Frame, crop, FrameT, _frame_repr, ImageT, _image_region, limit_time,
     load_image, _validate_region)
-from .logging import (_Annotation, ddebug, debug, draw_on, get_debug_level,
-                      ImageLogger)
+from .logging import (_Annotation, ddebug, debug, draw_on, draw_source_region,
+                      get_debug_level, ImageLogger)
 from .sqdiff import sqdiff
 from .types import Position, Region, UITestFailure
 from .utils import to_unicode
@@ -415,6 +415,7 @@ def _match_all(image, frame, match_parameters, region):
         raise ValueError("%r must be larger than reference image %r"
                          % (input_region, t.shape))
 
+    draw_source_region(frame, input_region)
     imglog = ImageLogger(
         "match", match_parameters=match_parameters,
         template_name=t.filename or "<Image>",

--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -17,7 +17,7 @@ import numpy
 from . import imgproc_cache
 from .config import get_config
 from .imgutils import Color, ColorT, crop, FrameT, _frame_repr, _validate_region
-from .logging import debug, ImageLogger, warn
+from .logging import debug, draw_source_region, ImageLogger, warn
 from .types import Region
 from .utils import LooseVersion, named_temporary_directory, to_unicode
 
@@ -286,6 +286,7 @@ def ocr(
     if upsample is None:
         upsample = get_config("ocr", "upsample", type_=bool)
 
+    draw_source_region(frame, region)
     imglog = ImageLogger("ocr", result=None)
 
     text = _tesseract(
@@ -360,6 +361,7 @@ def match_text(
 
     rts = getattr(frame, "time", None)
 
+    draw_source_region(frame, region)
     imglog = ImageLogger("match_text")
 
     xml = _tesseract(frame, region, mode, lang, _config,


### PR DESCRIPTION
So we can show which regions are being ocred in the object repo.