### PR TITLE
ocr & get_config changes for Object Repository

### DIFF
--- a/_stbt/config.py
+++ b/_stbt/config.py
@@ -165,7 +165,8 @@ def _config_init(force=False):
         config_files.extend(
             reversed(os.environ.get('STBT_CONFIG_FILE', '')
                      .split(':')))
-        config = configparser.ConfigParser()
+        config = configparser.ConfigParser(
+            interpolation=configparser.ExtendedInterpolation())
         config.read(config_files)
         _config = config
     return _config

--- a/_stbt/config.py
+++ b/_stbt/config.py
@@ -81,9 +81,6 @@ def get_config(
     Raises `ConfigurationError` if the specified ``section`` or ``key`` is not
     found, unless ``default`` is specified (in which case ``default`` is
     returned).
-
-    Changed in v32: Allow specifying ``None`` as the default value (previously
-    ``None`` would be treated as if you hadn't specified any default value).
     """
 
     config = _config_init()

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -124,7 +124,9 @@ class DeviceUnderTest():
         if isinstance(key, Enum):
             key = key.value
         if section := get_config("control", "keymap_section", None):
-            key = get_config(section, key, default=key)
+            mapped_key = get_config(section, key, default=key)
+        else:
+            mapped_key = key
 
         if hold_secs is not None and hold_secs > 60:
             # You must ensure that lircd's --repeat-max is set high enough.
@@ -137,7 +139,7 @@ class DeviceUnderTest():
                 else:
                     frame_before = self.get_frame()
                 out = Keypress(key, self._time.time(), None, frame_before)
-                self._control.press(key)
+                self._control.press(mapped_key)
                 out.end_time = self._time.time()
             self.draw_text(key, duration_secs=3)
             self._last_keypress = out
@@ -152,26 +154,28 @@ class DeviceUnderTest():
         if isinstance(key, Enum):
             key = key.value
         if section := get_config("control", "keymap_section", None):
-            key = get_config(section, key, default=key)
+            mapped_key = get_config(section, key, default=key)
+        else:
+            mapped_key = key
 
         with self._interpress_delay(interpress_delay_secs):
             out = Keypress(key, self._time.time(), None, self.get_frame())
             try:
-                self._control.keydown(key)
+                self._control.keydown(mapped_key)
                 self.draw_text("Holding %s" % key, duration_secs=3)
                 self._last_keypress = out
                 yield out
             except:
                 exc_info = sys.exc_info()
                 try:
-                    self._control.keyup(key)
+                    self._control.keyup(mapped_key)
                     self.draw_text("Released %s" % key, duration_secs=3)
                 except Exception:  # pylint:disable=broad-except
                     # Don't mask original exception from the test script.
                     pass
                 raise exc_info[1].with_traceback(exc_info[2])
             else:
-                self._control.keyup(key)
+                self._control.keyup(mapped_key)
                 out.end_time = self._time.time()
                 self.draw_text("Released %s" % key, duration_secs=3)
 

--- a/_stbt/core.py
+++ b/_stbt/core.py
@@ -124,7 +124,7 @@ class DeviceUnderTest():
         if isinstance(key, Enum):
             key = key.value
         if section := get_config("control", "keymap_section", None):
-            key = get_config(section, key, key)
+            key = get_config(section, key, default=key)
 
         if hold_secs is not None and hold_secs > 60:
             # You must ensure that lircd's --repeat-max is set high enough.
@@ -152,7 +152,7 @@ class DeviceUnderTest():
         if isinstance(key, Enum):
             key = key.value
         if section := get_config("control", "keymap_section", None):
-            key = get_config(section, key, key)
+            key = get_config(section, key, default=key)
 
         with self._interpress_delay(interpress_delay_secs):
             out = Keypress(key, self._time.time(), None, self.get_frame())

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -101,8 +101,6 @@ class Image(numpy.ndarray):
     :vartype relative_filename: str or None
     :ivar relative_filename: The path resolved by `stbt.load_image`, relative
         to the root of the test-pack git repo.
-
-    Added in v32.
     """
     def __new__(cls, array, dtype=None, order=None,
                 filename: str|None = None,
@@ -426,11 +424,6 @@ def load_image(filename, flags=None, color_channels=None) -> Image:
     :raises: `IOError` if the specified path doesn't exist or isn't a valid
         image file.
 
-    * Changed in v32: Return type is now `stbt.Image`, which is a
-      `numpy.ndarray` sub-class with additional attributes ``filename``,
-      ``relative_filename`` and ``absolute_filename``.
-    * Changed in v32: Allows passing an image (`numpy.ndarray` or `stbt.Image`)
-      instead of a string, in which case this function returns the given image.
     * Changed in v33: Added the ``color_channels`` parameter and deprecated
       ``flags``. The image will always be converted to the format specified by
       ``color_channels`` (previously it was only converted to the format

--- a/_stbt/keyboard.py
+++ b/_stbt/keyboard.py
@@ -142,22 +142,6 @@ class Keyboard():
     keyboard modes (lowercase, uppercase, and symbols) see our article
     `Testing on-screen keyboards <https://stb-tester.com/manual/keyboard>`__.
 
-    ``stbt.Keyboard`` was added in v31.
-
-    Changed in v32:
-
-    * Added support for keyboards with different modes (such as uppercase,
-      lowercase, and symbols).
-    * Changed the internal representation of the Directed Graph. Manipulating
-      the networkx graph directly is no longer supported.
-    * Removed ``stbt.Keyboard.parse_edgelist`` and
-      ``stbt.grid_to_navigation_graph``. Instead, first create the Keyboard
-      object, and then use `add_key`, `add_transition`, `add_edgelist`, and
-      `add_grid` to build the model of the keyboard.
-    * Removed the ``stbt.Keyboard.Selection`` type. Instead, your Page Object's
-      ``focus`` property should return a `Key` value obtained from
-      `find_key`.
-
     Changed in v33:
 
     * Added class `stbt.Keyboard.Key` (the type returned from `find_key`). This

--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -201,9 +201,6 @@ class MatchResult():
 
     :ivar Image image: The reference image that was searched for, as given to
         `match`.
-
-    Changed in v32: The type of the ``image`` attribute is now `stbt.Image`.
-    Previously it was a string or a numpy array.
     """
     _fields = ("time", "match", "region", "first_pass_result", "frame", "image")
 

--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -178,11 +178,17 @@ def ocr(
         `ISO-639-3 <http://www.loc.gov/standards/iso639-2/php/code_list.php>`__
         language code of the language you are attempting to read; for example
         "eng" for English or "deu" for German. More than one language can be
-        specified by joining with '+'; for example "eng+deu" means that the
-        text to be read may be in a mixture of English and German. This defaults
-        to "eng" (English). You can override the global default value by setting
-        ``lang`` in the ``[ocr]`` section of :ref:`.stbt.conf`. You may need to
-        install the tesseract language pack; see installation instructions
+        specified by joining with '+': for example "eng+deu" means that the
+        text to be read may be in a mixture of English and German.
+
+        This defaults to "eng" (English). You can change the global default
+        value by setting ``lang`` in the ``[ocr]`` section of
+        :ref:`.stbt.conf`. You can change the default value for a specific Node
+        by setting ``lang`` in the ``[device_type]`` section of the appropriate
+        :ref:`Node-specific configuration file <node-specific-config>`.
+
+        You may need to install the tesseract language pack; see installation
+        instructions
         `here <https://stb-tester.com/manual/faq#installing-language-packs>`__.
 
     :param dict tesseract_config:
@@ -610,6 +616,8 @@ def _tesseract(frame, region, mode, lang, _config, user_patterns, user_words,
     if _config is None:
         _config = {}
 
+    if lang is None:
+        lang = get_config("device_type", "lang", None)
     if lang is None:
         lang = get_config("ocr", "lang", "eng")
 

--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -273,9 +273,6 @@ def ocr(
         `stbt.set_global_ocr_corrections`. If global corrections have been set
         *and* this ``corrections`` parameter is specified, the corrections in
         this parameter are applied first.
-
-    | Added in v31: The ``char_whitelist`` parameter.
-    | Added in v32: The ``corrections`` parameter.
     """
     if frame is None:
         from stbt_core import get_frame
@@ -350,8 +347,6 @@ def match_text(
         assert m.match
         while not stbt.match('selected-button.png').region.contains(m.region):
             stbt.press('KEY_DOWN')
-
-    | Added in v31: The ``char_whitelist`` parameter.
     """
     if frame is None:
         from stbt_core import get_frame

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -78,9 +78,6 @@ def press_and_wait(
         A `Transition` object that will evaluate to true if the transition
         completed, false otherwise.
 
-    Changed in v32: Use the same difference-detection algorithm as
-    `wait_for_motion`.
-
     Added in v33: The ``started``, ``complete`` and ``stable`` attributes of
     the returned value.
 

--- a/stbt_core/__init__.py
+++ b/stbt_core/__init__.py
@@ -179,8 +179,6 @@ def last_keypress() -> "Keypress|None":
     test.
 
     See the return type of `stbt.press`.
-
-    Added in v32.
     """
     return _dut.last_keypress()
 

--- a/stbt_virtual_stb.py
+++ b/stbt_virtual_stb.py
@@ -60,10 +60,10 @@ def virtual_stb(command, x_keymap=None, verbose=False):
 
         try:
             config.update({
-                "control": "x11:%(x_display)s,%(x_keymap)s",
+                "control": "x11:${x_display},%{x_keymap}",
                 "source_pipeline": (
                     'ximagesrc use-damage=false remote=true show-pointer=false '
-                    'display-name=%(x_display)s ! video/x-raw,framerate=24/1'),
+                    'display-name=${x_display} ! video/x-raw,framerate=24/1'),
                 "x_display": display,
                 "vstb_child_pid": str(child.pid),
                 "vstb_pid": str(os.getpid()),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -156,7 +156,7 @@ def temporary_config(contents, prefix="stbt-test-config"):
             f.write(dedent(contents))
         _config_init(force=True)
         try:
-            yield
+            yield filename
         finally:
             os.environ["STBT_CONFIG_FILE"] = original_env
             _config_init(force=True)
@@ -193,3 +193,30 @@ def test_get_config_with_default_value():
         assert get_config("nosuchsection", "test", None) is None
         with pytest.raises(ConfigurationError):
             get_config("nosuchsection", "test")
+
+
+CONFIG_WITH_INTERPOLATION = dedent("""\
+    [ocr]
+    lang = ${device_type:lang}
+    basic = %(lang)s
+
+    [device_type]
+    lang = deu
+
+    """)
+
+
+def test_get_config_interpolation():
+    # Stb-tester uses extended interpolation:
+    # https://docs.python.org/3.10/library/configparser.html#configparser.ExtendedInterpolation
+    with temporary_config(CONFIG_WITH_INTERPOLATION):
+        assert get_config("ocr", "lang") == "deu"
+        # Basic interpolation syntax is treated literally:
+        assert get_config("ocr", "basic") == "%(lang)s"
+
+
+def test_that_set_config_preserves_interpolation():
+    with temporary_config(CONFIG_WITH_INTERPOLATION) as filename:
+        set_config("device_type", "lang", "eng")
+        assert open(filename, encoding="utf-8").read() == \
+            CONFIG_WITH_INTERPOLATION.replace("deu", "eng")

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -112,7 +112,14 @@ def test_that_match_text_accepts_unicode():
 def test_that_default_language_is_configurable():
     f = load_image("ocr/unicode.png")
     assert not stbt.match_text("Röthlisberger", f)  # reads Réthlisberger
+    assert "Röthlisberger" not in stbt.ocr(f)
     with temporary_config({"ocr.lang": "deu"}):
+        assert stbt.match_text("Röthlisberger", f)
+        assert "Röthlisberger" in stbt.ocr(f)
+    with temporary_config({"ocr.lang": "deu", "device_type.lang": "eng"}):
+        assert not stbt.match_text("Röthlisberger", f)
+        assert "Röthlisberger" not in stbt.ocr(f)
+    with temporary_config({"ocr.lang": "eng", "device_type.lang": "deu"}):
         assert stbt.match_text("Röthlisberger", f)
         assert "Röthlisberger" in stbt.ocr(f)
 

--- a/tests/test_press.py
+++ b/tests/test_press.py
@@ -41,14 +41,16 @@ def test_keymap_section():
                               sink_pipeline=NoSinkPipeline())
         dut.press("KEY_OK")
         assert control.press.call_args[0] == ("KEY_OK",)
-        dut.press("KEY_FLOOBLE")
+        keypress = dut.press("KEY_FLOOBLE")
         assert control.press.call_args[0] == ("KEY_UP",)
+        assert keypress.key == "KEY_FLOOBLE"
         with dut.pressing("KEY_OK"):
             assert control.keydown.call_args[0] == ("KEY_OK",)
         assert control.keyup.call_args[0] == ("KEY_OK",)
-        with dut.pressing("KEY_FLOOBLE"):
+        with dut.pressing("KEY_FLOOBLE") as keypress:
             assert control.keydown.call_args[0] == ("KEY_UP",)
         assert control.keyup.call_args[0] == ("KEY_UP",)
+        assert keypress.key == "KEY_FLOOBLE"
     finally:
         _config_init(force=True)
 


### PR DESCRIPTION
This allows overriding the default language for a particular device type. This will be particularly useful for OCR properties in the Object Repository.