### PR TITLE
Enable pyright "standard" mode

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -80,4 +80,4 @@ dummy-variables-rgx=_
 
 [FORMAT]
 max-line-length=80
-ignore-long-lines=https?://
+ignore-long-lines=https?://|# pyright:

--- a/_stbt/config.py
+++ b/_stbt/config.py
@@ -89,7 +89,7 @@ def get_config(
         if type_ is bool:
             return config.getboolean(section, key)  # type:ignore
         elif issubclass(type_, enum.Enum):  # type:ignore
-            return _to_enum(type_, config.get(section, key), section, key)
+            return _to_enum(type_, config.get(section, key), section, key)  # pyright:ignore[reportReturnType]
         else:
             return type_(config.get(section, key))  # type:ignore
     except configparser.Error as e:

--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -560,6 +560,7 @@ class RedRatHttpControl(RemoteControl):
                 error_msg = response.json()["error"]
             except Exception:  # pylint:disable=broad-except
                 response.raise_for_status()
+            assert error_msg  # pyright:ignore[reportPossiblyUnboundVariable]
             if re.match("Command '.*' is not known.", error_msg):
                 raise UnknownKeyError(error_msg)
             else:

--- a/_stbt/imgutils.py
+++ b/_stbt/imgutils.py
@@ -329,7 +329,7 @@ class Color:
     def __repr__(self) -> str:
         return f"Color('{self.hexstring}')"
 
-    def __eq__(self, other: Color) -> bool:
+    def __eq__(self, other: object) -> bool:
         return isinstance(other, Color) and self.hexstring == other.hexstring
 
     def __hash__(self) -> int:

--- a/_stbt/logging.py
+++ b/_stbt/logging.py
@@ -129,8 +129,8 @@ class ImageLogger():
         self.name = name
         self.frame_number = next(ImageLogger._frame_number)
 
+        outdir = os.path.join("stbt-debug", "%05d" % self.frame_number)
         try:
-            outdir = os.path.join("stbt-debug", "%05d" % self.frame_number)
             mkdir_p(outdir)
             self.outdir = outdir
         except OSError:

--- a/_stbt/match.py
+++ b/_stbt/match.py
@@ -488,6 +488,7 @@ def wait_for_match(
     last_pos = Position(0, 0)
     image = load_image(image)
     debug("Searching for " + (image.relative_filename or "<Image>"))
+    res = None
     for frame in frames:
         res = match(image, match_parameters=match_parameters,
                     region=region, frame=frame)
@@ -499,6 +500,9 @@ def wait_for_match(
         if match_count == consecutive_matches:
             debug("Matched " + (image.relative_filename or "<Image>"))
             return res
+
+    if res is None:
+        raise RuntimeError("No frames were processed")
 
     raise MatchTimeout(res.frame, image.relative_filename, timeout_secs)
 
@@ -611,6 +615,9 @@ def _find_candidate_matches(image, template, match_parameters, imglog):
     image_pyramid = _build_pyramid(image, len(template_pyramid))
     roi_mask = None  # Initial region of interest: The whole image.
 
+    (best_match_position, certainty, heatmap, heatmap_scale, level, matched,
+     threshold) = (None, None, None, None, None, None, None)
+
     for level in reversed(range(len(image_pyramid))):
         if roi_mask is not None:
             if any(x < 3 for x in roi_mask.shape):
@@ -652,7 +659,6 @@ def _find_candidate_matches(image, template, match_parameters, imglog):
             roi_mask = roi_mask.astype(numpy.uint8)
             imwrite("source_matchtemplate_threshold", roi_mask)
 
-    # pylint:disable=undefined-loop-variable
     region = Region(*_upsample(best_match_position, level),
                     width=template.shape[1], height=template.shape[0])
 

--- a/_stbt/wait.py
+++ b/_stbt/wait.py
@@ -125,6 +125,7 @@ def wait_until(callable_: Callable[[], T],
     stable_predicate_value = None
     start_time = time.time()
     expiry_time = start_time + timeout_secs
+    stable_since = float("inf")
 
     while True:
         t = time.time()

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,6 +1,6 @@
 {
   "pythonversion": "3.10",
-  "typeCheckingMode": "basic",
+  "typeCheckingMode": "standard",
   "exclude": [
     "**/__pycache__",
     "**/.*",

--- a/stbt_match.py
+++ b/stbt_match.py
@@ -61,7 +61,7 @@ def main():
             else:
                 raise Exception("Unknown match_parameter argument '%s'" % p)
     except Exception:  # pylint:disable=broad-except
-        error("Invalid argument '%s'" % p)
+        error("Invalid argument '%s'" % p)  # pyright:ignore[reportPossiblyUnboundVariable]
 
     source_image = cv2.imread(args.source_file)
     if source_image is None:


### PR DESCRIPTION
And fix the new warnings it reports:

* _stbt.config:

  > Type "Enum | IntEnum" is not assignable to return type "T@get_config | DefaultT@get_config"

  It seems to me that it *should* match the type. :shrug: 

* _stbt.control:

  > "error_msg" is possibly unbound

  Pyright doesn't know that `response.raise_for_status()` will have definitely raised.

* _stbt.imgutils:

  > Method "\_\_eq__" overrides class "object" in an incompatible manner
  > Parameter 2 type mismatch: base parameter is type "object", override parameter is type "Color"

* The rest are "possibly unbound" warnings, mostly because pyright doesn't know that the loop was guaranteed to run at least once.