### PR TITLE
AdbDevice.get_frame: Handle PNG data not corrupted by adb shell

### DIFF
--- a/_stbt/android.py
+++ b/_stbt/android.py
@@ -258,6 +258,7 @@ class AdbDevice():
                             timeout=60, capture_output=True) \
                        .stdout
             assert isinstance(data, bytes)
+            header = data[:10]
             if data.startswith(b"\x89PNG\r\r\n"):
                 # Older versions of `adb shell` convert LF to CRLF.
                 # The PNG format is designed to detect this: It should start
@@ -270,7 +271,7 @@ class AdbDevice():
                 logger.warning(
                     "AdbDevice.get_frame: Failed to get screenshot "
                     "via ADB (attempt %d/3)\n"
-                    "Length of data: %d", attempt, len(data))
+                    "Header: %s, length: %d", attempt, header, len(data))
             else:
                 break
         else:

--- a/_stbt/android.py
+++ b/_stbt/android.py
@@ -256,7 +256,13 @@ class AdbDevice():
             timestamp = time.time()
             data = self.adb(["shell", "screencap", "-p"],
                             timeout=60, capture_output=True) \
-                       .stdout.replace(b"\r\n", b"\n")
+                       .stdout
+            assert isinstance(data, bytes)
+            if data.startswith(b"\x89PNG\r\r\n"):
+                # Older versions of `adb shell` convert LF to CRLF.
+                # The PNG format is designed to detect this: It should start
+                # with 0x89, followed by "PNG", followed by CRLF.
+                data = data.replace(b"\r\n", b"\n")
             img = cv2.imdecode(
                 numpy.asarray(bytearray(data), dtype=numpy.uint8),
                 cv2.IMREAD_COLOR)


### PR DESCRIPTION
Older versions of `adb shell` would convert every LF in the PNG data to CRLF. Apparently newer versions of adb don't do this, so our "fix" actually corrupts the PNG and we get "AdbError: Failed to capture screenshot from android device".

https://stackoverflow.com/a/13593914:

> It's worth noting that the PNG file format is explicitly designed to catch exactly this (and related) problems. The magic number begins with 0x89 to catch anything that strips high bits, followed by "PNG" so you can easily tell what's in the file, followed by CR LF to catch various ASCII line converters, then 0x1a to trap old MS-DOS programs that used Ctrl-Z as a special end-of-file marker, and then a lone LF. By looking at the first few bytes of the file you can tell exactly what was done to it.
