### PR TITLE
stbt.Keyboard: Allow disjoint modes

### DIFF
--- a/_stbt/keyboard.py
+++ b/_stbt/keyboard.py
@@ -907,12 +907,22 @@ def _minimal_query(query):
 
 
 def _keys_to_press(G, source, targets):
+    from networkx import NetworkXNoPath
     from networkx.algorithms.shortest_paths.generic import shortest_path
 
-    paths = sorted(
-        [shortest_path(G, source=source, target=t, weight="weight")
-         for t in targets],
-        key=lambda p: _path_weight(G, p))
+    assert targets
+
+    paths = []
+    for t in targets:
+        try:
+            paths.append(shortest_path(
+                G, source=source, target=t, weight="weight"))
+        except NetworkXNoPath:
+            pass
+    if not paths:
+        raise NetworkXNoPath("No path to %s." % (
+            _join_with_commas([str(t) for t in targets], last_one=" or ")))
+    paths.sort(key=lambda p: _path_weight(G, p))
     path = paths[0]
     # shortest_path(G, "A", "V") -> ["A", "H", "O", "V"]
     # shortest_path(G, "A", "A") -> ["A"]


### PR DESCRIPTION
If there are two "A"s in the keyboard, it should succeed if it can find a path to one of them.

For convenience I'm modelling a Keyboard that has 2 different appearances (on different STBs) as a single Keyboard with 2 different modes (and a single Page Object that handles both appearances). Both modes have all the letters, and there's no way to get from one mode to the other. This way I don't have to make my Page Object remember which `Keyboard` instance to use — there's only one `Keyboard` instance.