### PR TITLE
Revert #851

### DIFF
--- a/_stbt/config.py
+++ b/_stbt/config.py
@@ -165,8 +165,7 @@ def _config_init(force=False):
         config_files.extend(
             reversed(os.environ.get('STBT_CONFIG_FILE', '')
                      .split(':')))
-        config = configparser.ConfigParser(
-            interpolation=configparser.ExtendedInterpolation())
+        config = configparser.ConfigParser()
         config.read(config_files)
         _config = config
     return _config

--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -178,17 +178,11 @@ def ocr(
         `ISO-639-3 <http://www.loc.gov/standards/iso639-2/php/code_list.php>`__
         language code of the language you are attempting to read; for example
         "eng" for English or "deu" for German. More than one language can be
-        specified by joining with '+': for example "eng+deu" means that the
-        text to be read may be in a mixture of English and German.
-
-        This defaults to "eng" (English). You can change the global default
-        value by setting ``lang`` in the ``[ocr]`` section of
-        :ref:`.stbt.conf`. You can change the default value for a specific Node
-        by setting ``lang`` in the ``[device_type]`` section of the appropriate
-        :ref:`Node-specific configuration file <node-specific-config>`.
-
-        You may need to install the tesseract language pack; see installation
-        instructions
+        specified by joining with '+'; for example "eng+deu" means that the
+        text to be read may be in a mixture of English and German. This defaults
+        to "eng" (English). You can override the global default value by setting
+        ``lang`` in the ``[ocr]`` section of :ref:`.stbt.conf`. You may need to
+        install the tesseract language pack; see installation instructions
         `here <https://stb-tester.com/manual/faq#installing-language-packs>`__.
 
     :param dict tesseract_config:
@@ -611,8 +605,6 @@ def _tesseract(frame, region, mode, lang, _config, user_patterns, user_words,
     if _config is None:
         _config = {}
 
-    if lang is None:
-        lang = get_config("device_type", "lang", None)
     if lang is None:
         lang = get_config("ocr", "lang", "eng")
 

--- a/_stbt/ocr.py
+++ b/_stbt/ocr.py
@@ -178,11 +178,16 @@ def ocr(
         `ISO-639-3 <http://www.loc.gov/standards/iso639-2/php/code_list.php>`__
         language code of the language you are attempting to read; for example
         "eng" for English or "deu" for German. More than one language can be
-        specified by joining with '+'; for example "eng+deu" means that the
-        text to be read may be in a mixture of English and German. This defaults
-        to "eng" (English). You can override the global default value by setting
-        ``lang`` in the ``[ocr]`` section of :ref:`.stbt.conf`. You may need to
-        install the tesseract language pack; see installation instructions
+        specified by joining with '+': for example "eng+deu" means that the
+        text to be read may be in a mixture of English and German.
+
+        This defaults to "eng" (English). You can change the global default
+        value by setting ``lang`` in the ``[ocr]`` section of
+        :ref:`.stbt.conf` or the appropriate
+        :ref:`Node-specific configuration file <node-specific-config>`.
+
+        You may need to install the tesseract language pack; see installation
+        instructions
         `here <https://stb-tester.com/manual/faq#installing-language-packs>`__.
 
     :param dict tesseract_config:

--- a/stbt_virtual_stb.py
+++ b/stbt_virtual_stb.py
@@ -60,10 +60,10 @@ def virtual_stb(command, x_keymap=None, verbose=False):
 
         try:
             config.update({
-                "control": "x11:${x_display},%{x_keymap}",
+                "control": "x11:%(x_display)s,%(x_keymap)s",
                 "source_pipeline": (
                     'ximagesrc use-damage=false remote=true show-pointer=false '
-                    'display-name=${x_display} ! video/x-raw,framerate=24/1'),
+                    'display-name=%(x_display)s ! video/x-raw,framerate=24/1'),
                 "x_display": display,
                 "vstb_child_pid": str(child.pid),
                 "vstb_pid": str(os.getpid()),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -156,7 +156,7 @@ def temporary_config(contents, prefix="stbt-test-config"):
             f.write(dedent(contents))
         _config_init(force=True)
         try:
-            yield filename
+            yield
         finally:
             os.environ["STBT_CONFIG_FILE"] = original_env
             _config_init(force=True)
@@ -193,30 +193,3 @@ def test_get_config_with_default_value():
         assert get_config("nosuchsection", "test", None) is None
         with pytest.raises(ConfigurationError):
             get_config("nosuchsection", "test")
-
-
-CONFIG_WITH_INTERPOLATION = dedent("""\
-    [ocr]
-    lang = ${device_type:lang}
-    basic = %(lang)s
-
-    [device_type]
-    lang = deu
-
-    """)
-
-
-def test_get_config_interpolation():
-    # Stb-tester uses extended interpolation:
-    # https://docs.python.org/3.10/library/configparser.html#configparser.ExtendedInterpolation
-    with temporary_config(CONFIG_WITH_INTERPOLATION):
-        assert get_config("ocr", "lang") == "deu"
-        # Basic interpolation syntax is treated literally:
-        assert get_config("ocr", "basic") == "%(lang)s"
-
-
-def test_that_set_config_preserves_interpolation():
-    with temporary_config(CONFIG_WITH_INTERPOLATION) as filename:
-        set_config("device_type", "lang", "eng")
-        assert open(filename, encoding="utf-8").read() == \
-            CONFIG_WITH_INTERPOLATION.replace("deu", "eng")

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -112,14 +112,7 @@ def test_that_match_text_accepts_unicode():
 def test_that_default_language_is_configurable():
     f = load_image("ocr/unicode.png")
     assert not stbt.match_text("Röthlisberger", f)  # reads Réthlisberger
-    assert "Röthlisberger" not in stbt.ocr(f)
     with temporary_config({"ocr.lang": "deu"}):
-        assert stbt.match_text("Röthlisberger", f)
-        assert "Röthlisberger" in stbt.ocr(f)
-    with temporary_config({"ocr.lang": "deu", "device_type.lang": "eng"}):
-        assert not stbt.match_text("Röthlisberger", f)
-        assert "Röthlisberger" not in stbt.ocr(f)
-    with temporary_config({"ocr.lang": "eng", "device_type.lang": "deu"}):
         assert stbt.match_text("Röthlisberger", f)
         assert "Röthlisberger" in stbt.ocr(f)
 


### PR DESCRIPTION
Revert a couple of changes from #851:

- You can just specify an `[ocr]` section in your node-specific config file, no need for a new config.
- We decided that changing the configparser interpolation is too risky.