### PR TITLE
imgproc_cache: Ignore EIO errors

### DIFF
--- a/_stbt/imgproc_cache.py
+++ b/_stbt/imgproc_cache.py
@@ -14,6 +14,7 @@ import inspect
 import itertools
 import json
 import os
+import warnings
 import sys
 from contextlib import contextmanager
 from itertools import zip_longest
@@ -216,6 +217,13 @@ def _cache_put(key, value):
                 "deleting the cache file (%s) to purge old "
                 "results\n" % _cache.path())
             _cache_full_warning = True
+    except lmdb.Error as e:
+        if "Input/output error" not in str(e):
+            raise
+        warnings.warn(
+            "I/O error writing to image processing cache.  This will cause "
+            "degraded performance.  Consider deleting the cache file (%s) "
+            "to recreate the cache.\n" % _cache.path())
 
 
 class NotCachable(Exception):


### PR DESCRIPTION
We don't want these errors polluting object repository results.  I've seen:

    Traceback (most recent call last):
      File ..., line ... in ...
        if stbt.match(image, frame= self._frame):
    lmdb.Error: mdb_txn_commit: Input/output error

In the object repo.