### PR TITLE
Lewis/use tmp path in unittests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ stb-tester-*.tar.gz
 stb-tester_*.deb
 stbt-control-relay
 stbt-controlc
-stbt-debug
 stbt_core.egg-info/
 TAGS
 tests/stbt-debug-expected-output/*/*/*.png

--- a/Makefile
+++ b/Makefile
@@ -211,12 +211,10 @@ PYTHON_FILES := \
 check: check-pylint check-pyright check-pytest check-integrationtests
 check-pytest: all
 	PYTHONPATH=$$PWD:/usr/lib/python$(python_version)/dist-packages/cec \
-	STBT_CONFIG_FILE=$$PWD/tests/stbt.conf \
 	$(PYTEST) -vv -rs --doctest-modules $(PYTEST_OPTS) \
 	    $$(printf "%s\n" $(PYTHON_FILES) |\
 	       grep -v -e __init__.py -e tests/vstb-example-html5/ -e ^extra/)
 check-pythonpackage:
-	export STBT_CONFIG_FILE=$$PWD/tests/stbt.conf && \
 	$(PYTEST) -vv -rs $(PYTEST_OPTS) \
 	    tests/subdirectory/test_load_image_from_subdirectory.py \
 	    tests/test_android.py \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 # pytest configuration
 
 import os
+from pathlib import Path
+from typing import Generator
 
 import pytest
 
@@ -18,3 +20,14 @@ def test_pack_root():
         yield
     finally:
         stbt_core.TEST_PACK_ROOT = None
+
+
+@pytest.fixture(name="cwd_is_tmp_path")
+def _cwd_is_tmp_path(tmp_path: Path) -> Generator[None, None, None]:
+    """Change the CWD to a temporary directory for the duration of a test."""
+    orig_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        yield
+    finally:
+        os.chdir(orig_cwd)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from typing import Generator
 
 import pytest
 
+import _stbt.config
 import _stbt.logging
 
 
@@ -31,3 +32,14 @@ def _cwd_is_tmp_path(tmp_path: Path) -> Generator[None, None, None]:
         yield
     finally:
         os.chdir(orig_cwd)
+
+
+@pytest.fixture(autouse=True)
+def set_STBT_CONFIG_FILE_for_tests(monkeypatch):
+    """Set the STBT_CONFIG_FILE environment variable to a test config file.
+
+    This applies to all test functions in the session.
+    """
+    test_config_file = Path(__file__).parent / "stbt.conf"
+    monkeypatch.setenv("STBT_CONFIG_FILE", str(test_config_file))
+    _stbt.config._config_init(force=True)

--- a/tests/stbt.conf
+++ b/tests/stbt.conf
@@ -38,7 +38,7 @@ noise_threshold=25
 consecutive_frames=10/20
 
 [is_screen_black]
-threshold = 10
+threshold = 20
 
 [run]
 save_video =

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,32 +1,32 @@
 import enum
 import os
-from contextlib import contextmanager
 from textwrap import dedent
 
 import pytest
 
 from _stbt.config import (_config_init, _sponge, ConfigurationError,
                           get_config, set_config)
-from _stbt.utils import named_temporary_directory, scoped_curdir, to_unicode
+from _stbt.utils import to_unicode
 
 
-def test_sponge_that_new_data_end_up_in_file():
-    with scoped_curdir():
-        with _sponge('hello') as f:
+def test_sponge_that_new_data_end_up_in_file(tmp_path):
+    path = tmp_path / "hello"
+    with _sponge(str(path)) as f:
+        f.write('hello')
+    assert path.read_text() == 'hello'
+
+
+def test_sponge_that_on_exception_file_isnt_modified(tmp_path):
+    path = tmp_path / "foo"
+    path.write_text("bar", encoding='utf-8')
+
+    try:
+        with _sponge(str(path)) as f:
             f.write('hello')
-        assert open('hello', encoding='utf-8').read() == 'hello'
-
-
-def test_sponge_that_on_exception_file_isnt_modified():
-    with scoped_curdir():
-        open('foo', 'w', encoding='utf-8').write('bar')
-        try:
-            with _sponge('foo') as f:
-                f.write('hello')
-                raise RuntimeError()
-        except RuntimeError:
-            pass
-        assert open('foo', encoding='utf-8').read() == 'bar'
+            raise RuntimeError()
+    except RuntimeError:
+        pass
+    assert path.read_text() == 'bar'
 
 test_config = dedent("""\
     [global]
@@ -35,33 +35,33 @@ test_config = dedent("""\
     another_test = goodbye""")
 
 
-@contextmanager
-def set_config_test():
-    with scoped_curdir() as d:
-        test_cfg = d + '/test.cfg'
-        os.environ['STBT_CONFIG_FILE'] = test_cfg
-        with open(test_cfg, 'w', encoding='utf-8') as f:
-            f.write(test_config)
-        yield
+@pytest.fixture(name="stbt_config_file")
+def _stbt_config_file(monkeypatch, tmp_path):
+    test_cfg = tmp_path / "test.cfg"
+    monkeypatch.setenv("STBT_CONFIG_FILE", str(test_cfg))
+    test_cfg.write_text(test_config, encoding="utf-8")
+    yield test_cfg
 
 
+@pytest.mark.usefixtures("stbt_config_file")
 def test_that_set_config_modifies_config_value():
-    with set_config_test():
-        set_config('global', 'test', 'goodbye')
-        assert get_config('global', 'test') == 'goodbye'
-        _config_init(force=True)
-        assert get_config('global', 'test') == 'goodbye'
+    set_config('global', 'test', 'goodbye')
+    assert get_config('global', 'test') == 'goodbye'
+    _config_init(force=True)
+    assert get_config('global', 'test') == 'goodbye'
 
 
+@pytest.mark.usefixtures("stbt_config_file")
 def test_that_set_config_creates_new_sections_if_required():
-    with set_config_test():
-        set_config('non_existent_section', 'test', 'goodbye')
-        assert get_config('non_existent_section', 'test') == 'goodbye'
-        _config_init(force=True)
-        assert get_config('non_existent_section', 'test') == 'goodbye'
+    set_config('non_existent_section', 'test', 'goodbye')
+    assert get_config('non_existent_section', 'test') == 'goodbye'
+    _config_init(force=True)
+    assert get_config('non_existent_section', 'test') == 'goodbye'
 
 
-def test_that_set_config_preserves_file_comments_and_formatting():
+def test_that_set_config_preserves_file_comments_and_formatting(
+    stbt_config_file,
+):
     # pylint:disable=fixme,unreachable
     # FIXME: Preserve comments and formatting.  This is fairly tricky as
     # comments and whitespace are not currently stored in Python's internal
@@ -69,33 +69,37 @@ def test_that_set_config_preserves_file_comments_and_formatting():
     # tricky.
     from unittest import SkipTest
     raise SkipTest("set_config doesn't currently preserve formatting")
-    with set_config_test():
-        set_config('global', 'test', 'goodbye')
-        assert open('test.cfg', 'r', encoding='utf-8').read() == \
-            test_config.replace('hello', 'goodbye')
+    set_config('global', 'test', 'goodbye')
+    expected = test_config.replace("hello", "goodbye")
+    assert stbt_config_file.read_text() == expected
 
 
-def test_that_set_config_creates_directories_if_required():
-    with scoped_curdir() as d:
-        os.environ['XDG_CONFIG_HOME'] = d + '/.config'
-        if 'STBT_CONFIG_FILE' in os.environ:
-            del os.environ['STBT_CONFIG_FILE']
-        set_config('global', 'test', 'hello2')
-        assert os.path.isfile(d + '/.config/stbt/stbt.conf')
-        _config_init(force=True)
-        assert get_config('global', 'test') == 'hello2'
+def test_that_set_config_creates_directories_if_required(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / '.config'))
+    monkeypatch.delenv("STBT_CONFIG_FILE", raising=False)
+
+    set_config('global', 'test', 'hello2')
+    assert (tmp_path / '.config/stbt/stbt.conf').is_file()
+    _config_init(force=True)
+    assert get_config('global', 'test') == 'hello2'
 
 
-def test_that_set_config_writes_to_the_first_stbt_config_file():
-    with scoped_curdir() as d:
-        filled_cfg = d + '/test.cfg'
-        empty_cfg = d + '/empty.cfg'
-        os.environ['STBT_CONFIG_FILE'] = '%s:%s' % (filled_cfg, empty_cfg)
-        open(filled_cfg, 'w', encoding='utf-8')
-        open(empty_cfg, 'w', encoding='utf-8')
-        set_config('global', 'test', 'goodbye')
-        assert open(filled_cfg, encoding='utf-8').read().startswith('[global]')
-        assert open(empty_cfg, encoding='utf-8').read() == ''
+def test_that_set_config_writes_to_the_first_stbt_config_file(
+    monkeypatch,
+    tmp_path,
+):
+    filled_cfg = tmp_path / 'test.cfg'
+    empty_cfg = tmp_path / 'empty.cfg'
+    monkeypatch.setenv("STBT_CONFIG_FILE", f"{filled_cfg}:{empty_cfg}")
+    filled_cfg.touch()
+    empty_cfg.touch()
+
+    set_config('global', 'test', 'goodbye')
+    assert filled_cfg.read_text().startswith('[global]')
+    assert empty_cfg.read_text() == ''
 
 
 class MyEnum(enum.Enum):
@@ -108,88 +112,100 @@ class MyIntEnum(enum.IntEnum):
     NAME_6 = 6
 
 
-def test_to_enum():
-    with temporary_config("""\
-            [global]
-            bystrlc = name_1
-            bystruc = NAME_1
-            byvallc = value-1
-            byvaluc = VALUE-1
-            badstr = notakey
-            byint = 5
-            byintname = NAME_5
-            badint = 7
-            """):
+def test_to_enum(config_factory):
+    config_factory("""\
+        [global]
+        bystrlc = name_1
+        bystruc = NAME_1
+        byvallc = value-1
+        byvaluc = VALUE-1
+        badstr = notakey
+        byint = 5
+        byintname = NAME_5
+        badint = 7
+        """
+    )
 
-        assert get_config("global", "bystrlc", type_=MyEnum) == MyEnum.NAME_1
-        assert get_config("global", "bystruc", type_=MyEnum) == MyEnum.NAME_1
-        assert get_config("global", "byvallc", type_=MyEnum) == MyEnum.NAME_1
+    assert get_config("global", "bystrlc", type_=MyEnum) == MyEnum.NAME_1
+    assert get_config("global", "bystruc", type_=MyEnum) == MyEnum.NAME_1
+    assert get_config("global", "byvallc", type_=MyEnum) == MyEnum.NAME_1
 
-        with pytest.raises(ConfigurationError) as excinfo:
-            get_config("global", "byvaluc", type_=MyEnum)
-        assert "Valid values are NAME_1, NAME_2" in str(excinfo.value)
+    with pytest.raises(ConfigurationError) as excinfo:
+        get_config("global", "byvaluc", type_=MyEnum)
+    assert "Valid values are NAME_1, NAME_2" in str(excinfo.value)
 
-        with pytest.raises(ConfigurationError):
-            get_config("global", "badstr", type_=MyEnum)
+    with pytest.raises(ConfigurationError):
+        get_config("global", "badstr", type_=MyEnum)
 
-        assert get_config("global", "notset", MyEnum.NAME_1, MyEnum) == \
-            MyEnum.NAME_1
+    assert get_config("global", "notset", MyEnum.NAME_1, MyEnum) == \
+        MyEnum.NAME_1
 
-        assert get_config("global", "byint", type_=MyIntEnum) == \
-            MyIntEnum.NAME_5
-        assert get_config("global", "byintname", type_=MyIntEnum) == \
-            MyIntEnum.NAME_5
+    assert get_config("global", "byint", type_=MyIntEnum) == \
+        MyIntEnum.NAME_5
+    assert get_config("global", "byintname", type_=MyIntEnum) == \
+        MyIntEnum.NAME_5
 
-        with pytest.raises(ConfigurationError) as excinfo:
-            get_config("global", "badint", type_=MyIntEnum)
-        assert "Valid values are NAME_5, NAME_6" in str(excinfo.value)
+    with pytest.raises(ConfigurationError) as excinfo:
+        get_config("global", "badint", type_=MyIntEnum)
+    assert "Valid values are NAME_5, NAME_6" in str(excinfo.value)
 
 
-@contextmanager
-def temporary_config(contents, prefix="stbt-test-config"):
-    with named_temporary_directory(prefix=prefix) as d:
+@pytest.fixture(name="config_factory")
+def _config_factory(monkeypatch, tmp_path):
+    """Return a factory for temporary configs.
+
+    The callable has the following signature:
+    * contents: str - the contents of the config file
+    * filename: str = "stbt-test.cfg" - the name of the config file to
+      create
+    """
+    def factory(contents, filename="stbt-test.cfg"):
+        filename = tmp_path / filename
         original_env = os.environ.get("STBT_CONFIG_FILE", "")
-        filename = os.path.join(d, "stbt.conf")
-        os.environ["STBT_CONFIG_FILE"] = to_unicode(":".join([filename,
-                                                              original_env]))
-        with open(filename, "w", encoding="utf-8") as f:
-            f.write(dedent(contents))
+        monkeypatch.setenv(
+            "STBT_CONFIG_FILE",
+            to_unicode(":".join([str(filename), original_env])),
+        )
+        filename.write_text(dedent(contents), encoding="utf-8")
         _config_init(force=True)
-        try:
-            yield
-        finally:
-            os.environ["STBT_CONFIG_FILE"] = original_env
-            _config_init(force=True)
+
+    try:
+        yield factory
+    finally:
+        _config_init(force=True)
 
 
-def test_unicode_in_STBT_CONFIG_FILE():
-    with temporary_config(test_config, prefix="\xf8"):
-        assert get_config("global", "test") == "hello"
+def test_unicode_in_STBT_CONFIG_FILE(config_factory):
+    config_factory(test_config, filename="\xf8.cfg")
+    assert get_config("global", "test") == "hello"
 
 
-def test_unicode_in_config_file_contents():
-    with temporary_config("""\
-            [global]
-            unicodeinkey\xf8 = hi
-            unicodeinvalue = \xf8
+def test_unicode_in_config_file_contents(config_factory):
+    config_factory("""\
+        [global]
+        unicodeinkey\xf8 = hi
+        unicodeinvalue = \xf8
 
-            [unicodeinsection\xf8]
-            key = bye
-            """):
+        [unicodeinsection\xf8]
+        key = bye
+        """
+    )
 
-        assert get_config("global", "unicodeinkey\xf8") == "hi"
-        assert get_config("global", "unicodeinvalue") == "\xf8"
-        assert get_config("unicodeinsection\xf8", "key") == "bye"
-        assert isinstance(get_config("global", "unicodeinvalue"), str)
+    assert get_config("global", "unicodeinkey\xf8") == "hi"
+    assert get_config("global", "unicodeinvalue") == "\xf8"
+    assert get_config("unicodeinsection\xf8", "key") == "bye"
+    assert isinstance(get_config("global", "unicodeinvalue"), str)
 
 
-def test_get_config_with_default_value():
-    with temporary_config("""\
-            [global]
-            test=hello"""):
-        assert get_config("global", "test", "my default") == "hello"
-        assert get_config("global", "nosuchkey", "my default") == "my default"
-        assert get_config("nosuchsection", "test", "my default") == "my default"
-        assert get_config("nosuchsection", "test", None) is None
-        with pytest.raises(ConfigurationError):
-            get_config("nosuchsection", "test")
+def test_get_config_with_default_value(config_factory):
+    config_factory("""\
+        [global]
+        test=hello"""
+    )
+
+    assert get_config("global", "test", "my default") == "hello"
+    assert get_config("global", "nosuchkey", "my default") == "my default"
+    assert get_config("nosuchsection", "test", "my default") == "my default"
+    assert get_config("nosuchsection", "test", None) is None
+    with pytest.raises(ConfigurationError):
+        get_config("nosuchsection", "test")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -66,12 +66,13 @@ def test_that_load_image_looks_in_callers_directory(test_pack_root):  # pylint:d
         stbt.load_image("info2.png")
 
 
-def test_load_image_with_unicode_filename():
+def test_load_image_with_unicode_filename(tmp_path):
     print(sys.getfilesystemencoding())
-    shutil.copyfile(_find_file("Rothlisberger.png"),
-                    _find_file("Röthlisberger.png"))
-    assert stbt.load_image("Röthlisberger.png") is not None
-    assert stbt.load_image("R\xf6thlisberger.png") is not None
+    original = _find_file("Rothlisberger.png")
+    new = tmp_path / "Röthlisberger.png"
+    shutil.copyfile(original, new)
+    assert stbt.load_image(str(tmp_path / "Röthlisberger.png")) is not None
+    assert stbt.load_image(str(tmp_path / "R\xf6thlisberger.png")) is not None
 
 
 def test_load_image_with_numpy_array():

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -223,6 +223,7 @@ def test_transparent_reference_image_false_negative_caused_by_pyramid(
     (stbt.MatchMethod.CCORR_NORMED, 0.8),
     (stbt.MatchMethod.CCOEFF_NORMED, 0.8),
 ])
+@pytest.mark.usefixtures("cwd_is_tmp_path")
 def test_pyramid_roi_too_small(frame, image, match_method, match_threshold):
     # This is a regression test for an error that was seen with a particular
     # frame from a single test-run, with SQDIFF_NORMED:

--- a/tests/test_stbt_debug.py
+++ b/tests/test_stbt_debug.py
@@ -1,20 +1,21 @@
 import itertools
 import os
 import subprocess
-from textwrap import dedent
+
+import pytest
 
 import stbt_core as stbt
 from _stbt.logging import ImageLogger, scoped_debug_level
-from _stbt.utils import scoped_curdir
 from stbt_core import MatchParameters as mp
 
 
-def test_match_debug():
+@pytest.mark.usefixtures("cwd_is_tmp_path")
+def test_match_debug(tmp_path):
     # So that the output directory name doesn't depend on how many tests
     # were run before this one.
     ImageLogger._frame_number = itertools.count(1)
 
-    with scoped_curdir(), scoped_debug_level(2):
+    with scoped_debug_level(2):
         # First pass gives no matches:
         matches = list(stbt.match_all(
             "videotestsrc-redblue-flipped.png",
@@ -43,281 +44,285 @@ def test_match_debug():
         print(matches)
         assert len(matches) == 6
 
-        files = subprocess.check_output("find stbt-debug | sort", shell=True) \
-                          .decode("utf-8")
-        assert files == dedent("""\
-            stbt-debug
-            stbt-debug/00001
-            stbt-debug/00001/index.html
-            stbt-debug/00001/level2-source_matchtemplate.png
-            stbt-debug/00001/level2-source.png
-            stbt-debug/00001/level2-source_with_match.png
-            stbt-debug/00001/level2-source_with_rois.png
-            stbt-debug/00001/level2-template.png
-            stbt-debug/00001/match0-heatmap.png
-            stbt-debug/00001/match0-source_with_match.png
-            stbt-debug/00001/source.png
-            stbt-debug/00001/template.png
-            stbt-debug/00002
-            stbt-debug/00002/index.html
-            stbt-debug/00002/level0-source_matchtemplate.png
-            stbt-debug/00002/level0-source_matchtemplate_threshold.png
-            stbt-debug/00002/level0-source.png
-            stbt-debug/00002/level0-source_with_match.png
-            stbt-debug/00002/level0-source_with_rois.png
-            stbt-debug/00002/level0-template.png
-            stbt-debug/00002/level1-source_matchtemplate.png
-            stbt-debug/00002/level1-source_matchtemplate_threshold.png
-            stbt-debug/00002/level1-source.png
-            stbt-debug/00002/level1-source_with_match.png
-            stbt-debug/00002/level1-source_with_rois.png
-            stbt-debug/00002/level1-template.png
-            stbt-debug/00002/level2-source_matchtemplate.png
-            stbt-debug/00002/level2-source_matchtemplate_threshold.png
-            stbt-debug/00002/level2-source.png
-            stbt-debug/00002/level2-source_with_match.png
-            stbt-debug/00002/level2-source_with_rois.png
-            stbt-debug/00002/level2-template.png
-            stbt-debug/00002/match0-confirm-absdiff.png
-            stbt-debug/00002/match0-confirm-absdiff_threshold_erode.png
-            stbt-debug/00002/match0-confirm-absdiff_threshold.png
-            stbt-debug/00002/match0-confirm-source_roi_gray_normalized.png
-            stbt-debug/00002/match0-confirm-source_roi_gray.png
-            stbt-debug/00002/match0-confirm-source_roi.png
-            stbt-debug/00002/match0-confirm-template_gray_normalized.png
-            stbt-debug/00002/match0-confirm-template_gray.png
-            stbt-debug/00002/match0-heatmap.png
-            stbt-debug/00002/match0-source_with_match.png
-            stbt-debug/00002/match1-confirm-absdiff.png
-            stbt-debug/00002/match1-confirm-absdiff_threshold_erode.png
-            stbt-debug/00002/match1-confirm-absdiff_threshold.png
-            stbt-debug/00002/match1-confirm-source_roi_gray_normalized.png
-            stbt-debug/00002/match1-confirm-source_roi_gray.png
-            stbt-debug/00002/match1-confirm-source_roi.png
-            stbt-debug/00002/match1-confirm-template_gray_normalized.png
-            stbt-debug/00002/match1-confirm-template_gray.png
-            stbt-debug/00002/match1-heatmap.png
-            stbt-debug/00002/match1-source_with_match.png
-            stbt-debug/00002/match2-confirm-absdiff.png
-            stbt-debug/00002/match2-confirm-absdiff_threshold_erode.png
-            stbt-debug/00002/match2-confirm-absdiff_threshold.png
-            stbt-debug/00002/match2-confirm-source_roi_gray_normalized.png
-            stbt-debug/00002/match2-confirm-source_roi_gray.png
-            stbt-debug/00002/match2-confirm-source_roi.png
-            stbt-debug/00002/match2-confirm-template_gray_normalized.png
-            stbt-debug/00002/match2-confirm-template_gray.png
-            stbt-debug/00002/match2-heatmap.png
-            stbt-debug/00002/match2-source_with_match.png
-            stbt-debug/00002/match3-confirm-absdiff.png
-            stbt-debug/00002/match3-confirm-absdiff_threshold_erode.png
-            stbt-debug/00002/match3-confirm-absdiff_threshold.png
-            stbt-debug/00002/match3-confirm-source_roi_gray_normalized.png
-            stbt-debug/00002/match3-confirm-source_roi_gray.png
-            stbt-debug/00002/match3-confirm-source_roi.png
-            stbt-debug/00002/match3-confirm-template_gray_normalized.png
-            stbt-debug/00002/match3-confirm-template_gray.png
-            stbt-debug/00002/match3-heatmap.png
-            stbt-debug/00002/match3-source_with_match.png
-            stbt-debug/00002/match4-confirm-absdiff.png
-            stbt-debug/00002/match4-confirm-absdiff_threshold_erode.png
-            stbt-debug/00002/match4-confirm-absdiff_threshold.png
-            stbt-debug/00002/match4-confirm-source_roi_gray_normalized.png
-            stbt-debug/00002/match4-confirm-source_roi_gray.png
-            stbt-debug/00002/match4-confirm-source_roi.png
-            stbt-debug/00002/match4-confirm-template_gray_normalized.png
-            stbt-debug/00002/match4-confirm-template_gray.png
-            stbt-debug/00002/match4-heatmap.png
-            stbt-debug/00002/match4-source_with_match.png
-            stbt-debug/00002/match5-confirm-absdiff.png
-            stbt-debug/00002/match5-confirm-absdiff_threshold_erode.png
-            stbt-debug/00002/match5-confirm-absdiff_threshold.png
-            stbt-debug/00002/match5-confirm-source_roi_gray_normalized.png
-            stbt-debug/00002/match5-confirm-source_roi_gray.png
-            stbt-debug/00002/match5-confirm-source_roi.png
-            stbt-debug/00002/match5-confirm-template_gray_normalized.png
-            stbt-debug/00002/match5-confirm-template_gray.png
-            stbt-debug/00002/match5-heatmap.png
-            stbt-debug/00002/match5-source_with_match.png
-            stbt-debug/00002/match6-heatmap.png
-            stbt-debug/00002/match6-source_with_match.png
-            stbt-debug/00002/source.png
-            stbt-debug/00002/template.png
-            stbt-debug/00003
-            stbt-debug/00003/index.html
-            stbt-debug/00003/level0-source_matchtemplate.png
-            stbt-debug/00003/level0-source_matchtemplate_threshold.png
-            stbt-debug/00003/level0-source.png
-            stbt-debug/00003/level0-source_with_match.png
-            stbt-debug/00003/level0-source_with_rois.png
-            stbt-debug/00003/level0-template.png
-            stbt-debug/00003/level1-source_matchtemplate.png
-            stbt-debug/00003/level1-source_matchtemplate_threshold.png
-            stbt-debug/00003/level1-source.png
-            stbt-debug/00003/level1-source_with_match.png
-            stbt-debug/00003/level1-source_with_rois.png
-            stbt-debug/00003/level1-template.png
-            stbt-debug/00003/level2-source_matchtemplate.png
-            stbt-debug/00003/level2-source_matchtemplate_threshold.png
-            stbt-debug/00003/level2-source.png
-            stbt-debug/00003/level2-source_with_match.png
-            stbt-debug/00003/level2-source_with_rois.png
-            stbt-debug/00003/level2-template.png
-            stbt-debug/00003/match0-confirm-absdiff.png
-            stbt-debug/00003/match0-confirm-absdiff_threshold_erode.png
-            stbt-debug/00003/match0-confirm-absdiff_threshold.png
-            stbt-debug/00003/match0-confirm-source_roi_gray_normalized.png
-            stbt-debug/00003/match0-confirm-source_roi_gray.png
-            stbt-debug/00003/match0-confirm-source_roi.png
-            stbt-debug/00003/match0-confirm-template_gray_normalized.png
-            stbt-debug/00003/match0-confirm-template_gray.png
-            stbt-debug/00003/match0-heatmap.png
-            stbt-debug/00003/match0-source_with_match.png
-            stbt-debug/00003/match1-confirm-absdiff.png
-            stbt-debug/00003/match1-confirm-absdiff_threshold_erode.png
-            stbt-debug/00003/match1-confirm-absdiff_threshold.png
-            stbt-debug/00003/match1-confirm-source_roi_gray_normalized.png
-            stbt-debug/00003/match1-confirm-source_roi_gray.png
-            stbt-debug/00003/match1-confirm-source_roi.png
-            stbt-debug/00003/match1-confirm-template_gray_normalized.png
-            stbt-debug/00003/match1-confirm-template_gray.png
-            stbt-debug/00003/match1-heatmap.png
-            stbt-debug/00003/match1-source_with_match.png
-            stbt-debug/00003/match2-confirm-absdiff.png
-            stbt-debug/00003/match2-confirm-absdiff_threshold_erode.png
-            stbt-debug/00003/match2-confirm-absdiff_threshold.png
-            stbt-debug/00003/match2-confirm-source_roi_gray_normalized.png
-            stbt-debug/00003/match2-confirm-source_roi_gray.png
-            stbt-debug/00003/match2-confirm-source_roi.png
-            stbt-debug/00003/match2-confirm-template_gray_normalized.png
-            stbt-debug/00003/match2-confirm-template_gray.png
-            stbt-debug/00003/match2-heatmap.png
-            stbt-debug/00003/match2-source_with_match.png
-            stbt-debug/00003/match3-confirm-absdiff.png
-            stbt-debug/00003/match3-confirm-absdiff_threshold_erode.png
-            stbt-debug/00003/match3-confirm-absdiff_threshold.png
-            stbt-debug/00003/match3-confirm-source_roi_gray_normalized.png
-            stbt-debug/00003/match3-confirm-source_roi_gray.png
-            stbt-debug/00003/match3-confirm-source_roi.png
-            stbt-debug/00003/match3-confirm-template_gray_normalized.png
-            stbt-debug/00003/match3-confirm-template_gray.png
-            stbt-debug/00003/match3-heatmap.png
-            stbt-debug/00003/match3-source_with_match.png
-            stbt-debug/00003/match4-confirm-absdiff.png
-            stbt-debug/00003/match4-confirm-absdiff_threshold_erode.png
-            stbt-debug/00003/match4-confirm-absdiff_threshold.png
-            stbt-debug/00003/match4-confirm-source_roi_gray_normalized.png
-            stbt-debug/00003/match4-confirm-source_roi_gray.png
-            stbt-debug/00003/match4-confirm-source_roi.png
-            stbt-debug/00003/match4-confirm-template_gray_normalized.png
-            stbt-debug/00003/match4-confirm-template_gray.png
-            stbt-debug/00003/match4-heatmap.png
-            stbt-debug/00003/match4-source_with_match.png
-            stbt-debug/00003/match5-confirm-absdiff.png
-            stbt-debug/00003/match5-confirm-absdiff_threshold_erode.png
-            stbt-debug/00003/match5-confirm-absdiff_threshold.png
-            stbt-debug/00003/match5-confirm-source_roi_gray_normalized.png
-            stbt-debug/00003/match5-confirm-source_roi_gray.png
-            stbt-debug/00003/match5-confirm-source_roi.png
-            stbt-debug/00003/match5-confirm-template_gray_normalized.png
-            stbt-debug/00003/match5-confirm-template_gray.png
-            stbt-debug/00003/match5-heatmap.png
-            stbt-debug/00003/match5-source_with_match.png
-            stbt-debug/00003/match6-confirm-absdiff.png
-            stbt-debug/00003/match6-confirm-absdiff_threshold_erode.png
-            stbt-debug/00003/match6-confirm-absdiff_threshold.png
-            stbt-debug/00003/match6-confirm-source_roi_gray_normalized.png
-            stbt-debug/00003/match6-confirm-source_roi_gray.png
-            stbt-debug/00003/match6-confirm-source_roi.png
-            stbt-debug/00003/match6-confirm-template_gray_normalized.png
-            stbt-debug/00003/match6-confirm-template_gray.png
-            stbt-debug/00003/match6-heatmap.png
-            stbt-debug/00003/match6-source_with_match.png
-            stbt-debug/00003/source.png
-            stbt-debug/00003/template.png
-            stbt-debug/00004
-            stbt-debug/00004/index.html
-            stbt-debug/00004/level0-source_matchtemplate.png
-            stbt-debug/00004/level0-source_matchtemplate_threshold.png
-            stbt-debug/00004/level0-source.png
-            stbt-debug/00004/level0-source_with_match.png
-            stbt-debug/00004/level0-source_with_rois.png
-            stbt-debug/00004/level0-template.png
-            stbt-debug/00004/level1-source_matchtemplate.png
-            stbt-debug/00004/level1-source_matchtemplate_threshold.png
-            stbt-debug/00004/level1-source.png
-            stbt-debug/00004/level1-source_with_match.png
-            stbt-debug/00004/level1-source_with_rois.png
-            stbt-debug/00004/level1-template.png
-            stbt-debug/00004/level2-source_matchtemplate.png
-            stbt-debug/00004/level2-source_matchtemplate_threshold.png
-            stbt-debug/00004/level2-source.png
-            stbt-debug/00004/level2-source_with_match.png
-            stbt-debug/00004/level2-source_with_rois.png
-            stbt-debug/00004/level2-template.png
-            stbt-debug/00004/match0-confirm-absdiff.png
-            stbt-debug/00004/match0-confirm-absdiff_threshold_erode.png
-            stbt-debug/00004/match0-confirm-absdiff_threshold.png
-            stbt-debug/00004/match0-confirm-source_roi_gray.png
-            stbt-debug/00004/match0-confirm-source_roi.png
-            stbt-debug/00004/match0-confirm-template_gray.png
-            stbt-debug/00004/match0-heatmap.png
-            stbt-debug/00004/match0-source_with_match.png
-            stbt-debug/00004/match1-confirm-absdiff.png
-            stbt-debug/00004/match1-confirm-absdiff_threshold_erode.png
-            stbt-debug/00004/match1-confirm-absdiff_threshold.png
-            stbt-debug/00004/match1-confirm-source_roi_gray.png
-            stbt-debug/00004/match1-confirm-source_roi.png
-            stbt-debug/00004/match1-confirm-template_gray.png
-            stbt-debug/00004/match1-heatmap.png
-            stbt-debug/00004/match1-source_with_match.png
-            stbt-debug/00004/match2-confirm-absdiff.png
-            stbt-debug/00004/match2-confirm-absdiff_threshold_erode.png
-            stbt-debug/00004/match2-confirm-absdiff_threshold.png
-            stbt-debug/00004/match2-confirm-source_roi_gray.png
-            stbt-debug/00004/match2-confirm-source_roi.png
-            stbt-debug/00004/match2-confirm-template_gray.png
-            stbt-debug/00004/match2-heatmap.png
-            stbt-debug/00004/match2-source_with_match.png
-            stbt-debug/00004/match3-confirm-absdiff.png
-            stbt-debug/00004/match3-confirm-absdiff_threshold_erode.png
-            stbt-debug/00004/match3-confirm-absdiff_threshold.png
-            stbt-debug/00004/match3-confirm-source_roi_gray.png
-            stbt-debug/00004/match3-confirm-source_roi.png
-            stbt-debug/00004/match3-confirm-template_gray.png
-            stbt-debug/00004/match3-heatmap.png
-            stbt-debug/00004/match3-source_with_match.png
-            stbt-debug/00004/match4-confirm-absdiff.png
-            stbt-debug/00004/match4-confirm-absdiff_threshold_erode.png
-            stbt-debug/00004/match4-confirm-absdiff_threshold.png
-            stbt-debug/00004/match4-confirm-source_roi_gray.png
-            stbt-debug/00004/match4-confirm-source_roi.png
-            stbt-debug/00004/match4-confirm-template_gray.png
-            stbt-debug/00004/match4-heatmap.png
-            stbt-debug/00004/match4-source_with_match.png
-            stbt-debug/00004/match5-confirm-absdiff.png
-            stbt-debug/00004/match5-confirm-absdiff_threshold_erode.png
-            stbt-debug/00004/match5-confirm-absdiff_threshold.png
-            stbt-debug/00004/match5-confirm-source_roi_gray.png
-            stbt-debug/00004/match5-confirm-source_roi.png
-            stbt-debug/00004/match5-confirm-template_gray.png
-            stbt-debug/00004/match5-heatmap.png
-            stbt-debug/00004/match5-source_with_match.png
-            stbt-debug/00004/match6-confirm-absdiff.png
-            stbt-debug/00004/match6-confirm-absdiff_threshold_erode.png
-            stbt-debug/00004/match6-confirm-absdiff_threshold.png
-            stbt-debug/00004/match6-confirm-source_roi_gray.png
-            stbt-debug/00004/match6-confirm-source_roi.png
-            stbt-debug/00004/match6-confirm-template_gray.png
-            stbt-debug/00004/match6-heatmap.png
-            stbt-debug/00004/match6-source_with_match.png
-            stbt-debug/00004/source.png
-            stbt-debug/00004/template.png
-            """)
+        stbt_debug_dir = tmp_path / "stbt-debug"
+        assert stbt_debug_dir.is_dir()
+        files = set(
+            f.relative_to(tmp_path).as_posix()
+            for f in stbt_debug_dir.rglob("*")
+        )
+        assert files == {
+            "stbt-debug/00001",
+            "stbt-debug/00001/index.html",
+            "stbt-debug/00001/level2-source_matchtemplate.png",
+            "stbt-debug/00001/level2-source.png",
+            "stbt-debug/00001/level2-source_with_match.png",
+            "stbt-debug/00001/level2-source_with_rois.png",
+            "stbt-debug/00001/level2-template.png",
+            "stbt-debug/00001/match0-heatmap.png",
+            "stbt-debug/00001/match0-source_with_match.png",
+            "stbt-debug/00001/source.png",
+            "stbt-debug/00001/template.png",
+            "stbt-debug/00002",
+            "stbt-debug/00002/index.html",
+            "stbt-debug/00002/level0-source_matchtemplate.png",
+            "stbt-debug/00002/level0-source_matchtemplate_threshold.png",
+            "stbt-debug/00002/level0-source.png",
+            "stbt-debug/00002/level0-source_with_match.png",
+            "stbt-debug/00002/level0-source_with_rois.png",
+            "stbt-debug/00002/level0-template.png",
+            "stbt-debug/00002/level1-source_matchtemplate.png",
+            "stbt-debug/00002/level1-source_matchtemplate_threshold.png",
+            "stbt-debug/00002/level1-source.png",
+            "stbt-debug/00002/level1-source_with_match.png",
+            "stbt-debug/00002/level1-source_with_rois.png",
+            "stbt-debug/00002/level1-template.png",
+            "stbt-debug/00002/level2-source_matchtemplate.png",
+            "stbt-debug/00002/level2-source_matchtemplate_threshold.png",
+            "stbt-debug/00002/level2-source.png",
+            "stbt-debug/00002/level2-source_with_match.png",
+            "stbt-debug/00002/level2-source_with_rois.png",
+            "stbt-debug/00002/level2-template.png",
+            "stbt-debug/00002/match0-confirm-absdiff.png",
+            "stbt-debug/00002/match0-confirm-absdiff_threshold_erode.png",
+            "stbt-debug/00002/match0-confirm-absdiff_threshold.png",
+            "stbt-debug/00002/match0-confirm-source_roi_gray_normalized.png",
+            "stbt-debug/00002/match0-confirm-source_roi_gray.png",
+            "stbt-debug/00002/match0-confirm-source_roi.png",
+            "stbt-debug/00002/match0-confirm-template_gray_normalized.png",
+            "stbt-debug/00002/match0-confirm-template_gray.png",
+            "stbt-debug/00002/match0-heatmap.png",
+            "stbt-debug/00002/match0-source_with_match.png",
+            "stbt-debug/00002/match1-confirm-absdiff.png",
+            "stbt-debug/00002/match1-confirm-absdiff_threshold_erode.png",
+            "stbt-debug/00002/match1-confirm-absdiff_threshold.png",
+            "stbt-debug/00002/match1-confirm-source_roi_gray_normalized.png",
+            "stbt-debug/00002/match1-confirm-source_roi_gray.png",
+            "stbt-debug/00002/match1-confirm-source_roi.png",
+            "stbt-debug/00002/match1-confirm-template_gray_normalized.png",
+            "stbt-debug/00002/match1-confirm-template_gray.png",
+            "stbt-debug/00002/match1-heatmap.png",
+            "stbt-debug/00002/match1-source_with_match.png",
+            "stbt-debug/00002/match2-confirm-absdiff.png",
+            "stbt-debug/00002/match2-confirm-absdiff_threshold_erode.png",
+            "stbt-debug/00002/match2-confirm-absdiff_threshold.png",
+            "stbt-debug/00002/match2-confirm-source_roi_gray_normalized.png",
+            "stbt-debug/00002/match2-confirm-source_roi_gray.png",
+            "stbt-debug/00002/match2-confirm-source_roi.png",
+            "stbt-debug/00002/match2-confirm-template_gray_normalized.png",
+            "stbt-debug/00002/match2-confirm-template_gray.png",
+            "stbt-debug/00002/match2-heatmap.png",
+            "stbt-debug/00002/match2-source_with_match.png",
+            "stbt-debug/00002/match3-confirm-absdiff.png",
+            "stbt-debug/00002/match3-confirm-absdiff_threshold_erode.png",
+            "stbt-debug/00002/match3-confirm-absdiff_threshold.png",
+            "stbt-debug/00002/match3-confirm-source_roi_gray_normalized.png",
+            "stbt-debug/00002/match3-confirm-source_roi_gray.png",
+            "stbt-debug/00002/match3-confirm-source_roi.png",
+            "stbt-debug/00002/match3-confirm-template_gray_normalized.png",
+            "stbt-debug/00002/match3-confirm-template_gray.png",
+            "stbt-debug/00002/match3-heatmap.png",
+            "stbt-debug/00002/match3-source_with_match.png",
+            "stbt-debug/00002/match4-confirm-absdiff.png",
+            "stbt-debug/00002/match4-confirm-absdiff_threshold_erode.png",
+            "stbt-debug/00002/match4-confirm-absdiff_threshold.png",
+            "stbt-debug/00002/match4-confirm-source_roi_gray_normalized.png",
+            "stbt-debug/00002/match4-confirm-source_roi_gray.png",
+            "stbt-debug/00002/match4-confirm-source_roi.png",
+            "stbt-debug/00002/match4-confirm-template_gray_normalized.png",
+            "stbt-debug/00002/match4-confirm-template_gray.png",
+            "stbt-debug/00002/match4-heatmap.png",
+            "stbt-debug/00002/match4-source_with_match.png",
+            "stbt-debug/00002/match5-confirm-absdiff.png",
+            "stbt-debug/00002/match5-confirm-absdiff_threshold_erode.png",
+            "stbt-debug/00002/match5-confirm-absdiff_threshold.png",
+            "stbt-debug/00002/match5-confirm-source_roi_gray_normalized.png",
+            "stbt-debug/00002/match5-confirm-source_roi_gray.png",
+            "stbt-debug/00002/match5-confirm-source_roi.png",
+            "stbt-debug/00002/match5-confirm-template_gray_normalized.png",
+            "stbt-debug/00002/match5-confirm-template_gray.png",
+            "stbt-debug/00002/match5-heatmap.png",
+            "stbt-debug/00002/match5-source_with_match.png",
+            "stbt-debug/00002/match6-heatmap.png",
+            "stbt-debug/00002/match6-source_with_match.png",
+            "stbt-debug/00002/source.png",
+            "stbt-debug/00002/template.png",
+            "stbt-debug/00003",
+            "stbt-debug/00003/index.html",
+            "stbt-debug/00003/level0-source_matchtemplate.png",
+            "stbt-debug/00003/level0-source_matchtemplate_threshold.png",
+            "stbt-debug/00003/level0-source.png",
+            "stbt-debug/00003/level0-source_with_match.png",
+            "stbt-debug/00003/level0-source_with_rois.png",
+            "stbt-debug/00003/level0-template.png",
+            "stbt-debug/00003/level1-source_matchtemplate.png",
+            "stbt-debug/00003/level1-source_matchtemplate_threshold.png",
+            "stbt-debug/00003/level1-source.png",
+            "stbt-debug/00003/level1-source_with_match.png",
+            "stbt-debug/00003/level1-source_with_rois.png",
+            "stbt-debug/00003/level1-template.png",
+            "stbt-debug/00003/level2-source_matchtemplate.png",
+            "stbt-debug/00003/level2-source_matchtemplate_threshold.png",
+            "stbt-debug/00003/level2-source.png",
+            "stbt-debug/00003/level2-source_with_match.png",
+            "stbt-debug/00003/level2-source_with_rois.png",
+            "stbt-debug/00003/level2-template.png",
+            "stbt-debug/00003/match0-confirm-absdiff.png",
+            "stbt-debug/00003/match0-confirm-absdiff_threshold_erode.png",
+            "stbt-debug/00003/match0-confirm-absdiff_threshold.png",
+            "stbt-debug/00003/match0-confirm-source_roi_gray_normalized.png",
+            "stbt-debug/00003/match0-confirm-source_roi_gray.png",
+            "stbt-debug/00003/match0-confirm-source_roi.png",
+            "stbt-debug/00003/match0-confirm-template_gray_normalized.png",
+            "stbt-debug/00003/match0-confirm-template_gray.png",
+            "stbt-debug/00003/match0-heatmap.png",
+            "stbt-debug/00003/match0-source_with_match.png",
+            "stbt-debug/00003/match1-confirm-absdiff.png",
+            "stbt-debug/00003/match1-confirm-absdiff_threshold_erode.png",
+            "stbt-debug/00003/match1-confirm-absdiff_threshold.png",
+            "stbt-debug/00003/match1-confirm-source_roi_gray_normalized.png",
+            "stbt-debug/00003/match1-confirm-source_roi_gray.png",
+            "stbt-debug/00003/match1-confirm-source_roi.png",
+            "stbt-debug/00003/match1-confirm-template_gray_normalized.png",
+            "stbt-debug/00003/match1-confirm-template_gray.png",
+            "stbt-debug/00003/match1-heatmap.png",
+            "stbt-debug/00003/match1-source_with_match.png",
+            "stbt-debug/00003/match2-confirm-absdiff.png",
+            "stbt-debug/00003/match2-confirm-absdiff_threshold_erode.png",
+            "stbt-debug/00003/match2-confirm-absdiff_threshold.png",
+            "stbt-debug/00003/match2-confirm-source_roi_gray_normalized.png",
+            "stbt-debug/00003/match2-confirm-source_roi_gray.png",
+            "stbt-debug/00003/match2-confirm-source_roi.png",
+            "stbt-debug/00003/match2-confirm-template_gray_normalized.png",
+            "stbt-debug/00003/match2-confirm-template_gray.png",
+            "stbt-debug/00003/match2-heatmap.png",
+            "stbt-debug/00003/match2-source_with_match.png",
+            "stbt-debug/00003/match3-confirm-absdiff.png",
+            "stbt-debug/00003/match3-confirm-absdiff_threshold_erode.png",
+            "stbt-debug/00003/match3-confirm-absdiff_threshold.png",
+            "stbt-debug/00003/match3-confirm-source_roi_gray_normalized.png",
+            "stbt-debug/00003/match3-confirm-source_roi_gray.png",
+            "stbt-debug/00003/match3-confirm-source_roi.png",
+            "stbt-debug/00003/match3-confirm-template_gray_normalized.png",
+            "stbt-debug/00003/match3-confirm-template_gray.png",
+            "stbt-debug/00003/match3-heatmap.png",
+            "stbt-debug/00003/match3-source_with_match.png",
+            "stbt-debug/00003/match4-confirm-absdiff.png",
+            "stbt-debug/00003/match4-confirm-absdiff_threshold_erode.png",
+            "stbt-debug/00003/match4-confirm-absdiff_threshold.png",
+            "stbt-debug/00003/match4-confirm-source_roi_gray_normalized.png",
+            "stbt-debug/00003/match4-confirm-source_roi_gray.png",
+            "stbt-debug/00003/match4-confirm-source_roi.png",
+            "stbt-debug/00003/match4-confirm-template_gray_normalized.png",
+            "stbt-debug/00003/match4-confirm-template_gray.png",
+            "stbt-debug/00003/match4-heatmap.png",
+            "stbt-debug/00003/match4-source_with_match.png",
+            "stbt-debug/00003/match5-confirm-absdiff.png",
+            "stbt-debug/00003/match5-confirm-absdiff_threshold_erode.png",
+            "stbt-debug/00003/match5-confirm-absdiff_threshold.png",
+            "stbt-debug/00003/match5-confirm-source_roi_gray_normalized.png",
+            "stbt-debug/00003/match5-confirm-source_roi_gray.png",
+            "stbt-debug/00003/match5-confirm-source_roi.png",
+            "stbt-debug/00003/match5-confirm-template_gray_normalized.png",
+            "stbt-debug/00003/match5-confirm-template_gray.png",
+            "stbt-debug/00003/match5-heatmap.png",
+            "stbt-debug/00003/match5-source_with_match.png",
+            "stbt-debug/00003/match6-confirm-absdiff.png",
+            "stbt-debug/00003/match6-confirm-absdiff_threshold_erode.png",
+            "stbt-debug/00003/match6-confirm-absdiff_threshold.png",
+            "stbt-debug/00003/match6-confirm-source_roi_gray_normalized.png",
+            "stbt-debug/00003/match6-confirm-source_roi_gray.png",
+            "stbt-debug/00003/match6-confirm-source_roi.png",
+            "stbt-debug/00003/match6-confirm-template_gray_normalized.png",
+            "stbt-debug/00003/match6-confirm-template_gray.png",
+            "stbt-debug/00003/match6-heatmap.png",
+            "stbt-debug/00003/match6-source_with_match.png",
+            "stbt-debug/00003/source.png",
+            "stbt-debug/00003/template.png",
+            "stbt-debug/00004",
+            "stbt-debug/00004/index.html",
+            "stbt-debug/00004/level0-source_matchtemplate.png",
+            "stbt-debug/00004/level0-source_matchtemplate_threshold.png",
+            "stbt-debug/00004/level0-source.png",
+            "stbt-debug/00004/level0-source_with_match.png",
+            "stbt-debug/00004/level0-source_with_rois.png",
+            "stbt-debug/00004/level0-template.png",
+            "stbt-debug/00004/level1-source_matchtemplate.png",
+            "stbt-debug/00004/level1-source_matchtemplate_threshold.png",
+            "stbt-debug/00004/level1-source.png",
+            "stbt-debug/00004/level1-source_with_match.png",
+            "stbt-debug/00004/level1-source_with_rois.png",
+            "stbt-debug/00004/level1-template.png",
+            "stbt-debug/00004/level2-source_matchtemplate.png",
+            "stbt-debug/00004/level2-source_matchtemplate_threshold.png",
+            "stbt-debug/00004/level2-source.png",
+            "stbt-debug/00004/level2-source_with_match.png",
+            "stbt-debug/00004/level2-source_with_rois.png",
+            "stbt-debug/00004/level2-template.png",
+            "stbt-debug/00004/match0-confirm-absdiff.png",
+            "stbt-debug/00004/match0-confirm-absdiff_threshold_erode.png",
+            "stbt-debug/00004/match0-confirm-absdiff_threshold.png",
+            "stbt-debug/00004/match0-confirm-source_roi_gray.png",
+            "stbt-debug/00004/match0-confirm-source_roi.png",
+            "stbt-debug/00004/match0-confirm-template_gray.png",
+            "stbt-debug/00004/match0-heatmap.png",
+            "stbt-debug/00004/match0-source_with_match.png",
+            "stbt-debug/00004/match1-confirm-absdiff.png",
+            "stbt-debug/00004/match1-confirm-absdiff_threshold_erode.png",
+            "stbt-debug/00004/match1-confirm-absdiff_threshold.png",
+            "stbt-debug/00004/match1-confirm-source_roi_gray.png",
+            "stbt-debug/00004/match1-confirm-source_roi.png",
+            "stbt-debug/00004/match1-confirm-template_gray.png",
+            "stbt-debug/00004/match1-heatmap.png",
+            "stbt-debug/00004/match1-source_with_match.png",
+            "stbt-debug/00004/match2-confirm-absdiff.png",
+            "stbt-debug/00004/match2-confirm-absdiff_threshold_erode.png",
+            "stbt-debug/00004/match2-confirm-absdiff_threshold.png",
+            "stbt-debug/00004/match2-confirm-source_roi_gray.png",
+            "stbt-debug/00004/match2-confirm-source_roi.png",
+            "stbt-debug/00004/match2-confirm-template_gray.png",
+            "stbt-debug/00004/match2-heatmap.png",
+            "stbt-debug/00004/match2-source_with_match.png",
+            "stbt-debug/00004/match3-confirm-absdiff.png",
+            "stbt-debug/00004/match3-confirm-absdiff_threshold_erode.png",
+            "stbt-debug/00004/match3-confirm-absdiff_threshold.png",
+            "stbt-debug/00004/match3-confirm-source_roi_gray.png",
+            "stbt-debug/00004/match3-confirm-source_roi.png",
+            "stbt-debug/00004/match3-confirm-template_gray.png",
+            "stbt-debug/00004/match3-heatmap.png",
+            "stbt-debug/00004/match3-source_with_match.png",
+            "stbt-debug/00004/match4-confirm-absdiff.png",
+            "stbt-debug/00004/match4-confirm-absdiff_threshold_erode.png",
+            "stbt-debug/00004/match4-confirm-absdiff_threshold.png",
+            "stbt-debug/00004/match4-confirm-source_roi_gray.png",
+            "stbt-debug/00004/match4-confirm-source_roi.png",
+            "stbt-debug/00004/match4-confirm-template_gray.png",
+            "stbt-debug/00004/match4-heatmap.png",
+            "stbt-debug/00004/match4-source_with_match.png",
+            "stbt-debug/00004/match5-confirm-absdiff.png",
+            "stbt-debug/00004/match5-confirm-absdiff_threshold_erode.png",
+            "stbt-debug/00004/match5-confirm-absdiff_threshold.png",
+            "stbt-debug/00004/match5-confirm-source_roi_gray.png",
+            "stbt-debug/00004/match5-confirm-source_roi.png",
+            "stbt-debug/00004/match5-confirm-template_gray.png",
+            "stbt-debug/00004/match5-heatmap.png",
+            "stbt-debug/00004/match5-source_with_match.png",
+            "stbt-debug/00004/match6-confirm-absdiff.png",
+            "stbt-debug/00004/match6-confirm-absdiff_threshold_erode.png",
+            "stbt-debug/00004/match6-confirm-absdiff_threshold.png",
+            "stbt-debug/00004/match6-confirm-source_roi_gray.png",
+            "stbt-debug/00004/match6-confirm-source_roi.png",
+            "stbt-debug/00004/match6-confirm-template_gray.png",
+            "stbt-debug/00004/match6-heatmap.png",
+            "stbt-debug/00004/match6-source_with_match.png",
+            "stbt-debug/00004/source.png",
+            "stbt-debug/00004/template.png",
+        }
 
-        assert_expected("stbt-debug-expected-output/match")
+        assert_expected("stbt-debug-expected-output/match", stbt_debug_dir)
 
 
-def test_motion_debug():
+@pytest.mark.usefixtures("cwd_is_tmp_path")
+def test_motion_debug(tmp_path):
     # So that the output directory name doesn't depend on how many tests
     # were run before this one.
     ImageLogger._frame_number = itertools.count(1)
@@ -328,7 +333,7 @@ def test_motion_debug():
                                "box-00003.png"]):
             yield stbt.Frame(stbt.load_image(f), time=i)
 
-    with scoped_curdir(), scoped_debug_level(2):
+    with scoped_debug_level(2):
 
         for _ in stbt.detect_motion(frames=fake_frames()):
             pass
@@ -338,60 +343,64 @@ def test_motion_debug():
                                     region=stbt.Region(0, 0, 320, 400)):
             pass
 
-        files = subprocess.check_output("find stbt-debug | sort", shell=True) \
-                          .decode("utf-8")
-        assert files == dedent("""\
-            stbt-debug
-            stbt-debug/00001
-            stbt-debug/00001/eroded.png
-            stbt-debug/00001/index.html
-            stbt-debug/00001/previous_frame.png
-            stbt-debug/00001/source.png
-            stbt-debug/00001/sqd.png
-            stbt-debug/00001/thresholded.png
-            stbt-debug/00002
-            stbt-debug/00002/eroded.png
-            stbt-debug/00002/index.html
-            stbt-debug/00002/previous_frame.png
-            stbt-debug/00002/source.png
-            stbt-debug/00002/sqd.png
-            stbt-debug/00002/thresholded.png
-            stbt-debug/00003
-            stbt-debug/00003/eroded.png
-            stbt-debug/00003/index.html
-            stbt-debug/00003/mask.png
-            stbt-debug/00003/previous_frame.png
-            stbt-debug/00003/source.png
-            stbt-debug/00003/sqd.png
-            stbt-debug/00003/thresholded.png
-            stbt-debug/00004
-            stbt-debug/00004/eroded.png
-            stbt-debug/00004/index.html
-            stbt-debug/00004/mask.png
-            stbt-debug/00004/previous_frame.png
-            stbt-debug/00004/source.png
-            stbt-debug/00004/sqd.png
-            stbt-debug/00004/thresholded.png
-            stbt-debug/00005
-            stbt-debug/00005/eroded.png
-            stbt-debug/00005/index.html
-            stbt-debug/00005/previous_frame.png
-            stbt-debug/00005/source.png
-            stbt-debug/00005/sqd.png
-            stbt-debug/00005/thresholded.png
-            stbt-debug/00006
-            stbt-debug/00006/eroded.png
-            stbt-debug/00006/index.html
-            stbt-debug/00006/previous_frame.png
-            stbt-debug/00006/source.png
-            stbt-debug/00006/sqd.png
-            stbt-debug/00006/thresholded.png
-        """)
+        stbt_debug_dir = tmp_path / "stbt-debug"
+        assert stbt_debug_dir.is_dir()
+        files = set(
+            f.relative_to(tmp_path).as_posix()
+            for f in stbt_debug_dir.rglob("*")
+        )
+        assert files == {
+            "stbt-debug/00001",
+            "stbt-debug/00001/eroded.png",
+            "stbt-debug/00001/index.html",
+            "stbt-debug/00001/previous_frame.png",
+            "stbt-debug/00001/source.png",
+            "stbt-debug/00001/sqd.png",
+            "stbt-debug/00001/thresholded.png",
+            "stbt-debug/00002",
+            "stbt-debug/00002/eroded.png",
+            "stbt-debug/00002/index.html",
+            "stbt-debug/00002/previous_frame.png",
+            "stbt-debug/00002/source.png",
+            "stbt-debug/00002/sqd.png",
+            "stbt-debug/00002/thresholded.png",
+            "stbt-debug/00003",
+            "stbt-debug/00003/eroded.png",
+            "stbt-debug/00003/index.html",
+            "stbt-debug/00003/mask.png",
+            "stbt-debug/00003/previous_frame.png",
+            "stbt-debug/00003/source.png",
+            "stbt-debug/00003/sqd.png",
+            "stbt-debug/00003/thresholded.png",
+            "stbt-debug/00004",
+            "stbt-debug/00004/eroded.png",
+            "stbt-debug/00004/index.html",
+            "stbt-debug/00004/mask.png",
+            "stbt-debug/00004/previous_frame.png",
+            "stbt-debug/00004/source.png",
+            "stbt-debug/00004/sqd.png",
+            "stbt-debug/00004/thresholded.png",
+            "stbt-debug/00005",
+            "stbt-debug/00005/eroded.png",
+            "stbt-debug/00005/index.html",
+            "stbt-debug/00005/previous_frame.png",
+            "stbt-debug/00005/source.png",
+            "stbt-debug/00005/sqd.png",
+            "stbt-debug/00005/thresholded.png",
+            "stbt-debug/00006",
+            "stbt-debug/00006/eroded.png",
+            "stbt-debug/00006/index.html",
+            "stbt-debug/00006/previous_frame.png",
+            "stbt-debug/00006/source.png",
+            "stbt-debug/00006/sqd.png",
+            "stbt-debug/00006/thresholded.png",
+        }
 
-        assert_expected("stbt-debug-expected-output/motion")
+        assert_expected("stbt-debug-expected-output/motion", stbt_debug_dir)
 
 
-def test_ocr_debug():
+@pytest.mark.usefixtures("cwd_is_tmp_path")
+def test_ocr_debug(tmp_path):
     # So that the output directory name doesn't depend on how many tests
     # were run before this one.
     ImageLogger._frame_number = itertools.count(1)
@@ -400,7 +409,7 @@ def test_ocr_debug():
     r = stbt.Region(0, 370, right=1280, bottom=410)
     c = (235, 235, 235)
 
-    with scoped_curdir(), scoped_debug_level(2):
+    with scoped_debug_level(2):
 
         stbt.ocr(f)
         stbt.ocr(f, region=r)
@@ -410,94 +419,104 @@ def test_ocr_debug():
         stbt.match_text("Summary", f, region=r)  # no match
         stbt.match_text("Summary", f, region=r, text_color=c)
 
+        stbt_debug_dir = tmp_path / "stbt-debug"
+        assert stbt_debug_dir.is_dir()
         # tessinput.png is created only if tessinput.tif is created by
         # tesseract, which is dependent on the tesseract version.
-        files = subprocess.check_output(
-            "find stbt-debug | grep -v tessinput.png | sort", shell=True
-        ).decode("utf-8")
-        assert files == dedent("""\
-            stbt-debug
-            stbt-debug/00001
-            stbt-debug/00001/index.html
-            stbt-debug/00001/source.png
-            stbt-debug/00001/upsampled.png
-            stbt-debug/00002
-            stbt-debug/00002/index.html
-            stbt-debug/00002/source.png
-            stbt-debug/00002/upsampled.png
-            stbt-debug/00003
-            stbt-debug/00003/binarized.png
-            stbt-debug/00003/diff.png
-            stbt-debug/00003/index.html
-            stbt-debug/00003/source.png
-            stbt-debug/00003/upsampled.png
-            stbt-debug/00004
-            stbt-debug/00004/index.html
-            stbt-debug/00004/source.png
-            stbt-debug/00004/upsampled.png
-            stbt-debug/00005
-            stbt-debug/00005/index.html
-            stbt-debug/00005/source.png
-            stbt-debug/00005/upsampled.png
-            stbt-debug/00006
-            stbt-debug/00006/binarized.png
-            stbt-debug/00006/diff.png
-            stbt-debug/00006/index.html
-            stbt-debug/00006/source.png
-            stbt-debug/00006/upsampled.png
-            """)
+        files = set(
+            f.relative_to(tmp_path).as_posix()
+            for f in stbt_debug_dir.rglob("*")
+            if f.name != "tessinput.png"
+        )
+        assert files == {
+            "stbt-debug/00001",
+            "stbt-debug/00001/index.html",
+            "stbt-debug/00001/source.png",
+            "stbt-debug/00001/upsampled.png",
+            "stbt-debug/00002",
+            "stbt-debug/00002/index.html",
+            "stbt-debug/00002/source.png",
+            "stbt-debug/00002/upsampled.png",
+            "stbt-debug/00003",
+            "stbt-debug/00003/binarized.png",
+            "stbt-debug/00003/diff.png",
+            "stbt-debug/00003/index.html",
+            "stbt-debug/00003/source.png",
+            "stbt-debug/00003/upsampled.png",
+            "stbt-debug/00004",
+            "stbt-debug/00004/index.html",
+            "stbt-debug/00004/source.png",
+            "stbt-debug/00004/upsampled.png",
+            "stbt-debug/00005",
+            "stbt-debug/00005/index.html",
+            "stbt-debug/00005/source.png",
+            "stbt-debug/00005/upsampled.png",
+            "stbt-debug/00006",
+            "stbt-debug/00006/binarized.png",
+            "stbt-debug/00006/diff.png",
+            "stbt-debug/00006/index.html",
+            "stbt-debug/00006/source.png",
+            "stbt-debug/00006/upsampled.png",
+        }
 
         # To see the generated files in tests/dave-debug/:
         # import shutil
-        # shutil.move("stbt-debug", _find_file("dave-debug"))
+        # shutil.move(stbt_debug_dir, _find_file("dave-debug"))
 
 
-def test_is_screen_black_debug():
+@pytest.mark.usefixtures("cwd_is_tmp_path")
+def test_is_screen_black_debug(tmp_path):
     # So that the output directory name doesn't depend on how many tests
     # were run before this one.
     ImageLogger._frame_number = itertools.count(1)
 
     f = stbt.load_image("videotestsrc-full-frame.png")
 
-    with scoped_curdir(), scoped_debug_level(2):
+    with scoped_debug_level(2):
 
         stbt.is_screen_black(f)
         stbt.is_screen_black(f, mask="videotestsrc-mask-non-black.png")
         stbt.is_screen_black(f, mask="videotestsrc-mask-no-video.png")
         stbt.is_screen_black(f, region=stbt.Region(0, 0, 160, 120))
 
-        files = subprocess.check_output("find stbt-debug | sort", shell=True) \
-                          .decode("utf-8")
-        assert files == dedent("""\
-            stbt-debug
-            stbt-debug/00001
-            stbt-debug/00001/gray.png
-            stbt-debug/00001/index.html
-            stbt-debug/00001/non_black.png
-            stbt-debug/00001/source.png
-            stbt-debug/00002
-            stbt-debug/00002/gray.png
-            stbt-debug/00002/index.html
-            stbt-debug/00002/mask.png
-            stbt-debug/00002/non_black.png
-            stbt-debug/00002/source.png
-            stbt-debug/00003
-            stbt-debug/00003/gray.png
-            stbt-debug/00003/index.html
-            stbt-debug/00003/mask.png
-            stbt-debug/00003/non_black.png
-            stbt-debug/00003/source.png
-            stbt-debug/00004
-            stbt-debug/00004/gray.png
-            stbt-debug/00004/index.html
-            stbt-debug/00004/non_black.png
-            stbt-debug/00004/source.png
-            """)
+        stbt_debug_dir = tmp_path / "stbt-debug"
+        assert stbt_debug_dir.is_dir()
+        files = set(
+            f.relative_to(tmp_path).as_posix()
+            for f in stbt_debug_dir.rglob("*")
+        )
+        assert files == {
+            "stbt-debug/00001",
+            "stbt-debug/00001/gray.png",
+            "stbt-debug/00001/index.html",
+            "stbt-debug/00001/non_black.png",
+            "stbt-debug/00001/source.png",
+            "stbt-debug/00002",
+            "stbt-debug/00002/gray.png",
+            "stbt-debug/00002/index.html",
+            "stbt-debug/00002/mask.png",
+            "stbt-debug/00002/non_black.png",
+            "stbt-debug/00002/source.png",
+            "stbt-debug/00003",
+            "stbt-debug/00003/gray.png",
+            "stbt-debug/00003/index.html",
+            "stbt-debug/00003/mask.png",
+            "stbt-debug/00003/non_black.png",
+            "stbt-debug/00003/source.png",
+            "stbt-debug/00004",
+            "stbt-debug/00004/gray.png",
+            "stbt-debug/00004/index.html",
+            "stbt-debug/00004/non_black.png",
+            "stbt-debug/00004/source.png",
+        }
 
-        assert_expected("stbt-debug-expected-output/is_screen_black")
+        assert_expected(
+            "stbt-debug-expected-output/is_screen_black",
+            stbt_debug_dir,
+        )
 
 
-def assert_expected(expected):
+def assert_expected(expected, stbt_debug_dir):
     expected = _find_file(expected)
 
     subprocess.check_call([
@@ -506,7 +525,7 @@ def assert_expected(expected):
         # different versions of OpenCV:
         r"--ignore-matching-lines=0\.99",
         "--ignore-matching-lines=Region",
-        expected, "stbt-debug"])
+        expected, stbt_debug_dir])
 
     # To update expected results in source checkout:
     # import shutil

--- a/tests/test_stbt_debug.py
+++ b/tests/test_stbt_debug.py
@@ -410,43 +410,40 @@ def test_ocr_debug():
         stbt.match_text("Summary", f, region=r)  # no match
         stbt.match_text("Summary", f, region=r, text_color=c)
 
-        files = subprocess.check_output("find stbt-debug | sort", shell=True) \
-                          .decode("utf-8")
+        # tessinput.png is created only if tessinput.tif is created by
+        # tesseract, which is dependent on the tesseract version.
+        files = subprocess.check_output(
+            "find stbt-debug | grep -v tessinput.png | sort", shell=True
+        ).decode("utf-8")
         assert files == dedent("""\
             stbt-debug
             stbt-debug/00001
             stbt-debug/00001/index.html
             stbt-debug/00001/source.png
-            stbt-debug/00001/tessinput.png
             stbt-debug/00001/upsampled.png
             stbt-debug/00002
             stbt-debug/00002/index.html
             stbt-debug/00002/source.png
-            stbt-debug/00002/tessinput.png
             stbt-debug/00002/upsampled.png
             stbt-debug/00003
             stbt-debug/00003/binarized.png
             stbt-debug/00003/diff.png
             stbt-debug/00003/index.html
             stbt-debug/00003/source.png
-            stbt-debug/00003/tessinput.png
             stbt-debug/00003/upsampled.png
             stbt-debug/00004
             stbt-debug/00004/index.html
             stbt-debug/00004/source.png
-            stbt-debug/00004/tessinput.png
             stbt-debug/00004/upsampled.png
             stbt-debug/00005
             stbt-debug/00005/index.html
             stbt-debug/00005/source.png
-            stbt-debug/00005/tessinput.png
             stbt-debug/00005/upsampled.png
             stbt-debug/00006
             stbt-debug/00006/binarized.png
             stbt-debug/00006/diff.png
             stbt-debug/00006/index.html
             stbt-debug/00006/source.png
-            stbt-debug/00006/tessinput.png
             stbt-debug/00006/upsampled.png
             """)
 


### PR DESCRIPTION
I'm looking at contributing some changes to
1. unify the various config files into the modern pyproject.toml file
2. update the packaging of the library pushed to PyPi - hoping to avoid the build of libstbt.so within the Makefile
3. add support for <=python3.13

In order to do all that, I'd benefit from being able to run CI locally, and thus this PR contains a few changes that ultimately let me run pytest against the whole repo with everything passing.

Obviously if you're not interested in the above, please let me know.