### PR TITLE
Color: typing: Add overload for passing a single `Color` argument

### DIFF
--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -231,6 +231,9 @@ class Color:
     @overload
     def __init__(self, bgra: tuple[int, int, int, int]) -> None:
         ...
+    @overload
+    def __init__(self, color: Color, /) -> None:
+        ...
     def __init__(self, *args,
                  hexstring: str|None = None,
                  blue: int|None = None,


### PR DESCRIPTION
...always supported, just wasn't in the type annotations.