### PR TITLE
Keyboard: performance optimisations for defining a keyboard

### DIFF
--- a/_stbt/keyboard.py
+++ b/_stbt/keyboard.py
@@ -6,6 +6,7 @@ import dataclasses
 import re
 import time
 import typing
+from collections import defaultdict
 from logging import getLogger
 from typing import Optional, TypeAlias, TypeVar
 
@@ -201,6 +202,7 @@ class Keyboard():
         self.G = DiGraph()
         self.G_ = None  # navigation without shift transitions that type text
         self.modes = set()
+        self.name_index = defaultdict(list)
 
         self.mask = load_mask(mask)
         self.navigate_timeout = navigate_timeout
@@ -346,7 +348,11 @@ class Keyboard():
             raise ValueError("Empty query %r" % (query,))
         if mode is not None:
             query["mode"] = mode
-        return [x for x in self.G.nodes()
+        if "name" in query:
+            nodes = self.name_index[query["name"]]
+        else:
+            nodes = self.G.nodes()
+        return [x for x in nodes
                 if ("name" not in query or x.name == query["name"]) and
                    ("text" not in query or x.text == query["text"]) and
                    ("region" not in query or (
@@ -394,6 +400,7 @@ class Keyboard():
                              "other keys in the keyboard do" % (spec,))
         self.G.add_node(node)
         self.G_ = None
+        self.name_index[node.name].append(node)
         if node.region is None:
             self._any_without_region = True
         else:

--- a/_stbt/keyboard.py
+++ b/_stbt/keyboard.py
@@ -347,15 +347,12 @@ class Keyboard():
         if mode is not None:
             query["mode"] = mode
         return [x for x in self.G.nodes()
-                if all(Keyboard.QUERYER[k](x, v) for k, v in query.items())]
-
-    QUERYER = {
-        "name": lambda x, v: x.name == v,
-        "text": lambda x, v: x.text == v,
-        "region": lambda x, v: (x.region is not None and
-                                x.region.contains(v.center)),
-        "mode": lambda x, v: x.mode == v,
-    }
+                if ("name" not in query or x.name == query["name"]) and
+                   ("text" not in query or x.text == query["text"]) and
+                   ("region" not in query or (
+                    x.region is not None and
+                    x.region.contains(query["region"].center))) and
+                   ("mode" not in query or x.mode == query["mode"])]
 
     def _find_or_add_key(self, query):
         """Note: We don't want to expose this operation in the public API

--- a/_stbt/keyboard.py
+++ b/_stbt/keyboard.py
@@ -222,7 +222,7 @@ class Keyboard():
         name: str,
         text: Optional[str] = None,
         region: Optional[Region] = None,
-        mode: str = None,
+        mode: Optional[str] = None,
     ):
         """Add a key to the model (specification) of the keyboard.
 

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 import time
 from unittest import mock
@@ -1082,6 +1083,8 @@ def test_disjoint_modes():
                             kb.find_keys("0")))
 
 
+@pytest.mark.skipif("STBT_RUN_PERFORMANCE_TESTS" not in os.environ,
+                    reason="$STBT_RUN_PERFORMANCE_TESTS is not set")
 def test_keyboard_definition_performance():
     start_time = time.time()
     kb = stbt.Keyboard()
@@ -1090,4 +1093,4 @@ def test_keyboard_definition_performance():
                               data=["abcdefghijklmnopqrstuvwxyz"]),
                     mode=str(mode))
     duration = time.time() - start_time
-    assert duration < 0.1
+    assert duration < 0.3

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import time
 from unittest import mock
 
 import numpy
@@ -1079,3 +1080,14 @@ def test_disjoint_modes():
         list(_keys_to_press(kb.G,
                             kb.find_key("a", mode="single-row"),
                             kb.find_keys("0")))
+
+
+def test_keyboard_definition_performance():
+    start_time = time.time()
+    kb = stbt.Keyboard()
+    for mode in range(100):
+        kb.add_grid(stbt.Grid(region=stbt.Region(0, 0, 26, 1),
+                              data=["abcdefghijklmnopqrstuvwxyz"]),
+                    mode=str(mode))
+    duration = time.time() - start_time
+    assert duration < 0.1


### PR DESCRIPTION
This fixes a quadratic algorithm when adding keys, because each time we added a key, we scanned through the entire list of keys to check that it wasn't already present.

Defining a keyboard is typically done at module import time, not at run time, so we want it to be as fast as possible, even if it doesn't seem like much.