### PR TITLE
Add control.keymap_section config variable

### DIFF
--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -123,6 +123,8 @@ class DeviceUnderTest():
     def press(self, key, interpress_delay_secs=None, hold_secs=None):
         if isinstance(key, Enum):
             key = key.value
+        if section := get_config("control", "keymap_section", None):
+            key = get_config(section, key, key)
 
         if hold_secs is not None and hold_secs > 60:
             # You must ensure that lircd's --repeat-max is set high enough.
@@ -149,6 +151,8 @@ class DeviceUnderTest():
     def pressing(self, key, interpress_delay_secs=None):
         if isinstance(key, Enum):
             key = key.value
+        if section := get_config("control", "keymap_section", None):
+            key = get_config(section, key, key)
 
         with self._interpress_delay(interpress_delay_secs):
             out = Keypress(key, self._time.time(), None, self.get_frame())


### PR DESCRIPTION
This allows mapping key names in the config file.

Example:

    [control]
    keymap_section = mykeymap

    [mykeymap]
    KEY_UP = KEYCODE_DPAD_UP

And now when you call `stbt.press("KEY_UP")` actually `KEYCODE_DPAD_UP` will get sent.