### PR TITLE
android: Set permissions of adb secret key to 0600

### DIFF
--- a/_stbt/android.py
+++ b/_stbt/android.py
@@ -189,6 +189,7 @@ class AdbDevice():
                 "commit the 'config/android' directory to git.")
         shutil.copytree(os.path.join(root, "config/android"),
                         os.path.join(os.environ["HOME"], ".android"))
+        os.chmod(os.path.join(os.environ["HOME"], ".android/adbkey"), 0o600)
 
     def adb(self, args, *, timeout=None, **subprocess_kwargs) \
             -> subprocess.CompletedProcess:


### PR DESCRIPTION
This is how adb expects it.