### PR TITLE
BGRDiff, GrayscaleDiff: Read default threshold from stbt.conf

### DIFF
--- a/_stbt/diff.py
+++ b/_stbt/diff.py
@@ -6,6 +6,7 @@ import cv2
 import numpy
 from numpy.typing import NDArray
 
+from .config import get_config
 from .imgutils import Frame, FrameT, crop, _frame_repr, pixel_bounding_box
 from .logging import debug, ddebug, ImageLogger
 from .mask import load_mask, MaskTypes
@@ -149,10 +150,13 @@ class BGRDiff(Differ):
     def __init__(
         self,
         min_size: SizeT | None = None,
-        threshold: int = 25,
+        threshold: float | None = None,
         erode: bool | numpy.ndarray = True,
     ):
         self.min_size = min_size
+
+        if threshold is None:
+            threshold = get_config("motion", "threshold", 25, float)
         self.threshold = threshold
 
         if isinstance(erode, numpy.ndarray):  # For power users
@@ -194,7 +198,7 @@ class BGRDiff(Differ):
         cframe = crop(frame, region)
         cprev = crop(prev_frame, region)
 
-        d = _threshold_diff_bgr(cprev, cframe, (self.threshold ** 2) * 3,
+        d = _threshold_diff_bgr(cprev, cframe, int((self.threshold ** 2) * 3),
                                 imglog, mask_pixels)
         if mask_pixels is not None:
             numpy.bitwise_and(d, mask_pixels[:, :, 0], out=d)
@@ -324,10 +328,13 @@ class GrayscaleDiff(Differ):
     def __init__(
         self,
         min_size: SizeT | None = None,
-        threshold: float = 0.84,
+        threshold: float | None = None,
         erode: bool | numpy.ndarray = True,
     ):
         self.min_size = min_size
+
+        if threshold is None:
+            threshold = get_config("motion", "threshold", 0.84, float)
         self.threshold = threshold
 
         if isinstance(erode, numpy.ndarray):  # For power users

--- a/_stbt/transition.py
+++ b/_stbt/transition.py
@@ -36,7 +36,7 @@ def press_and_wait(
     frames: Optional[Iterator[Frame]] = None,
     _dut=None,
     *,
-    threshold: Optional[int] = None,
+    threshold: Optional[float] = None,
     differ: Optional[Differ] = None,
 ) -> Transition:
 
@@ -151,7 +151,7 @@ def wait_for_transition_to_end(
     min_size: Optional[SizeT] = None,
     frames: Optional[Iterator[Frame]] = None,
     *,
-    threshold: Optional[int] = None,
+    threshold: Optional[float] = None,
     differ: Optional[Differ] = None,
 ) -> Transition:
 
@@ -203,7 +203,7 @@ class _Transition():
     def __init__(self, mask: MaskTypes, timeout_secs: float,
                  stable_secs: float, min_size: SizeT | None,
                  frames: Iterator[Frame],
-                 threshold: Optional[int] = None,
+                 threshold: Optional[float] = None,
                  differ: Optional[Differ] = None):
         self.mask = mask
         self.timeout_secs = timeout_secs


### PR DESCRIPTION
It seems wrong that the default threshold applies to wait_for_motion but not press_and_wait.

This is technically a change in behaviour, but it doesn't affect any of our customers because they don't create differs directly and don't set the "motion.threshold" config.

Note that:

- detect_motion & wait_for_motion still read "motion.noise_threshold" config for backward compatibility, and use it to override the differ threshold.

- We don't set "motion.threshold" in `_stbt/stbt.conf` and we haven't published the documentation for it yet so we don't expect any users to have set it. See commit 9fe227024 (#864).