### PR TITLE
android: Don't run adb server in current directory

### DIFF
--- a/_stbt/android.py
+++ b/_stbt/android.py
@@ -180,14 +180,17 @@ class AdbDevice():
             "android", "coordinate_system", default=CoordinateSystem.HDMI_720P,
             type_=CoordinateSystem)
 
-        if not (self.adb_server or
-                os.environ.get("ANDROID_ADB_SERVER_ADDRESS") or
-                os.environ.get("ADB_SERVER_SOCKET")):
+        if not self._is_remote_server():
             self._setup_adb_key()
-            subprocess.check_call([self.adb_binary, "start-server"], cwd="/run")
 
         if not lazy_connect and self.tcpip:
             self._connect()
+
+    def _is_remote_server(self):
+        return bool(
+            self.adb_server or
+            os.environ.get("ANDROID_ADB_SERVER_ADDRESS") or
+            os.environ.get("ADB_SERVER_SOCKET"))
 
     def _setup_adb_key(self):
         if os.path.exists(os.path.join(os.environ["HOME"], ".android/adbkey")):
@@ -396,6 +399,12 @@ class AdbDevice():
         # hang indefinitely "waiting for device".
         if timeout is None:
             timeout = 60
+
+        if not self._is_remote_server():
+            # On the Stb-tester Node each test is run in a separate directory.
+            # We don't want adb server to hold the current test-run directory
+            # open, so that it won't be killed by the result upload process.
+            subprocess.check_call([self.adb_binary, "start-server"], cwd="/run")
 
         devices_output = self.devices()
         devices = _parse_devices(devices_output)

--- a/_stbt/android.py
+++ b/_stbt/android.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import os
 import re
 import shutil
+import socket
 import subprocess
 import threading
 import time
@@ -404,7 +405,11 @@ class AdbDevice():
             # On the Stb-tester Node each test is run in a separate directory.
             # We don't want adb server to hold the current test-run directory
             # open, so that it won't be killed by the result upload process.
-            subprocess.check_call([self.adb_binary, "start-server"], cwd="/run")
+            try:
+                socket.create_connection(("127.0.0.1", 5037), timeout=1)
+            except ConnectionRefusedError:
+                subprocess.check_call([self.adb_binary, "start-server"],
+                                      cwd="/run")
 
         devices_output = self.devices()
         devices = _parse_devices(devices_output)

--- a/_stbt/android.py
+++ b/_stbt/android.py
@@ -180,16 +180,16 @@ class AdbDevice():
             "android", "coordinate_system", default=CoordinateSystem.HDMI_720P,
             type_=CoordinateSystem)
 
-        self._setup_adb_key()
+        if not (self.adb_server or
+                os.environ.get("ANDROID_ADB_SERVER_ADDRESS") or
+                os.environ.get("ADB_SERVER_SOCKET")):
+            self._setup_adb_key()
+            subprocess.check_call([self.adb_binary, "start-server"], cwd="/run")
 
         if not lazy_connect and self.tcpip:
             self._connect()
 
     def _setup_adb_key(self):
-        if (self.adb_server or os.environ.get("ANDROID_ADB_SERVER_ADDRESS") or
-                os.environ.get("ADB_SERVER_SOCKET")):
-            # Can't manage adbkey for a remote server.
-            return
         if os.path.exists(os.path.join(os.environ["HOME"], ".android/adbkey")):
             return
         import stbt_core

--- a/_stbt/android.py
+++ b/_stbt/android.py
@@ -197,10 +197,7 @@ class AdbDevice():
         if root is None:
             return
         if not os.path.exists(os.path.join(root, "config/android/adbkey")):
-            raise ConfigurationError(
-                "To run adb on the Stb-tester Node you must generate an ADB "
-                "host key by running 'adb keygen config/android/adbkey' and "
-                "commit the 'config/android' directory to git.")
+            return
         shutil.copytree(os.path.join(root, "config/android"),
                         os.path.join(os.environ["HOME"], ".android"))
         os.chmod(os.path.join(os.environ["HOME"], ".android/adbkey"), 0o600)

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -1,6 +1,5 @@
 import os
 from textwrap import dedent
-from unittest import mock
 
 import cv2
 import pytest
@@ -137,10 +136,7 @@ def test_parse_display_dimensions():
 
 # This is a regression test.
 def test_adbdevice_default_constructor():
-    with mock.patch("subprocess.check_call") as mock_check_call:
-        adb = AdbDevice()
-        assert mock_check_call.mock_calls == [
-            mock.call(["adb", "start-server"], cwd="/run")]
+    adb = AdbDevice()
     assert adb.coordinate_system == CoordinateSystem.HDMI_720P
 
 

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -1,5 +1,6 @@
 import os
 from textwrap import dedent
+from unittest import mock
 
 import cv2
 import pytest
@@ -136,7 +137,10 @@ def test_parse_display_dimensions():
 
 # This is a regression test.
 def test_adbdevice_default_constructor():
-    adb = AdbDevice()
+    with mock.patch("subprocess.check_call") as mock_check_call:
+        adb = AdbDevice()
+        assert mock_check_call.mock_calls == [
+            mock.call(["adb", "start-server"], cwd="/run")]
     assert adb.coordinate_system == CoordinateSystem.HDMI_720P
 
 


### PR DESCRIPTION
On the Stb-tester Node each test is run in a separate directory. We don't want the adb server to hold the current test-run directory open, so that it won't be killed by the result upload process.
